### PR TITLE
Align statistics period filters with backend

### DIFF
--- a/assets/js/ui/StatisticsChartManager.js
+++ b/assets/js/ui/StatisticsChartManager.js
@@ -71,19 +71,58 @@ export default class StatisticsChartManager {
 				".statistics-dashboard"
 			),
 		};
-		this.charts = {};
-        this.heatmapTooltip = null; 
-		this.currentPeriod = this.elements.periodSelectEl
-			? this.elements.periodSelectEl.value
-			: "30d";
-		this.previousStatsState = {};
-	}
+                this.charts = {};
+                this.heatmapTooltip = null;
 
-	setStore(storeInstance) {
-		this.store = storeInstance;
-		if (this.store) {
-			this.previousStatsState = this.store.getState().statistics;
-			this.store.subscribe(this.handleStateUpdate.bind(this));
+                const initialPeriodValue = this.elements.periodSelectEl
+                        ? this.elements.periodSelectEl.value
+                        : null;
+                this.currentPeriod = this._normalizePeriodValue(initialPeriodValue);
+
+                if (
+                        this.elements.periodSelectEl &&
+                        this.elements.periodSelectEl.value !== this.currentPeriod
+                ) {
+                        const matchingOption = this.elements.periodSelectEl.querySelector(
+                                `option[value="${this.currentPeriod}"]`
+                        );
+                        if (matchingOption) {
+                                this.elements.periodSelectEl.value = this.currentPeriod;
+                        }
+                }
+
+                this.previousStatsState = {};
+        }
+
+        _normalizePeriodValue(rawValue) {
+                const DEFAULT_PERIOD = "30d";
+
+                if (rawValue === undefined || rawValue === null) {
+                        return DEFAULT_PERIOD;
+                }
+
+                const normalizedValue = String(rawValue).trim().toLowerCase();
+
+                if (normalizedValue === "all") {
+                        return "all";
+                }
+
+                const match = normalizedValue.match(/^(\d+)(d)?$/);
+                if (match) {
+                        const days = parseInt(match[1], 10);
+                        if (!Number.isNaN(days) && days > 0) {
+                                return `${days}d`;
+                        }
+                }
+
+                return DEFAULT_PERIOD;
+        }
+
+        setStore(storeInstance) {
+                this.store = storeInstance;
+                if (this.store) {
+                        this.previousStatsState = this.store.getState().statistics;
+                        this.store.subscribe(this.handleStateUpdate.bind(this));
 		}
 	}
 
@@ -98,10 +137,24 @@ export default class StatisticsChartManager {
 
 		if (!this.elements.periodSelectEl) return;
 
-		this.elements.periodSelectEl.addEventListener("change", (event) => {
-			this.currentPeriod = event.target.value;
-			this._triggerFetchStatistics();
-		});
+                this.elements.periodSelectEl.addEventListener("change", (event) => {
+                        const selectEl = event.target;
+                        const normalizedPeriod = this._normalizePeriodValue(
+                                selectEl.value
+                        );
+
+                        if (selectEl.value !== normalizedPeriod) {
+                                const matchingOption = selectEl.querySelector(
+                                        `option[value="${normalizedPeriod}"]`
+                                );
+                                if (matchingOption) {
+                                        selectEl.value = normalizedPeriod;
+                                }
+                        }
+
+                        this.currentPeriod = normalizedPeriod;
+                        this._triggerFetchStatistics();
+                });
 
 		const currentStats = this.store.getState().statistics;
 		if (!currentStats.data && !currentStats.isLoading) {

--- a/quiz/templates/quiz/account_page.html
+++ b/quiz/templates/quiz/account_page.html
@@ -162,9 +162,9 @@
                                 <div class="form-group" style="max-width: 250px;">
                                     <label for="stats-period-select" class="form-label">Visualizar Período:</label>
                                     <select id="stats-period-select" class="form-control form-control--small">
-                                        <option value="7">Últimos 7 dias</option>
-                                        <option value="30" selected>Últimos 30 dias</option>
-                                        <option value="90">Últimos 90 dias</option>
+                                        <option value="7d">Últimos 7 dias</option>
+                                        <option value="30d" selected>Últimos 30 dias</option>
+                                        <option value="90d">Últimos 90 dias</option>
                                         <option value="all">Desde o início</option>
                                     </select>
                                 </div>

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -1,6 +1,7 @@
 # quiz/views.py
 import json
 import random
+import re
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth import login, logout
 from django.contrib.auth.decorators import login_required
@@ -281,11 +282,27 @@ def get_or_create_daily_stats(user: User):
 
 
 def _filter_queryset_by_period(queryset, period_str: str, date_field_name: str = "data_estatistica"):
-    if period_str == "all":
+    normalized_period = (
+        str(period_str).strip().lower() if period_str is not None else "30d"
+    )
+
+    if normalized_period == "all":
         return queryset
 
-    days_map = {"7d": 7, "30d": 30, "90d": 90}
-    days = days_map.get(str(period_str).lower(), 30)
+    days = None
+
+    if isinstance(period_str, (int, float)):
+        try:
+            days = int(period_str)
+        except (TypeError, ValueError):
+            days = None
+    else:
+        match = re.match(r"^(\d+)(d)?$", normalized_period)
+        if match:
+            days = int(match.group(1))
+
+    if not days or days <= 0:
+        days = 30
 
     current_ts = timezone.now()
 


### PR DESCRIPTION
## Summary
- update the account statistics period dropdown to use the same keys accepted by the backend
- normalize the selected statistics period in the chart manager before sending it to the API
- allow the backend period filter helper to understand numeric inputs in addition to the canonical `Xd` values

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68cab33f51fc8333a21e15a7de662468