### PR TITLE
Ensure quiz configuration cache stays fresh after updates

### DIFF
--- a/quiz/models.py
+++ b/quiz/models.py
@@ -551,7 +551,14 @@ class ConfiguracoesGeraisQuiz(models.Model):
             raise ValidationError('Só pode haver uma instância de ConfiguracoesGeraisQuiz. Edite a existente.')
         if self.penalidade_por_erro < 0:
             raise ValidationError({'penalidade_por_erro': 'A penalidade por erro não pode ser negativa.'})
-        return super().save(*args, **kwargs)
+        result = super().save(*args, **kwargs)
+        try:
+            from .views import invalidate_quiz_config_cache
+            invalidate_quiz_config_cache()
+        except ImportError:
+            # Durante alguns fluxos de import (como migrações) as views podem não estar disponíveis.
+            pass
+        return result
 
     class Meta:
         verbose_name = "Configuração Geral do Quiz"

--- a/quiz/tests.py
+++ b/quiz/tests.py
@@ -1,3 +1,26 @@
 from django.test import TestCase
 
-# Create your tests here.
+from quiz.models import ConfiguracoesGeraisQuiz
+from quiz.views import get_quiz_config, invalidate_quiz_config_cache
+
+
+class QuizConfigCacheTests(TestCase):
+    def setUp(self):
+        # Garante que cada teste começa sem cache e com o banco limpo
+        invalidate_quiz_config_cache()
+        ConfiguracoesGeraisQuiz.objects.all().delete()
+
+    def test_quiz_config_reloads_after_save(self):
+        cached_config = get_quiz_config()
+        self.assertEqual(cached_config.pontuacao_por_acerto, 15)
+
+        # Simula edição externa (como no admin) usando uma nova instância do modelo
+        updated_config = ConfiguracoesGeraisQuiz.objects.get(pk=cached_config.pk)
+        updated_config.pontuacao_por_acerto = 42
+        updated_config.penalidade_por_erro = 3
+        updated_config.save()
+
+        # Deve recarregar os valores atualizados após o save invalidar o cache
+        reloaded_config = get_quiz_config()
+        self.assertEqual(reloaded_config.pontuacao_por_acerto, 42)
+        self.assertEqual(reloaded_config.penalidade_por_erro, 3)

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -42,6 +42,12 @@ from .forms import (
 _quiz_config_cache = None
 
 
+def invalidate_quiz_config_cache():
+    """Limpa o cache em memória da configuração geral do quiz."""
+    global _quiz_config_cache
+    _quiz_config_cache = None
+
+
 def get_quiz_config():
     """
     Retorna a instância (singleton) de ConfiguracoesGeraisQuiz.


### PR DESCRIPTION
## Summary
- add a helper to clear the in-memory quiz configuration cache and reuse it within the getter
- invalidate the cached configuration whenever ConfiguracoesGeraisQuiz is saved so API calls see new values
- cover the behaviour with a regression test that simulates admin updates

## Testing
- python manage.py test quiz *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68cab736ece083339cc0b4d4a372bf03