### PR TITLE
Remove duplicate category filter markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,16 +293,12 @@
         </div>
         <div class="filter-panel__body">
             <div class="filter-group" id="filter-group-categories">
-                <div class="filter-group" id="filter-group-categories">
-                    <div class="filter-group__header">
-                        <h3 class="filter-group__title" id="filter-group-categories-title">Categorias</h3>
-                        </div>
-                    <div class="filter-group__controls filter-group__controls--standalone">
-                        <button class="button button--text button--small" id="btn-cat-select-all">Selecionar Todas</button>
-                        <button class="button button--text button--small" id="btn-cat-clear-all">Limpar Todas</button>
-                    </div>
-                    <ul class="category-tree" id="category-tree-list" role="tree" aria-labelledby="filter-group-categories-title">
-                        </ul>
+                <div class="filter-group__header">
+                    <h3 class="filter-group__title" id="filter-group-categories-title">Categorias</h3>
+                </div>
+                <div class="filter-group__controls filter-group__controls--standalone">
+                    <button class="button button--text button--small" id="btn-cat-select-all">Selecionar Todas</button>
+                    <button class="button button--text button--small" id="btn-cat-clear-all">Limpar Todas</button>
                 </div>
                 <ul class="category-tree" id="category-tree-list" role="tree" aria-labelledby="filter-group-categories-title">
                 </ul>


### PR DESCRIPTION
## Summary
- remove the duplicated wrapper around the category filter group in the filter panel
- keep a single category tree list element so existing QuizUI caching works without duplicates

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68cabd4a49248333927ddebd6ab0e304