### PR TITLE
Add gray-50 neutral tone for light backgrounds

### DIFF
--- a/assets/css/base/variables.css
+++ b/assets/css/base/variables.css
@@ -42,6 +42,7 @@
     --color-gray-300: #e9ecef;
     --color-gray-200: #f1f3f5;
     --color-gray-100: #f8f9fa;
+    --color-gray-50: #fbfcfe;
     --color-white: #ffffff;
     --color-dark: #333;
 


### PR DESCRIPTION
## Summary
- add the missing --color-gray-50 token to the shared neutral palette
- ensure components that rely on the token render with the intended light gray background

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68cac3bc1bc08333a4a2a9ce195d9a07