### PR TITLE
Adjust bottom navigation padding for safe area insets

### DIFF
--- a/assets/css/components/navigation.css
+++ b/assets/css/components/navigation.css
@@ -85,6 +85,7 @@
   left: 0;
   width: 100%;
   height: var(--bottom-nav-height, 60px); /* Altura da barra */
+  padding-bottom: env(safe-area-inset-bottom, 0);
   background-color: var(--bottom-nav-bg-color, var(--color-white));
   border-top: var(--border-width) solid var(--bottom-nav-border-top-color, var(--color-gray-300));
   box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.08);

--- a/assets/css/layout/main-sections.css
+++ b/assets/css/layout/main-sections.css
@@ -65,10 +65,10 @@ main {
   }
   
   @media (max-width: 768px) { /* Tablet Portrait e Mobile */
-  
+
     /* Adiciona padding inferior ao body para compensar a altura da bottom-nav */
     body {
-      padding-bottom: var(--bottom-nav-height, 60px);
+      padding-bottom: calc(var(--bottom-nav-height, 60px) + env(safe-area-inset-bottom, 0));
       /* Certifique-se que --bottom-nav-height está definida em _variables.css */
     }
   


### PR DESCRIPTION
## Summary
- add safe-area inset padding to the fixed bottom navigation component
- update the mobile body padding to account for the safe-area inset alongside the navigation height

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cac8eaf7c88333bd31ac53b47ae6d8