### PR TITLE
Refactor challenge hub layout with glassmorphism

### DIFF
--- a/assets/css/components/challenge-hub.css
+++ b/assets/css/components/challenge-hub.css
@@ -2,51 +2,112 @@
 
 /* Container Principal do Hub */
 .challenge-hub {
+    position: relative;
+    width: min(1120px, 100%);
+    margin: clamp(32px, 6vw, 72px) auto;
+    padding: clamp(32px, 6vw, 52px);
+    border-radius: var(--border-radius-xl, 32px);
+    background: linear-gradient(145deg,
+            rgba(var(--color-primary-light-rgb, 238,243,248), 0.85) 0%,
+            rgba(255, 255, 255, 0.92) 35%,
+            rgba(var(--color-primary-light-rgb, 238,243,248), 0.6) 100%);
+    backdrop-filter: blur(18px);
+    border: 1px solid rgba(255, 255, 255, 0.55);
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+    overflow: hidden;
+}
+
+.challenge-hub__layout {
+    display: grid;
+    gap: clamp(24px, 4vw, 32px);
+    align-items: start;
+}
+
+@media (min-width: 960px) {
+    .challenge-hub__layout {
+        grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+        gap: clamp(32px, 5vw, 48px);
+    }
+}
+
+.challenge-hub__hero-pane {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-lg, 25px);
-    width: 100%;
-    max-width: 820px;
-    margin: var(--spacing-xl, 30px) auto;
-    padding: clamp(40px, 7vh, 55px) var(--spacing-lg, 30px);
-    background-color: var(--color-gray-100);
-    border-radius: var(--border-radius-lg);
-    box-shadow: var(--shadow-md);
+    gap: clamp(18px, 3vw, 26px);
 }
 
 .challenge-hub__header {
-    text-align: center;
-    margin-bottom: var(--spacing-md, 20px);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(10px, 2vw, 14px);
+    text-align: left;
 }
 
 .challenge-hub__title {
+    margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(1.8rem, 4.5vw, 2.2rem);
+    font-size: clamp(2rem, 4.4vw, 2.6rem);
+    line-height: 1.1;
     color: var(--color-primary-dark);
     font-weight: var(--font-weight-bold);
-    margin-top: 0;
-    margin-bottom: var(--spacing-xs, 8px);
 }
 
 .challenge-hub__subtitle {
-    font-family: var(--font-family-sans);
-    font-size: clamp(0.95rem, 2.5vw, 1.1rem);
-    color: var(--color-text-secondary);
     margin: 0;
-    font-weight: var(--font-weight-normal);
+    font-family: var(--font-family-sans);
+    font-size: clamp(1rem, 2.6vw, 1.15rem);
+    line-height: var(--line-height-relaxed, 1.5);
+    color: var(--color-text-secondary);
 }
 
-/* Grade de Opções */
-.challenge-hub__options-grid {
+.challenge-hub__stats {
     display: grid;
-    grid-template-columns: 1fr;
-    gap: var(--spacing-lg, 25px);
-    width: 100%;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: clamp(14px, 2.8vw, 18px);
+    margin: 0;
+    padding: 0;
 }
 
-@media (min-width: 768px) {
-    .challenge-hub__options-grid {
-        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+.challenge-hub__stat {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: clamp(14px, 2.6vw, 18px);
+    border-radius: var(--border-radius-lg, 20px);
+    background: rgba(255, 255, 255, 0.72);
+    border: 1px solid rgba(var(--color-primary-light-rgb, 238,243,248), 0.7);
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+}
+
+.challenge-hub__stat-label {
+    font-size: var(--font-size-xs, 0.75rem);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-primary-medium);
+    font-weight: var(--font-weight-semibold);
+}
+
+.challenge-hub__stat-value {
+    font-size: clamp(1.05rem, 2.8vw, 1.2rem);
+    color: var(--color-text-primary);
+    font-weight: var(--font-weight-medium, 600);
+    margin: 0;
+}
+
+.challenge-hub__actions-pane {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(20px, 3.2vw, 28px);
+}
+
+.challenge-hub__cta-grid {
+    display: grid;
+    gap: clamp(16px, 2.6vw, 20px);
+}
+
+@media (min-width: 600px) {
+    .challenge-hub__cta-grid {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     }
 }
 
@@ -56,28 +117,29 @@
 
 /* Base para todos os cards de desafio */
 .challenge-card {
-    background-color: var(--color-white);
-    border: var(--border-width) solid var(--color-gray-300);
-    border-radius: var(--border-radius-md);
-    box-shadow: var(--shadow-sm);
-    padding: var(--spacing-lg, 25px);
+    background: rgba(255, 255, 255, 0.82);
+    border: 1px solid rgba(var(--color-primary-light-rgb, 238,243,248), 0.7);
+    border-radius: var(--border-radius-lg, 20px);
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+    backdrop-filter: blur(14px);
+    padding: clamp(18px, 2.8vw, 24px);
     text-align: left;
     color: inherit;
     text-decoration: none;
-    transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+    transition: transform var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast);
 
     /* --- Layout Base (para cards simples como "Personalizar" e "Quiz Rápido") --- */
     display: flex;
     align-items: center; /* Centraliza verticalmente ícone e conteúdo */
-    gap: var(--spacing-md, 20px);
+    gap: clamp(14px, 2.2vw, 18px);
 }
 
 /* Efeito de hover para cards clicáveis */
 .challenge-card:not(.challenge-card--resume):hover,
 .challenge-card:not(.challenge-card--resume):focus-visible {
-    transform: translateY(-3px);
-    box-shadow: var(--shadow-lg);
-    border-color: var(--color-primary-medium);
+    transform: translateY(-4px);
+    box-shadow: 0 20px 42px rgba(15, 23, 42, 0.14);
+    border-color: rgba(var(--color-primary-medium-rgb, 26,95,158), 0.45);
 }
 .challenge-card:focus-visible {
     outline: var(--focus-outline-width) solid var(--focus-outline-color);
@@ -90,14 +152,16 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    background-color: var(--color-primary-light);
+    background: linear-gradient(160deg,
+            rgba(var(--color-primary-medium-rgb, 26,95,158), 0.16) 0%,
+            rgba(var(--color-primary-light-rgb, 238,243,248), 0.9) 100%);
     border-radius: var(--border-radius-circle);
-    padding: var(--spacing-sm, 12px);
-    color: var(--color-primary-dark);
+    padding: clamp(12px, 2.2vw, 16px);
+    color: var(--color-primary-medium);
 }
 
 .challenge-card__icon {
-    font-size: 2rem;
+    font-size: clamp(1.8rem, 3vw, 2.1rem);
     display: block;
 }
 
@@ -108,18 +172,18 @@
 
 .challenge-card__title {
     font-family: var(--font-family-heading);
-    font-size: var(--font-size-h3, 1.3rem);
+    font-size: clamp(1.15rem, 2.8vw, 1.35rem);
     color: var(--color-text-primary);
     font-weight: var(--font-weight-semibold);
     margin-top: 0;
-    margin-bottom: var(--spacing-xxs, 4px);
+    margin-bottom: clamp(4px, 1vw, 6px);
 }
 
 .challenge-card__description {
     font-family: var(--font-family-sans);
-    font-size: var(--font-size-sm, 0.9rem);
+    font-size: clamp(0.95rem, 2.4vw, 1.05rem);
     color: var(--color-text-secondary);
-    line-height: var(--line-height-base);
+    line-height: var(--line-height-relaxed, 1.5);
     margin: 0;
     overflow-wrap: break-word;
 }
@@ -127,9 +191,10 @@
 /* --- Variante de Card de Resumo (layout mais complexo) --- */
 .challenge-card--resume {
     cursor: default;
-    background-color: var(--color-primary-xlight);
-    border-color: var(--color-primary-medium);
-    grid-column: 1 / -1; /* Ocupa a largura toda da grade */
+    background: linear-gradient(155deg,
+            rgba(var(--color-primary-medium-rgb, 26,95,158), 0.18) 0%,
+            rgba(var(--color-primary-light-rgb, 238,243,248), 0.95) 100%);
+    border-color: rgba(var(--color-primary-medium-rgb, 26,95,158), 0.35);
 }
 
 /* Novo container principal que agrupa conteúdo e ações */
@@ -146,8 +211,9 @@
     display: flex;
     justify-content: flex-end; /* Alinha botões à direita */
     align-items: center;
-    gap: var(--spacing-sm, 12px);
-    margin-top: var(--spacing-md, 20px); /* Espaço entre a descrição e os botões */
+    gap: clamp(12px, 2vw, 16px);
+    margin-top: clamp(16px, 2.6vw, 20px); /* Espaço entre a descrição e os botões */
+    flex-wrap: wrap;
 }
 
 /* --- Outras Variantes --- */
@@ -206,7 +272,7 @@
     flex-wrap: wrap;
     justify-content: flex-end;
     align-items: center;
-    gap: var(--spacing-xs, 12px);
+    gap: clamp(10px, 2vw, 14px);
 }
 
 .challenge-hub__metric {
@@ -214,10 +280,10 @@
     align-items: center;
     gap: var(--spacing-xxs, 8px);
     padding: 8px 14px;
-    background: var(--color-gray-100);
+    background: rgba(var(--color-primary-light-rgb, 238,243,248), 0.6);
     color: var(--color-text-secondary);
     border-radius: var(--border-radius-pill, 999px);
-    border: 1px solid var(--color-gray-200);
+    border: 1px solid rgba(var(--color-primary-light-rgb, 238,243,248), 0.75);
     font-size: var(--font-size-sm, 0.9rem);
     white-space: nowrap;
 }
@@ -251,8 +317,8 @@
     border-radius: var(--border-radius-pill, 999px);
     font-size: var(--font-size-sm, 0.9rem);
     color: var(--color-text-secondary);
-    background: var(--color-gray-100);
-    border: 1px solid var(--color-gray-200);
+    background: rgba(var(--color-primary-light-rgb, 238,243,248), 0.45);
+    border: 1px solid rgba(var(--color-primary-light-rgb, 238,243,248), 0.65);
     margin: 0;
     width: fit-content;
 }
@@ -277,13 +343,13 @@
 .challenge-hub__predefined-section {
     display: flex;
     flex-direction: column;
-    gap: clamp(18px, 3vw, 24px);
-    padding: clamp(22px, 3vw, 26px);
-    background-color: var(--color-white);
-    border: var(--border-width, 1px) solid var(--color-gray-200);
-    border-radius: var(--border-radius-lg);
-    box-shadow: var(--shadow-xs);
-    grid-column: 1 / -1;
+    gap: clamp(20px, 3vw, 28px);
+    padding: clamp(24px, 3.2vw, 32px);
+    background: rgba(255, 255, 255, 0.88);
+    border: 1px solid rgba(var(--color-primary-light-rgb, 238,243,248), 0.7);
+    border-radius: var(--border-radius-xl, 28px);
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+    backdrop-filter: blur(14px);
 }
 .challenge-hub__predefined-grid {
     display: grid;
@@ -298,10 +364,11 @@
     width: 100%;
     gap: clamp(12px, 2.5vw, 16px);
     padding: clamp(20px, 3vw, 24px);
-    border: var(--border-width, 1px) solid var(--color-gray-200);
+    border: 1px solid rgba(var(--color-primary-light-rgb, 238,243,248), 0.65);
     border-radius: var(--border-radius-lg);
-    background-color: var(--color-white);
-    box-shadow: var(--shadow-xs);
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+    backdrop-filter: blur(10px);
     text-align: left;
 }
 
@@ -309,7 +376,9 @@
     width: clamp(44px, 6vw, 52px);
     height: clamp(44px, 6vw, 52px);
     padding: var(--spacing-xs, 10px);
-    background-color: rgba(var(--color-primary-light-rgb, 238,243,248), 0.9);
+    background: linear-gradient(160deg,
+            rgba(var(--color-primary-medium-rgb, 26,95,158), 0.16) 0%,
+            rgba(var(--color-primary-light-rgb, 238,243,248), 0.92) 100%);
     border-radius: var(--border-radius-md);
     color: var(--color-primary-medium);
     box-shadow: none;
@@ -385,11 +454,11 @@
     align-items: center;
     gap: 6px;
     padding: 6px 12px;
-    background: rgba(var(--color-gray-100-rgb, 248,249,250), 0.85);
+    background: rgba(var(--color-primary-light-rgb, 238,243,248), 0.5);
     color: var(--color-text-secondary);
     border-radius: var(--border-radius-pill, 999px);
     font-size: var(--font-size-xs, 0.8rem);
-    border: 1px solid var(--color-gray-200);
+    border: 1px solid rgba(var(--color-primary-light-rgb, 238,243,248), 0.7);
 }
 
 .challenge-card__meta-item .material-symbols-outlined {
@@ -408,17 +477,17 @@
     align-items: center;
     padding: 4px 10px;
     border-radius: var(--border-radius-pill, 999px);
-    background: var(--color-gray-100);
-    border: 1px solid var(--color-gray-200);
+    background: rgba(var(--color-primary-light-rgb, 238,243,248), 0.45);
+    border: 1px solid rgba(var(--color-primary-light-rgb, 238,243,248), 0.65);
     color: var(--color-text-secondary);
     font-size: var(--font-size-xs, 0.78rem);
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium, 600);
     letter-spacing: 0.01em;
 }
 
 .challenge-card__tag--more {
     color: var(--color-primary-medium);
-    background: rgba(var(--color-primary-light-rgb, 238,243,248), 0.85);
+    background: rgba(var(--color-primary-light-rgb, 238,243,248), 0.8);
     border-color: rgba(var(--color-primary-medium-rgb, 26,95,158), 0.32);
 }
 

--- a/quiz/templates/quiz/questions_page.html
+++ b/quiz/templates/quiz/questions_page.html
@@ -39,53 +39,71 @@
         <div class="question-section__main-content">
             
             <div id="challenge-hub-container" class="challenge-hub">
-                <div class="challenge-hub__header">
-                    <h2 class="challenge-hub__title">Escolha seu Desafio</h2>
-                    <p class="challenge-hub__subtitle">Explore nosso banco de <span id="hub-total-questions-count">0</span> questões.</p>
-                </div>
-                <div class="challenge-hub__options-grid">
-                    
-                    {# ========================================================================== #}
-                    {# ============ CARD DE RESUMO REFAFORADO (COM HTML MELHORADO) ============ #}
-                    {# ========================================================================== #}
-                    <div id="hub-resume-quiz-card" class="challenge-card challenge-card--resume u-is-hidden">
-                        <div class="challenge-card__icon-wrapper">
-                            <span class="material-symbols-outlined challenge-card__icon">play_arrow</span>
+                <div class="challenge-hub__layout">
+                    <div class="challenge-hub__hero-pane">
+                        <header class="challenge-hub__header">
+                            <h2 class="challenge-hub__title">Escolha seu Desafio</h2>
+                            <p class="challenge-hub__subtitle">Personalize sessões sob medida ou mergulhe em desafios rápidos.</p>
+                        </header>
+                        <dl class="challenge-hub__stats">
+                            <div class="challenge-hub__stat">
+                                <dt class="challenge-hub__stat-label">Questões no banco</dt>
+                                <dd class="challenge-hub__stat-value"><span id="hub-total-questions-count">0</span> disponíveis</dd>
+                            </div>
+                            <div class="challenge-hub__stat">
+                                <dt class="challenge-hub__stat-label">Rodada rápida</dt>
+                                <dd class="challenge-hub__stat-value"><span id="hub-quick-quiz-count">10</span> questões por sessão</dd>
+                            </div>
+                        </dl>
+                    </div>
+
+                    <div class="challenge-hub__actions-pane">
+                        {# ========================================================================== #}
+                        {# ============ CARD DE RESUMO REFAFORADO (COM HTML MELHORADO) ============ #}
+                        {# ========================================================================== #}
+                        <div id="hub-resume-quiz-card" class="challenge-card challenge-card--resume u-is-hidden">
+                            <div class="challenge-card__icon-wrapper">
+                                <span class="material-symbols-outlined challenge-card__icon">play_arrow</span>
+                            </div>
+                            <div class="challenge-card__main">
+                                <div class="challenge-card__content">
+                                    <h3 class="challenge-card__title">Continuar Desafio</h3>
+                                    <p class="challenge-card__description" id="hub-resume-card-description">
+                                        Você tem uma sessão em andamento.
+                                    </p>
+                                </div>
+                                <div class="challenge-card__actions">
+                                    <button id="hub-discard-resume-btn" class="button button--text button--compact">Descartar</button>
+                                    <button id="hub-confirm-resume-btn" class="button button--primary button--small">Continuar</button>
+                                </div>
+                            </div>
                         </div>
-                        <div class="challenge-card__main">
-                            <div class="challenge-card__content">
-                                <h3 class="challenge-card__title">Continuar Desafio</h3>
-                                <p class="challenge-card__description" id="hub-resume-card-description">
-                                    Você tem uma sessão em andamento.
-                                </p>
-                            </div>
-                            <div class="challenge-card__actions">
-                                <button id="hub-discard-resume-btn" class="button button--text button--compact">Descartar</button>
-                                <button id="hub-confirm-resume-btn" class="button button--primary button--small">Continuar</button>
-                            </div>
+                        {# ======================= FIM DA REFAFORAÇÃO DO CARD ====================== #}
+
+                        <div class="challenge-hub__cta-grid">
+                            <button id="hub-customize-quiz-btn" class="challenge-card">
+                                <div class="challenge-card__icon-wrapper">
+                                    <span class="material-symbols-outlined challenge-card__icon">tune</span>
+                                </div>
+                                <div class="challenge-card__content">
+                                    <h3 class="challenge-card__title">Personalizar Quiz</h3>
+                                    <p class="challenge-card__description">Escolha temas, dificuldade e modo de estudo.</p>
+                                </div>
+                            </button>
+                            <button id="hub-quick-quiz-btn" class="challenge-card">
+                                <div class="challenge-card__icon-wrapper">
+                                    <span class="material-symbols-outlined challenge-card__icon">bolt</span>
+                                </div>
+                                <div class="challenge-card__content">
+                                    <h3 class="challenge-card__title">Quiz Rápido</h3>
+                                    <p class="challenge-card__description">Inicie uma rodada instantânea com questões aleatórias.</p>
+                                </div>
+                            </button>
                         </div>
                     </div>
-                    {# ======================= FIM DA REFAFORAÇÃO DO CARD ====================== #}
+                </div>
 
-                    <button id="hub-customize-quiz-btn" class="challenge-card">
-                        <div class="challenge-card__icon-wrapper">
-                            <span class="material-symbols-outlined challenge-card__icon">tune</span>
-                        </div>
-                        <div class="challenge-card__content">
-                            <h3 class="challenge-card__title">Personalizar Quiz</h3>
-                            <p class="challenge-card__description">Escolha temas, dificuldade e modo de estudo.</p>
-                        </div>
-                    </button>
-                    <button id="hub-quick-quiz-btn" class="challenge-card">
-                        <div class="challenge-card__icon-wrapper">
-                            <span class="material-symbols-outlined challenge-card__icon">bolt</span>
-                        </div>
-                        <div class="challenge-card__content">
-                            <h3 class="challenge-card__title">Quiz Rápido</h3>
-                            <p class="challenge-card__description">Um desafio de <span id="hub-quick-quiz-count">10</span> questões aleatórias para começar.</p>
-                        </div>
-                    </button>
-                    <div id="hub-predefined-quizzes-section" class="challenge-hub__predefined-section u-is-hidden" role="region" aria-labelledby="hub-predefined-section-title">
+                <div id="hub-predefined-quizzes-section" class="challenge-hub__predefined-section u-is-hidden" role="region" aria-labelledby="hub-predefined-section-title">
                         <div class="challenge-hub__section-header">
                             <div class="challenge-hub__section-heading">
                                 <span class="challenge-hub__section-kicker">Coleções prontas</span>


### PR DESCRIPTION
## Summary
- restructure the challenge hub markup into hero and actions panes while keeping existing interactive IDs
- introduce quick stats in the hero column and move resume/CTA cards into a dedicated grid
- refresh challenge hub styling with a glassmorphism background, grid layout, and updated spacing/shadow tokens

## Testing
- python manage.py check *(fails: Django is not installed in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdac7f17d483339cea6321286e5b80