### PR TITLE
Refine predefined challenge cards layout

### DIFF
--- a/assets/css/components/challenge-hub.css
+++ b/assets/css/components/challenge-hub.css
@@ -293,73 +293,49 @@
 }
 
 .challenge-card--predefined {
-    flex-direction: column;
-    align-items: stretch;
+    position: relative;
+    display: block;
     width: 100%;
-    gap: clamp(12px, 2.5vw, 16px);
-    padding: clamp(20px, 3vw, 24px);
+    padding: clamp(22px, 3.4vw, 28px);
     border: var(--border-width, 1px) solid var(--color-gray-200);
     border-radius: var(--border-radius-lg);
     background-color: var(--color-white);
     box-shadow: var(--shadow-xs);
     text-align: left;
+    will-change: transform, box-shadow;
+    transition: transform var(--transition-fast),
+        box-shadow var(--transition-fast),
+        border-color var(--transition-fast),
+        background-color var(--transition-fast);
 }
 
-.challenge-card__icon-wrapper--predefined {
-    width: clamp(44px, 6vw, 52px);
-    height: clamp(44px, 6vw, 52px);
-    padding: var(--spacing-xs, 10px);
-    background-color: rgba(var(--color-primary-light-rgb, 238,243,248), 0.9);
-    border-radius: var(--border-radius-md);
-    color: var(--color-primary-medium);
-    box-shadow: none;
+.challenge-card--predefined:hover,
+.challenge-card--predefined:focus-visible {
+    transform: translateY(-6px);
+    border-color: rgba(var(--color-primary-medium-rgb, 26,95,158), 0.45);
+    box-shadow: var(--shadow-lg);
+    background-color: var(--color-white);
 }
 
-.challenge-card--predefined .challenge-card__icon {
-    font-size: clamp(1.6rem, 2.8vw, 1.9rem);
-}
-
-.challenge-card__content--predefined {
-    display: flex;
-    flex-direction: column;
-    gap: clamp(12px, 2vw, 16px);
-    width: 100%;
-}
-
-.challenge-card__header {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-sm, 16px);
-}
-
-.challenge-card__header-text {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xxs, 6px);
-}
-
-.challenge-card--predefined .challenge-card__title {
-    margin: 0;
-    font-size: clamp(1.05rem, 2.6vw, 1.2rem);
-    line-height: var(--line-height-tight, 1.3);
-    color: var(--color-text-primary);
-}
-
-.challenge-card__meta-note {
+.challenge-card__badge {
+    position: absolute;
+    top: clamp(14px, 2vw, 18px);
+    right: clamp(14px, 2vw, 18px);
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    padding: 2px 8px;
+    padding: 4px 10px;
     font-size: var(--font-size-xs, 0.75rem);
-    color: var(--color-text-secondary);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-primary-medium);
     background: rgba(var(--color-primary-light-rgb, 238,243,248), 0.85);
     border-radius: var(--border-radius-pill, 999px);
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26,95,158), 0.25);
-    align-self: flex-start;
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26,95,158), 0.28);
+    pointer-events: none;
     white-space: nowrap;
 }
 
-.challenge-card__meta-note::before {
+.challenge-card__badge::before {
     content: '';
     width: 6px;
     height: 6px;
@@ -367,58 +343,77 @@
     background: var(--color-primary-medium);
 }
 
+.challenge-card__content--predefined {
+    display: grid;
+    gap: clamp(14px, 2.4vw, 20px);
+}
+
+.challenge-card__header--predefined {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: var(--spacing-sm, 16px);
+}
+
+.challenge-card__icon-wrapper--predefined {
+    width: clamp(46px, 6vw, 56px);
+    height: clamp(46px, 6vw, 56px);
+    padding: var(--spacing-xs, 10px);
+    background-color: rgba(var(--color-primary-light-rgb, 238,243,248), 0.9);
+    border-radius: var(--border-radius-lg);
+    color: var(--color-primary-medium);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: none;
+}
+
+.challenge-card--predefined .challenge-card__icon {
+    font-size: clamp(1.6rem, 2.8vw, 1.95rem);
+}
+
+.challenge-card__title--predefined {
+    margin: 0;
+    font-size: clamp(1.08rem, 2.6vw, 1.24rem);
+    line-height: var(--line-height-tight, 1.28);
+    color: var(--color-text-primary);
+}
+
 .challenge-card__description--predefined {
     margin: 0;
     color: var(--color-text-secondary);
-    line-height: var(--line-height-base);
+    line-height: var(--line-height-relaxed, 1.5);
 }
 
-.challenge-card__meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--spacing-xs, 12px);
+.challenge-card__meta-line {
     margin: 0;
-}
-
-.challenge-card__meta-item {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 6px 12px;
-    background: rgba(var(--color-gray-100-rgb, 248,249,250), 0.85);
-    color: var(--color-text-secondary);
-    border-radius: var(--border-radius-pill, 999px);
-    font-size: var(--font-size-xs, 0.8rem);
-    border: 1px solid var(--color-gray-200);
-}
-
-.challenge-card__meta-item .material-symbols-outlined {
-    font-size: 1.05rem;
+    font-size: var(--font-size-sm, 0.9rem);
+    color: var(--color-text-tertiary, rgba(15, 23, 42, 0.7));
 }
 
 .challenge-card__tags {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--spacing-xxs, 6px);
+    gap: var(--spacing-xxs, 8px);
     margin: 0;
 }
 
 .challenge-card__tag {
     display: inline-flex;
     align-items: center;
-    padding: 4px 10px;
+    padding: 4px 12px;
     border-radius: var(--border-radius-pill, 999px);
-    background: var(--color-gray-100);
-    border: 1px solid var(--color-gray-200);
+    background: rgba(var(--color-gray-100-rgb, 248,249,250), 0.9);
+    border: 1px solid rgba(var(--color-gray-300-rgb, 226,232,240), 0.8);
     color: var(--color-text-secondary);
     font-size: var(--font-size-xs, 0.78rem);
     font-weight: var(--font-weight-medium);
     letter-spacing: 0.01em;
 }
 
-.challenge-card__tag--more {
+.challenge-card__tag--overflow {
     color: var(--color-primary-medium);
-    background: rgba(var(--color-primary-light-rgb, 238,243,248), 0.85);
+    background: rgba(var(--color-primary-light-rgb, 238,243,248), 0.88);
     border-color: rgba(var(--color-primary-medium-rgb, 26,95,158), 0.32);
 }
 
@@ -453,8 +448,16 @@
     }
 
     .challenge-card--predefined {
-        gap: var(--spacing-sm, 14px);
-        padding: clamp(18px, 7vw, 22px);
+        padding: clamp(20px, 7vw, 24px);
+    }
+
+    .challenge-card__badge {
+        top: clamp(12px, 4vw, 16px);
+        right: clamp(12px, 4vw, 16px);
+    }
+
+    .challenge-card__content--predefined {
+        gap: clamp(12px, 4vw, 18px);
     }
 }
 

--- a/assets/js/ui/ChallengeHub.js
+++ b/assets/js/ui/ChallengeHub.js
@@ -329,23 +329,46 @@ export default class ChallengeHub {
             totalCategories,
         });
         const updatedLabel = this._formatRelativeDate(quiz?.updated_at);
+        const estimatedMinutes = this._estimateQuizDurationMinutes(quiz, questionCount);
+        const MAX_VISIBLE_TAGS = 3;
 
-        card.title = label + ' - ' + questionCount + ' ' + questionLabel;
+        const tooltipMeta = [];
+        if (questionCount) {
+            tooltipMeta.push(questionCount + ' ' + questionLabel);
+        }
+        if (estimatedMinutes) {
+            tooltipMeta.push(estimatedMinutes + ' min');
+        }
+        const tooltipParts = [label];
+        if (tooltipMeta.length) {
+            tooltipParts.push(tooltipMeta.join(' · '));
+        }
+        card.title = tooltipParts.join(' — ');
 
         const ariaParts = ['Iniciar ' + label];
         if (questionCount) {
             ariaParts.push(questionCount + ' ' + questionLabel);
         }
+        if (estimatedMinutes) {
+            ariaParts.push('Tempo estimado de ' + estimatedMinutes + ' ' + (estimatedMinutes === 1 ? 'minuto' : 'minutos'));
+        }
         if (topCategories.length) {
-            ariaParts.push('Temas: ' + topCategories.slice(0, 2).join(', '));
+            ariaParts.push('Temas: ' + topCategories.slice(0, MAX_VISIBLE_TAGS).join(', '));
         }
         card.setAttribute('aria-label', ariaParts.join('. ') + '.');
 
         const content = document.createElement('div');
         content.className = 'challenge-card__content challenge-card__content--predefined';
 
+        if (updatedLabel) {
+            const badge = document.createElement('span');
+            badge.className = 'challenge-card__badge';
+            badge.textContent = updatedLabel;
+            card.appendChild(badge);
+        }
+
         const header = document.createElement('div');
-        header.className = 'challenge-card__header';
+        header.className = 'challenge-card__header challenge-card__header--predefined';
 
         const iconWrapper = document.createElement('div');
         iconWrapper.className = 'challenge-card__icon-wrapper challenge-card__icon-wrapper--predefined';
@@ -355,21 +378,11 @@ export default class ChallengeHub {
         iconWrapper.appendChild(icon);
         header.appendChild(iconWrapper);
 
-        const headerText = document.createElement('div');
-        headerText.className = 'challenge-card__header-text';
         const title = document.createElement('h3');
-        title.className = 'challenge-card__title';
+        title.className = 'challenge-card__title challenge-card__title--predefined';
         title.textContent = label;
-        headerText.appendChild(title);
+        header.appendChild(title);
 
-        if (updatedLabel) {
-            const updatedBadge = document.createElement('span');
-            updatedBadge.className = 'challenge-card__meta-note';
-            updatedBadge.textContent = updatedLabel;
-            headerText.appendChild(updatedBadge);
-        }
-
-        header.appendChild(headerText);
         content.appendChild(header);
 
         if (description) {
@@ -379,22 +392,21 @@ export default class ChallengeHub {
             content.appendChild(descriptionEl);
         }
 
-        const metaItems = [];
+        const metaParts = [];
         if (questionCount) {
-            metaItems.push(this._createMetaItem('quiz', questionCount + ' ' + questionLabel));
+            metaParts.push(questionCount + ' ' + questionLabel);
         }
-        if (totalCategories > 0) {
-            const categoryLabel = totalCategories === 1 ? 'tema' : 'temas';
-            metaItems.push(this._createMetaItem('category', totalCategories + ' ' + categoryLabel));
+        if (estimatedMinutes) {
+            metaParts.push(estimatedMinutes + ' min');
         }
-        if (metaItems.length) {
-            const meta = document.createElement('div');
-            meta.className = 'challenge-card__meta';
-            metaItems.forEach((item) => meta.appendChild(item));
-            content.appendChild(meta);
+        if (metaParts.length) {
+            const metaLine = document.createElement('p');
+            metaLine.className = 'challenge-card__meta-line';
+            metaLine.textContent = metaParts.join(' · ');
+            content.appendChild(metaLine);
         }
 
-        const displayedCategories = topCategories.slice(0, 2);
+        const displayedCategories = topCategories.slice(0, MAX_VISIBLE_TAGS);
         const referenceTotal = totalCategories || topCategories.length;
         if (displayedCategories.length) {
             const tagsWrapper = document.createElement('div');
@@ -408,9 +420,8 @@ export default class ChallengeHub {
             const remaining = Math.max(referenceTotal - displayedCategories.length, 0);
             if (remaining > 0) {
                 const tag = document.createElement('span');
-                tag.className = 'challenge-card__tag challenge-card__tag--more';
-                const remainingLabel = '+' + remaining + ' ' + (remaining === 1 ? 'tema' : 'temas');
-                tag.textContent = remainingLabel;
+                tag.className = 'challenge-card__tag challenge-card__tag--overflow';
+                tag.textContent = '+' + remaining;
                 tagsWrapper.appendChild(tag);
             }
             content.appendChild(tagsWrapper);
@@ -426,23 +437,28 @@ export default class ChallengeHub {
 
         return card;
     }
+    _estimateQuizDurationMinutes(quiz, questionCount) {
+        const candidateValues = [
+            quiz?.estimated_minutes,
+            quiz?.tempo_estimado_minutos,
+            quiz?.tempo_medio_minutos,
+            quiz?.tempo_estimado,
+            quiz?.tempo_medio,
+        ];
 
+        for (const value of candidateValues) {
+            const parsed = Number(value);
+            if (Number.isFinite(parsed) && parsed > 0) {
+                return Math.max(1, Math.round(parsed));
+            }
+        }
 
-    _createMetaItem(iconName, text) {
-        const wrapper = document.createElement('span');
-        wrapper.className = 'challenge-card__meta-item';
+        if (!questionCount) {
+            return null;
+        }
 
-        const icon = document.createElement('span');
-        icon.className = 'material-symbols-outlined';
-        icon.setAttribute('aria-hidden', 'true');
-        icon.textContent = iconName;
-        wrapper.appendChild(icon);
-
-        const label = document.createElement('span');
-        label.textContent = text;
-        wrapper.appendChild(label);
-
-        return wrapper;
+        // Fallback heurístico: ~40 segundos por questão ≈ 0,67 minuto.
+        return Math.max(1, Math.round(questionCount * 0.67));
     }
 
     _resolvePredefinedDescription({ quiz, topCategories, questionCount, totalCategories }) {


### PR DESCRIPTION
## Summary
- restructure the predefined challenge card markup to use a compact header, corner badge, condensed meta line, and limited tag list
- refresh the predefined challenge card styling with grid-based spacing, richer hover feedback, and updated tag pill visuals
- add an estimated duration heuristic so cards surface "min" timing alongside question counts

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cdac837dc88333968d979a75f37aba