### PR TITLE
Refine challenge hub layout and visuals

### DIFF
--- a/assets/css/components/challenge-hub.css
+++ b/assets/css/components/challenge-hub.css
@@ -15,12 +15,15 @@
     border: 1px solid rgba(255, 255, 255, 0.55);
     box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(28px, 5vw, 42px);
 }
 
 .challenge-hub__layout {
     display: grid;
     gap: clamp(24px, 4vw, 32px);
-    align-items: start;
+    align-items: stretch;
 }
 
 @media (min-width: 960px) {
@@ -34,6 +37,7 @@
     display: flex;
     flex-direction: column;
     gap: clamp(18px, 3vw, 26px);
+    height: 100%;
 }
 
 .challenge-hub__header {
@@ -62,7 +66,7 @@
 
 .challenge-hub__stats {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     gap: clamp(14px, 2.8vw, 18px);
     margin: 0;
     padding: 0;
@@ -71,12 +75,14 @@
 .challenge-hub__stat {
     display: flex;
     flex-direction: column;
-    gap: 6px;
-    padding: clamp(14px, 2.6vw, 18px);
+    justify-content: center;
+    gap: clamp(6px, 1.8vw, 10px);
+    padding: clamp(16px, 2.6vw, 20px);
     border-radius: var(--border-radius-lg, 20px);
     background: rgba(255, 255, 255, 0.72);
     border: 1px solid rgba(var(--color-primary-light-rgb, 238,243,248), 0.7);
     box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+    min-height: 110px;
 }
 
 .challenge-hub__stat-label {
@@ -85,6 +91,7 @@
     text-transform: uppercase;
     color: var(--color-primary-medium);
     font-weight: var(--font-weight-semibold);
+    margin: 0;
 }
 
 .challenge-hub__stat-value {
@@ -92,22 +99,33 @@
     color: var(--color-text-primary);
     font-weight: var(--font-weight-medium, 600);
     margin: 0;
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.challenge-hub__stat-number {
+    font-weight: var(--font-weight-bold);
+    color: var(--color-primary-dark);
 }
 
 .challenge-hub__actions-pane {
     display: flex;
     flex-direction: column;
     gap: clamp(20px, 3.2vw, 28px);
+    height: 100%;
 }
 
 .challenge-hub__cta-grid {
     display: grid;
     gap: clamp(16px, 2.6vw, 20px);
+    align-items: stretch;
 }
 
 @media (min-width: 600px) {
     .challenge-hub__cta-grid {
         grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        grid-auto-rows: 1fr;
     }
 }
 
@@ -130,8 +148,10 @@
 
     /* --- Layout Base (para cards simples como "Personalizar" e "Quiz Rápido") --- */
     display: flex;
-    align-items: center; /* Centraliza verticalmente ícone e conteúdo */
+    align-items: flex-start; /* Mantém ícone alinhado ao topo do conteúdo */
     gap: clamp(14px, 2.2vw, 18px);
+    width: 100%;
+    height: 100%;
 }
 
 /* Efeito de hover para cards clicáveis */
@@ -168,6 +188,9 @@
 /* Conteúdo (Título e Descrição) */
 .challenge-card__content {
     flex-grow: 1; /* Permite que a área de conteúdo cresça */
+    display: flex;
+    flex-direction: column;
+    gap: clamp(6px, 1.8vw, 10px);
 }
 
 .challenge-card__title {
@@ -188,6 +211,10 @@
     overflow-wrap: break-word;
 }
 
+.challenge-card__description strong {
+    color: var(--color-primary-dark);
+}
+
 /* --- Variante de Card de Resumo (layout mais complexo) --- */
 .challenge-card--resume {
     cursor: default;
@@ -195,6 +222,8 @@
             rgba(var(--color-primary-medium-rgb, 26,95,158), 0.18) 0%,
             rgba(var(--color-primary-light-rgb, 238,243,248), 0.95) 100%);
     border-color: rgba(var(--color-primary-medium-rgb, 26,95,158), 0.35);
+    align-items: stretch;
+    gap: clamp(18px, 3vw, 24px);
 }
 
 /* Novo container principal que agrupa conteúdo e ações */
@@ -203,17 +232,22 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between; /* Garante que as ações fiquem no fundo */
-    min-height: 90px; /* Altura mínima para garantir alinhamento em textos curtos */
+    gap: clamp(12px, 2vw, 18px);
+    min-height: 100px; /* Altura mínima para garantir alinhamento em textos curtos */
 }
 
 /* Ações (botões) */
 .challenge-card__actions {
     display: flex;
-    justify-content: flex-end; /* Alinha botões à direita */
+    justify-content: flex-start;
     align-items: center;
     gap: clamp(12px, 2vw, 16px);
     margin-top: clamp(16px, 2.6vw, 20px); /* Espaço entre a descrição e os botões */
     flex-wrap: wrap;
+}
+
+.challenge-card__actions .button {
+    min-width: 140px;
 }
 
 /* --- Outras Variantes --- */
@@ -343,7 +377,7 @@
 .challenge-hub__predefined-section {
     display: flex;
     flex-direction: column;
-    gap: clamp(20px, 3vw, 28px);
+    gap: clamp(20px, 3vw, 32px);
     padding: clamp(24px, 3.2vw, 32px);
     background: rgba(255, 255, 255, 0.88);
     border: 1px solid rgba(var(--color-primary-light-rgb, 238,243,248), 0.7);
@@ -356,6 +390,7 @@
     grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr));
     gap: clamp(16px, 3vw, 22px);
     align-items: stretch;
+    grid-auto-rows: 1fr;
 }
 
 .challenge-card--predefined {
@@ -370,6 +405,7 @@
     box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
     backdrop-filter: blur(10px);
     text-align: left;
+    height: 100%;
 }
 
 .challenge-card__icon-wrapper--predefined {
@@ -397,7 +433,7 @@
 
 .challenge-card__header {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: var(--spacing-sm, 16px);
 }
 

--- a/assets/js/ui/ChallengeHub.js
+++ b/assets/js/ui/ChallengeHub.js
@@ -249,7 +249,8 @@ export default class ChallengeHub {
         if (!this.elements.resumeCard || !resumableSession) return;
 
         const questionCount = resumableSession.perguntas?.length || 0;
-        this.elements.resumeCardDescription.innerHTML = `Você tem uma sessão em andamento de <strong>${questionCount}</strong> questões.`;
+        const questionLabel = questionCount === 1 ? 'questão' : 'questões';
+        this.elements.resumeCardDescription.innerHTML = `Você tem uma sessão em andamento com <strong>${questionCount}</strong> ${questionLabel}.`;
 
         this.quizUI.showElement(this.elements.resumeCard);
     }

--- a/quiz/templates/quiz/questions_page.html
+++ b/quiz/templates/quiz/questions_page.html
@@ -48,11 +48,17 @@
                         <dl class="challenge-hub__stats">
                             <div class="challenge-hub__stat">
                                 <dt class="challenge-hub__stat-label">Questões no banco</dt>
-                                <dd class="challenge-hub__stat-value"><span id="hub-total-questions-count">0</span> disponíveis</dd>
+                                <dd class="challenge-hub__stat-value">
+                                    <span class="challenge-hub__stat-number" id="hub-total-questions-count">0</span>
+                                    <span>disponíveis</span>
+                                </dd>
                             </div>
                             <div class="challenge-hub__stat">
                                 <dt class="challenge-hub__stat-label">Rodada rápida</dt>
-                                <dd class="challenge-hub__stat-value"><span id="hub-quick-quiz-count">10</span> questões por sessão</dd>
+                                <dd class="challenge-hub__stat-value">
+                                    <span class="challenge-hub__stat-number" id="hub-quick-quiz-count">10</span>
+                                    <span>questões por sessão</span>
+                                </dd>
                             </div>
                         </dl>
                     </div>
@@ -103,7 +109,7 @@
                     </div>
                 </div>
 
-                <div id="hub-predefined-quizzes-section" class="challenge-hub__predefined-section u-is-hidden" role="region" aria-labelledby="hub-predefined-section-title">
+                <div id="hub-predefined-quizzes-section" class="challenge-hub__predefined-section" role="region" aria-labelledby="hub-predefined-section-title">
                         <div class="challenge-hub__section-header">
                             <div class="challenge-hub__section-heading">
                                 <span class="challenge-hub__section-kicker">Coleções prontas</span>


### PR DESCRIPTION
## Summary
- tweak the challenge hub layout so the hero stats, CTA cards and predefined grids share consistent alignment and spacing
- expose the predefined lists section by default and highlight key counts for better legibility
- improve the resume card description by pluralising the question count dynamically

## Testing
- python manage.py check *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdaf57c7908333b0ff2463c41e2376