### PR TITLE
Add closure table for categories and related tests

### DIFF
--- a/quiz/migrations/0004_categoriahierarquia.py
+++ b/quiz/migrations/0004_categoriahierarquia.py
@@ -1,0 +1,62 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def populate_categoria_hierarquia(apps, schema_editor):
+    Categoria = apps.get_model('quiz', 'Categoria')
+    CategoriaHierarquia = apps.get_model('quiz', 'CategoriaHierarquia')
+
+    CategoriaHierarquia.objects.all().delete()
+
+    parent_map = dict(Categoria.objects.all().values_list('pk', 'id_categoria_pai_id'))
+    registros = []
+    for descendant_id in parent_map.keys():
+        depth = 0
+        current_id = descendant_id
+        visited = set()
+        while current_id is not None and current_id not in visited:
+            visited.add(current_id)
+            registros.append(CategoriaHierarquia(
+                ancestor_id=current_id,
+                descendant_id=descendant_id,
+                depth=depth,
+            ))
+            depth += 1
+            current_id = parent_map.get(current_id)
+
+    if registros:
+        CategoriaHierarquia.objects.bulk_create(registros, batch_size=1000)
+
+
+def clear_categoria_hierarquia(apps, schema_editor):
+    CategoriaHierarquia = apps.get_model('quiz', 'CategoriaHierarquia')
+    CategoriaHierarquia.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('quiz', '0003_configuracoesgeraisquiz_quizdefinicao_and_more'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CategoriaHierarquia',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('depth', models.PositiveIntegerField()),
+                ('ancestor', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='hierarquia_descendentes', to='quiz.categoria')),
+                ('descendant', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='hierarquia_ancestrais', to='quiz.categoria')),
+            ],
+            options={
+                'indexes': [
+                    models.Index(fields=['ancestor', 'descendant']),
+                    models.Index(fields=['descendant', 'ancestor']),
+                ],
+                'constraints': [
+                    models.UniqueConstraint(fields=('ancestor', 'descendant'), name='unique_categoriahierarquia_ancestor_descendant'),
+                ],
+            },
+        ),
+        migrations.RunPython(populate_categoria_hierarquia, clear_categoria_hierarquia),
+    ]

--- a/quiz/models.py
+++ b/quiz/models.py
@@ -1,5 +1,5 @@
 # quiz/models.py
-from django.db import models
+from django.db import models, transaction
 from django.contrib.auth.models import User
 from django.utils import timezone
 from django.core.exceptions import ValidationError
@@ -44,11 +44,144 @@ class Categoria(models.Model):
             return f"{self.id_categoria_pai.nome_categoria} -> {self.nome_categoria}"
         return self.nome_categoria
 
+    def save(self, *args, **kwargs):
+        is_new = self.pk is None
+        old_parent_id = None
+        descendant_ids = None
+        if not is_new and self.pk:
+            old_parent_id = Categoria.objects.filter(pk=self.pk).values_list(
+                'id_categoria_pai_id', flat=True
+            ).first()
+            descendant_ids = list(
+                CategoriaHierarquia.objects.filter(ancestor_id=self.pk)
+                .values_list('descendant_id', flat=True)
+            )
+
+        with transaction.atomic():
+            super().save(*args, **kwargs)
+
+            # Se a categoria é nova ou seu pai mudou, precisamos recalcular a hierarquia
+            parent_changed = old_parent_id != self.id_categoria_pai_id
+            if is_new or parent_changed:
+                ids_to_rebuild = descendant_ids if descendant_ids else []
+                if is_new:
+                    ids_to_rebuild.append(self.pk)
+                CategoriaHierarquia.rebuild_for_descendants(ids_to_rebuild or [self.pk])
+            else:
+                # Garante que pelo menos o elo reflexivo exista
+                if not CategoriaHierarquia.objects.filter(
+                    ancestor_id=self.pk, descendant_id=self.pk
+                ).exists():
+                    CategoriaHierarquia.rebuild_for_descendants([self.pk])
+
+    def delete(self, *args, **kwargs):
+        descendant_ids = list(
+            CategoriaHierarquia.objects.filter(ancestor_id=self.pk)
+            .values_list('descendant_id', flat=True)
+        )
+
+        with transaction.atomic():
+            super().delete(*args, **kwargs)
+
+            remaining_descendants = [
+                pk for pk in descendant_ids if pk and pk != self.pk
+            ]
+            if remaining_descendants:
+                CategoriaHierarquia.rebuild_for_descendants(remaining_descendants)
+
     class Meta:
         verbose_name = "Categoria de Pergunta"
         verbose_name_plural = "Categorias de Perguntas"
         unique_together = ('nome_categoria', 'id_categoria_pai')
         ordering = ['nome_categoria']
+
+
+class CategoriaHierarquia(models.Model):
+    ancestor = models.ForeignKey(
+        'Categoria',
+        related_name='hierarquia_descendentes',
+        on_delete=models.CASCADE,
+    )
+    descendant = models.ForeignKey(
+        'Categoria',
+        related_name='hierarquia_ancestrais',
+        on_delete=models.CASCADE,
+    )
+    depth = models.PositiveIntegerField()
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=['ancestor', 'descendant'],
+                name='unique_categoriahierarquia_ancestor_descendant'
+            )
+        ]
+        indexes = [
+            models.Index(fields=['ancestor', 'descendant']),
+            models.Index(fields=['descendant', 'ancestor']),
+        ]
+
+    def __str__(self):
+        return f"{self.ancestor_id} -> {self.descendant_id} (depth={self.depth})"
+
+    @classmethod
+    def rebuild_for_descendants(cls, descendant_ids, batch_size=1000):
+        if not descendant_ids:
+            return
+
+        ids = {int(pk) for pk in descendant_ids if pk is not None}
+        if not ids:
+            return
+
+        cls.objects.filter(descendant_id__in=ids).delete()
+
+        parent_map = dict(
+            Categoria.objects.all().values_list('pk', 'id_categoria_pai_id')
+        )
+        to_create = []
+        for descendant_id in ids:
+            if descendant_id not in parent_map:
+                continue
+            depth = 0
+            current_id = descendant_id
+            visited = set()
+            while current_id is not None and current_id not in visited:
+                visited.add(current_id)
+                to_create.append(cls(
+                    ancestor_id=current_id,
+                    descendant_id=descendant_id,
+                    depth=depth,
+                ))
+                depth += 1
+                current_id = parent_map.get(current_id)
+
+        if to_create:
+            cls.objects.bulk_create(to_create, batch_size=batch_size)
+
+    @classmethod
+    def rebuild_tree(cls, batch_size=1000):
+        parent_map = dict(
+            Categoria.objects.all().values_list('pk', 'id_categoria_pai_id')
+        )
+        cls.objects.all().delete()
+
+        to_create = []
+        for descendant_id in parent_map.keys():
+            depth = 0
+            current_id = descendant_id
+            visited = set()
+            while current_id is not None and current_id not in visited:
+                visited.add(current_id)
+                to_create.append(cls(
+                    ancestor_id=current_id,
+                    descendant_id=descendant_id,
+                    depth=depth,
+                ))
+                depth += 1
+                current_id = parent_map.get(current_id)
+
+        if to_create:
+            cls.objects.bulk_create(to_create, batch_size=batch_size)
 
 
 class Pergunta(models.Model):

--- a/quiz/tests.py
+++ b/quiz/tests.py
@@ -1,7 +1,15 @@
 from django.test import TestCase
 
-from quiz.models import ConfiguracoesGeraisQuiz
-from quiz.views import get_quiz_config, invalidate_quiz_config_cache
+from quiz.models import (
+    Categoria,
+    CategoriaHierarquia,
+    ConfiguracoesGeraisQuiz,
+)
+from quiz.views import (
+    get_descendant_category_ids,
+    get_quiz_config,
+    invalidate_quiz_config_cache,
+)
 
 
 class QuizConfigCacheTests(TestCase):
@@ -24,3 +32,100 @@ class QuizConfigCacheTests(TestCase):
         reloaded_config = get_quiz_config()
         self.assertEqual(reloaded_config.pontuacao_por_acerto, 42)
         self.assertEqual(reloaded_config.penalidade_por_erro, 3)
+
+
+class CategoriaHierarchyTests(TestCase):
+    def test_closure_created_on_category_creation(self):
+        root = Categoria.objects.create(nome_categoria="Raiz")
+        child = Categoria.objects.create(
+            nome_categoria="Filha",
+            id_categoria_pai=root,
+        )
+        grandchild = Categoria.objects.create(
+            nome_categoria="Neta",
+            id_categoria_pai=child,
+        )
+
+        self.assertTrue(
+            CategoriaHierarquia.objects.filter(
+                ancestor=root, descendant=root, depth=0
+            ).exists()
+        )
+        self.assertTrue(
+            CategoriaHierarquia.objects.filter(
+                ancestor=root, descendant=child, depth=1
+            ).exists()
+        )
+        self.assertTrue(
+            CategoriaHierarquia.objects.filter(
+                ancestor=root, descendant=grandchild, depth=2
+            ).exists()
+        )
+
+        descendants = get_descendant_category_ids([str(root.pk)])
+        self.assertSetEqual(descendants, {root.pk, child.pk, grandchild.pk})
+
+    def test_closure_updates_on_category_move(self):
+        root_a = Categoria.objects.create(nome_categoria="Raiz A")
+        root_b = Categoria.objects.create(nome_categoria="Raiz B")
+        child = Categoria.objects.create(
+            nome_categoria="Filha",
+            id_categoria_pai=root_a,
+        )
+        grandchild = Categoria.objects.create(
+            nome_categoria="Neta",
+            id_categoria_pai=child,
+        )
+
+        child.id_categoria_pai = root_b
+        child.save()
+
+        self.assertFalse(
+            CategoriaHierarquia.objects.filter(
+                ancestor=root_a, descendant=child
+            ).exists()
+        )
+        self.assertFalse(
+            CategoriaHierarquia.objects.filter(
+                ancestor=root_a, descendant=grandchild
+            ).exists()
+        )
+        self.assertTrue(
+            CategoriaHierarquia.objects.filter(
+                ancestor=root_b, descendant=child, depth=1
+            ).exists()
+        )
+        self.assertTrue(
+            CategoriaHierarquia.objects.filter(
+                ancestor=root_b, descendant=grandchild, depth=2
+            ).exists()
+        )
+
+        descendants_root_b = get_descendant_category_ids([str(root_b.pk)])
+        self.assertSetEqual(descendants_root_b, {root_b.pk, child.pk, grandchild.pk})
+
+    def test_closure_updates_on_category_delete(self):
+        root = Categoria.objects.create(nome_categoria="Raiz")
+        child = Categoria.objects.create(
+            nome_categoria="Filha",
+            id_categoria_pai=root,
+        )
+        grandchild = Categoria.objects.create(
+            nome_categoria="Neta",
+            id_categoria_pai=child,
+        )
+
+        root.delete()
+
+        self.assertFalse(
+            CategoriaHierarquia.objects.filter(
+                ancestor_id=root.pk
+            ).exists()
+        )
+        child.refresh_from_db()
+        grandchild.refresh_from_db()
+        self.assertIsNone(child.id_categoria_pai)
+        self.assertEqual(grandchild.id_categoria_pai_id, child.pk)
+
+        child_descendants = get_descendant_category_ids([str(child.pk)])
+        self.assertSetEqual(child_descendants, {child.pk, grandchild.pk})

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -22,7 +22,7 @@ from django.contrib.auth.models import User
 from collections import defaultdict
 
 from .models import (
-    Pergunta, Categoria, OpcaoResposta,
+    Pergunta, Categoria, CategoriaHierarquia, OpcaoResposta,
     SessoesQuizUsuario, RespostasUsuarioPorSessao, EstatisticasDiariasUsuario,
     QuestaoFavorita,
     QuizDefinicao,  # NOVO MODELO
@@ -80,34 +80,24 @@ def get_descendant_category_ids(category_ids_str_list):
     if not category_ids_str_list:
         return set()
     try:
-        # Garante que apenas IDs numéricos válidos sejam processados
-        initial_ids = set(int(cat_id) for cat_id in category_ids_str_list if str(
-            cat_id).strip().isdigit())
+        initial_ids = {
+            int(cat_id)
+            for cat_id in category_ids_str_list
+            if str(cat_id).strip().isdigit()
+        }
     except ValueError:
-        # Se houver algum valor não numérico que não foi filtrado, retorna conjunto vazio
         return set()
 
     if not initial_ids:
         return set()
 
-    all_descendant_ids = set()
-    # Fila para processamento BFS (Breadth-First Search)
-    queue = list(initial_ids)
-    processed_ids = set()     # Para evitar reprocessar e ciclos infinitos
-
-    while queue:
-        current_id = queue.pop(0)
-        if current_id in processed_ids:
-            continue
-        processed_ids.add(current_id)
-        all_descendant_ids.add(current_id)
-
-        subcategorias = Categoria.objects.filter(
-            id_categoria_pai_id=current_id).values_list('pk', flat=True)
-        for sub_cat_id in subcategorias:
-            if sub_cat_id not in processed_ids:
-                queue.append(sub_cat_id)
-    return all_descendant_ids
+    descendant_ids = set(
+        CategoriaHierarquia.objects.filter(ancestor_id__in=initial_ids)
+        .values_list('descendant_id', flat=True)
+    )
+    # Garante que as categorias originais estejam presentes, mesmo que ainda não haja registros
+    descendant_ids.update(initial_ids)
+    return descendant_ids
 
 
 def get_quiz_data_dict(
@@ -384,21 +374,28 @@ def _get_overall_accuracy_data(daily_stats_period_qs):
 
 def _get_category_performance_data(user_sessions_period_qs):
     category_performance = {}
-    main_categories = Categoria.objects.filter(
-        id_categoria_pai__isnull=True).prefetch_related('subcategorias')
+    main_categories = list(
+        Categoria.objects.filter(id_categoria_pai__isnull=True)
+    )
 
     responses_in_period = RespostasUsuarioPorSessao.objects.filter(
         id_sessao_quiz__in=user_sessions_period_qs,
         id_opcao_resposta_selecionada__isnull=False
     ).select_related('id_pergunta').prefetch_related('id_pergunta__categorias')
 
-    all_descendant_map = {cat.pk: get_descendant_category_ids(
-        [str(cat.pk)]) for cat in main_categories}
+    descendant_map = defaultdict(set)
+    if main_categories:
+        main_category_ids = [cat.pk for cat in main_categories]
+        for ancestor_id, descendant_id in CategoriaHierarquia.objects.filter(
+            ancestor_id__in=main_category_ids
+        ).values_list('ancestor_id', 'descendant_id'):
+            descendant_map[ancestor_id].add(descendant_id)
 
     for resp in responses_in_period:
         pergunta_obj = resp.id_pergunta
         for main_cat_obj in main_categories:
-            if any(cat.pk in all_descendant_map[main_cat_obj.pk] for cat in pergunta_obj.categorias.all()):
+            descendants = descendant_map.get(main_cat_obj.pk, {main_cat_obj.pk})
+            if any(cat.pk in descendants for cat in pergunta_obj.categorias.all()):
                 cat_name = main_cat_obj.nome_categoria
                 if cat_name not in category_performance:
                     category_performance[cat_name] = {


### PR DESCRIPTION
## Summary
- add a CategoriaHierarquia closure table model with helper methods and hook Categoria saves/deletes to keep it updated
- populate the closure table for existing data via a new migration
- refactor descendant category queries to use the closure table and extend tests to cover hierarchy creation, movement, and deletion

## Testing
- `python manage.py test` *(fails: Django not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb69ccc2083339204c79d6a419ef7