### PR TITLE
Add explicit names to CategoriaHierarquia indexes

### DIFF
--- a/quiz/migrations/0004_categoriahierarquia.py
+++ b/quiz/migrations/0004_categoriahierarquia.py
@@ -50,8 +50,14 @@ class Migration(migrations.Migration):
             ],
             options={
                 'indexes': [
-                    models.Index(fields=['ancestor', 'descendant']),
-                    models.Index(fields=['descendant', 'ancestor']),
+                    models.Index(
+                        fields=['ancestor', 'descendant'],
+                        name='categoriahierarquia_ancestor_descendant_idx',
+                    ),
+                    models.Index(
+                        fields=['descendant', 'ancestor'],
+                        name='categoriahierarquia_descendant_ancestor_idx',
+                    ),
                 ],
                 'constraints': [
                     models.UniqueConstraint(fields=('ancestor', 'descendant'), name='unique_categoriahierarquia_ancestor_descendant'),

--- a/quiz/models.py
+++ b/quiz/models.py
@@ -117,8 +117,14 @@ class CategoriaHierarquia(models.Model):
             )
         ]
         indexes = [
-            models.Index(fields=['ancestor', 'descendant']),
-            models.Index(fields=['descendant', 'ancestor']),
+            models.Index(
+                fields=['ancestor', 'descendant'],
+                name='categoriahierarquia_ancestor_descendant_idx',
+            ),
+            models.Index(
+                fields=['descendant', 'ancestor'],
+                name='categoriahierarquia_descendant_ancestor_idx',
+            ),
         ]
 
     def __str__(self):


### PR DESCRIPTION
## Summary
- add explicit names to the CategoriaHierarquia model indexes
- mirror the same index names in the original CategoriaHierarquia migration

## Testing
- `python manage.py migrate` *(fails: django not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd63c7d388333aa2dd6363a45a651