### PR TITLE
Enable reviewing favorite questions from account page

### DIFF
--- a/assets/js/app/App.js
+++ b/assets/js/app/App.js
@@ -54,6 +54,7 @@ export default class App {
 
             if (currentPageId === 'questions') {
                 await this.actionOrchestrator.initializeQuizPage();
+                await this._handlePendingFavoriteReview();
             } else if (currentPageId === 'account') {
                 this.accountPageManager.init();
             }
@@ -139,6 +140,20 @@ export default class App {
             }
         }
     }
+
+    async _handlePendingFavoriteReview() {
+        if (!this.favoriteManager || typeof this.favoriteManager.consumePendingReviewRequest !== 'function') {
+            return;
+        }
+
+        const pendingReview = this.favoriteManager.consumePendingReviewRequest();
+        if (!pendingReview || !pendingReview.questionId) {
+            return;
+        }
+
+        await this.actionOrchestrator.reviewFavoriteQuestion(pendingReview.questionId);
+    }
+
     handleLoadError(message) {
         console.error("App.js: handleLoadError - ", message);
         try {

--- a/assets/js/app/flux/ActionOrchestrator.js
+++ b/assets/js/app/flux/ActionOrchestrator.js
@@ -261,13 +261,17 @@ export default class ActionOrchestrator {
     async answerQuestion(selectedOptionId) {
         const state = this.store.getState().quiz;
         const question = state.currentQuestionsSet[state.currentQuestionIndex];
-        
+
         if (!question || question.respostaDadaId !== undefined) return;
 
         const correct = isAnswerCorrect(question, selectedOptionId);
         if (correct === null) return;
         
         this.store.dispatch(quizActions.answerQuestion(selectedOptionId, correct));
+
+        if (!state.currentSessionId) {
+            return;
+        }
 
         try {
             const response = await this.apiService.registerAnswer({
@@ -276,11 +280,11 @@ export default class ActionOrchestrator {
                 opcao_id: selectedOptionId,
                 current_question_index: state.currentQuestionIndex
             });
-            
+
             this.store.dispatch(
                 quizActions.updateUserStats(
                     response.pontuacao_sessao,
-                    response.total_acertos_sessao, 
+                    response.total_acertos_sessao,
                     response.total_erros_sessao
                 )
             );
@@ -295,15 +299,17 @@ export default class ActionOrchestrator {
 
         if (question && question.respostaDadaId === undefined) {
             this.store.dispatch({ type: ActionTypes.SKIP_QUESTION });
-            try {
-                await this.apiService.registerAnswer({ 
-                    session_id: state.currentSessionId, 
-                    pergunta_id: question.id_pergunta, 
-                    opcao_id: null, 
-                    current_question_index: state.currentQuestionIndex 
-                });
-            } catch (err) { 
-                console.warn("ActionOrchestrator: Erro ao registrar pulo de questão:", err); 
+            if (state.currentSessionId) {
+                try {
+                    await this.apiService.registerAnswer({
+                        session_id: state.currentSessionId,
+                        pergunta_id: question.id_pergunta,
+                        opcao_id: null,
+                        current_question_index: state.currentQuestionIndex
+                    });
+                } catch (err) {
+                    console.warn("ActionOrchestrator: Erro ao registrar pulo de questão:", err);
+                }
             }
         }
 
@@ -412,6 +418,41 @@ export default class ActionOrchestrator {
             }
         } catch (error) {
             this.store.dispatch(quizActions.loadFavoritesFailure(error.message));
+        }
+    }
+
+    async reviewFavoriteQuestion(questionId) {
+        const normalizedId = Number.parseInt(questionId, 10);
+        if (!Number.isInteger(normalizedId) || normalizedId <= 0) {
+            return false;
+        }
+
+        this.stopTimer();
+
+        this.ui.showSessionLoadingIndicator(true, "Carregando questão favorita...");
+        try {
+            const response = await this.apiService.getQuestionDetail(normalizedId);
+            if (response && response.status === 'success' && response.question) {
+                this.store.dispatch(quizActions.setActiveSection('questions'));
+                this.store.dispatch(
+                    quizActions.initializeQuiz(
+                        [response.question],
+                        'Revisão',
+                        null,
+                        null,
+                        'Questão Favorita'
+                    )
+                );
+                return true;
+            }
+
+            this.ui.showWarning(response?.message || 'Não foi possível carregar a questão favorita.', 'error');
+            return false;
+        } catch (error) {
+            this.ui.showWarning(getFriendlyErrorMessage(error, 'Erro ao carregar questão favorita.'), 'error');
+            return false;
+        } finally {
+            this.ui.showSessionLoadingIndicator(false);
         }
     }
 }

--- a/assets/js/app/flux/reducer.js
+++ b/assets/js/app/flux/reducer.js
@@ -298,6 +298,9 @@ export function quizReducer(state = initialState, action) {
                 mainQuizTitle = quizDefinitionName;
             } else if (mode === 'Rápido') {
                 mainQuizTitle = 'Quiz Rápido';
+            } else if (mode === 'Revisão') {
+                displayMode = 'review';
+                mainQuizTitle = quizDefinitionName || 'Questão Favorita';
             }
 
             const newQuizState = {

--- a/assets/js/app/services/ApiService.js
+++ b/assets/js/app/services/ApiService.js
@@ -127,6 +127,11 @@ export default class ApiService {
         return _request(API_URLS.get_favorite_questions, 'GET');
     }
 
+    async getQuestionDetail(perguntaId) {
+        const endpoint = API_URLS.get_question_detail(perguntaId);
+        return _request(endpoint, 'GET');
+    }
+
     async fetchUserStatistics(period = '30d') {
         const queryParams = { period };
         if (!API_URLS.api_get_user_statistics) {

--- a/assets/js/ui/FavoriteManager.js
+++ b/assets/js/ui/FavoriteManager.js
@@ -1,5 +1,7 @@
 // assets/js/ui/FavoriteManager.js
 
+export const FAVORITE_REVIEW_STORAGE_KEY = 'medquiz.favoriteReviewTarget';
+
 export default class FavoriteManager {
     constructor(quizUIInstance) {
         this.quizUI = quizUIInstance;
@@ -83,6 +85,7 @@ export default class FavoriteManager {
         if (!container) return;
         
         const { isLoading, items: favoriteQuestionsData, error } = favoritesState;
+        const questionsPageUrl = this._getQuestionsPageUrl();
         
         if (isLoading) {
             this.quizUI.hideElement(emptyState);
@@ -268,7 +271,7 @@ export default class FavoriteManager {
             actionsContainer.className = 'favorite-question-card__actions';
 
             const reviewLink = document.createElement('a');
-            reviewLink.href = `#q${fav.id_pergunta}`;
+            reviewLink.href = questionsPageUrl;
             reviewLink.className = 'button button--outline button--small favorite-question-card__action favorite-question-link';
             reviewLink.dataset.perguntaId = fav.id_pergunta;
             reviewLink.title = `Revisar a questão P${fav.id_pergunta} no quiz`;
@@ -277,6 +280,7 @@ export default class FavoriteManager {
             reviewLabel.className = 'button__label';
             reviewLabel.textContent = 'Ir para a questão';
             reviewLink.appendChild(reviewLabel);
+            reviewLink.addEventListener('click', event => this._handleReviewLinkClick(event, fav));
             actionsContainer.appendChild(reviewLink);
 
             if (explanationContainer) {
@@ -306,6 +310,72 @@ export default class FavoriteManager {
 
             container.appendChild(questionCard);
         });
+    }
+
+    consumePendingReviewRequest() {
+        if (typeof window === 'undefined' || !window.sessionStorage) {
+            return null;
+        }
+
+        const storedValue = window.sessionStorage.getItem(FAVORITE_REVIEW_STORAGE_KEY);
+        if (!storedValue) return null;
+
+        window.sessionStorage.removeItem(FAVORITE_REVIEW_STORAGE_KEY);
+
+        try {
+            const parsedValue = JSON.parse(storedValue);
+            const questionId = Number.parseInt(parsedValue?.questionId, 10);
+            if (!Number.isInteger(questionId) || questionId <= 0) {
+                return null;
+            }
+            return { questionId };
+        } catch (error) {
+            console.warn('FavoriteManager: dados inválidos encontrados para revisão de favorito.', error);
+            return null;
+        }
+    }
+
+    _handleReviewLinkClick(event, favoriteQuestion) {
+        if (event) {
+            event.preventDefault();
+        }
+
+        if (!favoriteQuestion || typeof favoriteQuestion.id_pergunta === 'undefined') {
+            return;
+        }
+
+        if (typeof window !== 'undefined' && window.sessionStorage) {
+            try {
+                window.sessionStorage.setItem(
+                    FAVORITE_REVIEW_STORAGE_KEY,
+                    JSON.stringify({
+                        questionId: favoriteQuestion.id_pergunta,
+                        timestamp: Date.now(),
+                    })
+                );
+            } catch (storageError) {
+                console.warn('FavoriteManager: não foi possível armazenar dados para revisão da questão favorita.', storageError);
+            }
+        }
+
+        const destinationUrl = this._getQuestionsPageUrl();
+        if (typeof window !== 'undefined' && destinationUrl) {
+            window.location.href = destinationUrl;
+        }
+    }
+
+    _getQuestionsPageUrl() {
+        const bottomNav = this.quizUI?.elements?.bottomNavElement;
+        const questionsLink = bottomNav?.querySelector('[data-section-target-django="questions"]');
+        if (questionsLink && questionsLink.href) {
+            return questionsLink.href;
+        }
+
+        if (typeof window !== 'undefined' && window.location) {
+            return `${window.location.origin}/questions/`;
+        }
+
+        return '/questions/';
     }
 
     _formatFavoriteDate(isoDateString) {

--- a/assets/js/ui/QuestionDisplay.js
+++ b/assets/js/ui/QuestionDisplay.js
@@ -225,6 +225,12 @@ export default class QuestionDisplay {
         const { navigationButtons, prevBtn, nextBtn } = this.elements;
         if (!navigationButtons || !prevBtn || !nextBtn || !question) return;
 
+        const displayMode = this.store?.getState().quiz?.quizDisplayContext?.displayMode;
+        if (displayMode === 'review') {
+            this.quizUI.hideElement(navigationButtons);
+            return;
+        }
+
         if (totalQuestions <= 0) {
             this.quizUI.hideElement(navigationButtons);
         } else {
@@ -250,10 +256,15 @@ export default class QuestionDisplay {
     renderQuestionGrid() {
         const container = this.elements.questionGridContainer;
         if (!container || !this.store) return;
-        
+
         const state = this.store.getState().quiz;
         const { currentQuestionsSet, currentQuestionIndex } = state;
-        
+
+        if (state.quizDisplayContext?.displayMode === 'review') {
+            this.quizUI.hideElement(container);
+            return;
+        }
+
         if (!currentQuestionsSet || currentQuestionsSet.length === 0) {
             this.quizUI.hideElement(container);
             return;

--- a/assets/js/ui/QuizUI.js
+++ b/assets/js/ui/QuizUI.js
@@ -79,17 +79,27 @@ export default class QuizUI {
         }
         
         const currentState = this.store.getState();
-        const wasQuizActive = this.previousState.quiz?.currentSessionId !== null;
-        const isQuizActive = currentState.quiz?.currentSessionId !== null;
-    
+        const previousSessionId = this.previousState.quiz?.currentSessionId;
+        const currentSessionId = currentState.quiz?.currentSessionId;
+        const wasQuizActive = previousSessionId !== null && previousSessionId !== undefined;
+        const isQuizActive = currentSessionId !== null && currentSessionId !== undefined;
+
         const wasQuizEnded = this.previousState.quiz?.quizEnded === true;
         const isQuizEnded = currentState.quiz?.quizEnded === true;
-    
-        if (!wasQuizActive && isQuizActive) {
+
+        const previousDisplayMode = this.previousState.quiz?.quizDisplayContext?.displayMode;
+        const currentDisplayMode = currentState.quiz?.quizDisplayContext?.displayMode;
+        const wasInReviewMode = previousDisplayMode === 'review';
+        const isInReviewMode = currentDisplayMode === 'review';
+
+        const wasQuizVisible = wasQuizActive || wasInReviewMode;
+        const isQuizVisible = isQuizActive || isInReviewMode;
+
+        if (!wasQuizVisible && isQuizVisible) {
             this.displayQuizLayout(true);
         }
-    
-        if ((wasQuizActive || wasQuizEnded) && !isQuizActive && !isQuizEnded) {
+
+        if ((wasQuizVisible || wasQuizEnded) && !isQuizVisible && !isQuizEnded) {
             this.displayQuizLayout(false);
         }
     
@@ -313,13 +323,17 @@ export default class QuizUI {
     
     displayQuizLayout(showQuizLayout = true) {
         const { placeholderFiltrosContainer, quizSectionContent, bottomNavElement } = this.elements;
-        
+        const displayMode = this.store?.getState()?.quiz?.quizDisplayContext?.displayMode || 'challenge';
+
         if (showQuizLayout) {
-            if (this.scorePanel) this.scorePanel.show();
+            if (this.scorePanel) {
+                if (displayMode === 'review') this.scorePanel.hide();
+                else this.scorePanel.show();
+            }
             if (this.challengeHubInstance) this.challengeHubInstance.hideHub();
-            this.showElement(quizSectionContent); 
-            if (this.warningDisplay) this.warningDisplay.clear(); 
-            this.hideElement(placeholderFiltrosContainer); 
+            this.showElement(quizSectionContent);
+            if (this.warningDisplay) this.warningDisplay.clear();
+            this.hideElement(placeholderFiltrosContainer);
             if (this.resultDisplay) this.resultDisplay.hide();
             if (bottomNavElement) this.hideElement(bottomNavElement);
             // --- INÍCIO DA ALTERAÇÃO: Remoção da chamada ao banner antigo ---

--- a/assets/js/utils/constants.js
+++ b/assets/js/utils/constants.js
@@ -11,6 +11,7 @@ export const API_URLS = {
     start_quiz_session: '/api/quiz/start-session/',
     register_answer: '/api/quiz/register-answer/',
     end_quiz_session: '/api/quiz/end-session/',
+    get_question_detail: (perguntaId) => `/api/question/${perguntaId}/`,
     toggle_favorite_status: (perguntaId) => `/api/question/${perguntaId}/toggle_favorite/`,
     get_favorite_questions: '/api/favorites/',
     api_get_user_statistics: '/api/user-statistics/',

--- a/quiz/api/viewsets.py
+++ b/quiz/api/viewsets.py
@@ -652,6 +652,41 @@ class QuestionViewSet(viewsets.ViewSet):
     lookup_field = 'pergunta_id'
     lookup_value_regex = r'\d+'
 
+    def retrieve(self, request, pergunta_id=None):
+        if not request.user.is_authenticated:
+            return Response(
+                {'status': 'error', 'message': 'Autenticação necessária.'},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        pergunta = get_object_or_404(Pergunta.objects.filter(ativa=True), pk=pergunta_id)
+
+        opcoes_data = [
+            {
+                'id_opcao_resposta': opcao.pk,
+                'id_pergunta': opcao.pergunta_id,
+                'texto_opcao': opcao.texto_opcao,
+                'eh_correta': opcao.eh_correta,
+                'ordem_exibicao': opcao.ordem_exibicao,
+                'feedback_opcao': opcao.feedback_opcao,
+            }
+            for opcao in pergunta.opcoes.order_by('ordem_exibicao', 'pk')
+        ]
+
+        question_payload = {
+            'id_pergunta': pergunta.pk,
+            'texto_pergunta': pergunta.texto_pergunta,
+            'url_imagem': pergunta.url_imagem,
+            'referencia_bibliografica': pergunta.referencia_bibliografica,
+            'categoria_ids': list(pergunta.categorias.values_list('pk', flat=True)),
+            'nivel_dificuldade': pergunta.nivel_dificuldade,
+            'explicacao_resposta': pergunta.explicacao_resposta,
+            'opcoes': opcoes_data,
+            'is_favorited': QuestaoFavorita.objects.filter(usuario=request.user, pergunta=pergunta).exists(),
+        }
+
+        return Response({'status': 'success', 'question': question_payload})
+
     @action(detail=True, methods=['post'], url_path='toggle_favorite')
     def toggle_favorite(self, request, pergunta_id=None):
         if not request.user.is_authenticated:

--- a/quiz/tests/test_api_quiz.py
+++ b/quiz/tests/test_api_quiz.py
@@ -12,6 +12,7 @@ from quiz.models import (
     EstatisticasDiariasUsuario,
     OpcaoResposta,
     Pergunta,
+    QuestaoFavorita,
     SessoesQuizUsuario,
 )
 from quiz.views import get_quiz_config, invalidate_quiz_config_cache
@@ -111,6 +112,24 @@ class QuizApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         favorites_payload = response.json()
         self.assertEqual(len(favorites_payload['favorite_questions']), 1)
+
+    def test_question_detail_requires_authentication(self):
+        url = reverse('quiz:question-detail', kwargs={'pergunta_id': self.question.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_question_detail_returns_payload(self):
+        self._auth_client()
+        QuestaoFavorita.objects.create(usuario=self.user, pergunta=self.question)
+
+        url = reverse('quiz:question-detail', kwargs={'pergunta_id': self.question.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        payload = response.json()
+        self.assertEqual(payload['status'], 'success')
+        self.assertEqual(payload['question']['id_pergunta'], self.question.pk)
+        self.assertTrue(payload['question']['is_favorited'])
 
     def test_user_statistics_endpoint(self):
         self._auth_client()


### PR DESCRIPTION
## Summary
- add a dedicated API endpoint to fetch full details for a favorite question
- persist the selected favorite question and redirect users to the questions page for a review session
- adjust the quiz UI to support a review display mode and hide navigation elements for single-question reviews
- cover the new endpoint with tests and wire the frontend service helpers

## Testing
- python manage.py test *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68ce0f9ec8dc833394fa87268c574259