### PR TITLE
Add cached fallback when reviewing favorite question

### DIFF
--- a/assets/js/app/App.js
+++ b/assets/js/app/App.js
@@ -151,7 +151,10 @@ export default class App {
             return;
         }
 
-        await this.actionOrchestrator.reviewFavoriteQuestion(pendingReview.questionId);
+        await this.actionOrchestrator.reviewFavoriteQuestion(
+            pendingReview.questionId,
+            pendingReview.questionData || null
+        );
     }
 
     handleLoadError(message) {

--- a/assets/js/app/flux/ActionOrchestrator.js
+++ b/assets/js/app/flux/ActionOrchestrator.js
@@ -421,11 +421,46 @@ export default class ActionOrchestrator {
         }
     }
 
-    async reviewFavoriteQuestion(questionId) {
+    async reviewFavoriteQuestion(questionId, cachedQuestionData = null) {
         const normalizedId = Number.parseInt(questionId, 10);
         if (!Number.isInteger(normalizedId) || normalizedId <= 0) {
             return false;
         }
+
+        const initializeQuizWithQuestion = question => {
+            if (!question) {
+                return false;
+            }
+
+            const questionPayload = { ...question };
+            if (typeof questionPayload.is_favorited === 'undefined') {
+                questionPayload.is_favorited = true;
+            }
+
+            this.store.dispatch(quizActions.setActiveSection('questions'));
+            this.store.dispatch(
+                quizActions.initializeQuiz(
+                    [questionPayload],
+                    'Revisão',
+                    null,
+                    null,
+                    'Questão Favorita'
+                )
+            );
+            return true;
+        };
+
+        const useCachedQuestion = (message = null, messageType = 'warning') => {
+            if (!cachedQuestionData) {
+                return false;
+            }
+
+            const initialized = initializeQuizWithQuestion(cachedQuestionData);
+            if (initialized && message) {
+                this.ui.showWarning(message, messageType);
+            }
+            return initialized;
+        };
 
         this.stopTimer();
 
@@ -433,22 +468,21 @@ export default class ActionOrchestrator {
         try {
             const response = await this.apiService.getQuestionDetail(normalizedId);
             if (response && response.status === 'success' && response.question) {
-                this.store.dispatch(quizActions.setActiveSection('questions'));
-                this.store.dispatch(
-                    quizActions.initializeQuiz(
-                        [response.question],
-                        'Revisão',
-                        null,
-                        null,
-                        'Questão Favorita'
-                    )
-                );
+                initializeQuizWithQuestion(response.question);
+                return true;
+            }
+
+            if (useCachedQuestion(response?.message || 'Não foi possível carregar a versão mais recente da questão. Exibindo dados salvos.')) {
                 return true;
             }
 
             this.ui.showWarning(response?.message || 'Não foi possível carregar a questão favorita.', 'error');
             return false;
         } catch (error) {
+            if (error?.response?.status === 404 && useCachedQuestion('Questão não encontrada no banco atual. Exibindo dados salvos da sua lista de favoritos.')) {
+                return true;
+            }
+
             this.ui.showWarning(getFriendlyErrorMessage(error, 'Erro ao carregar questão favorita.'), 'error');
             return false;
         } finally {

--- a/assets/js/ui/FavoriteManager.js
+++ b/assets/js/ui/FavoriteManager.js
@@ -328,7 +328,12 @@ export default class FavoriteManager {
             if (!Number.isInteger(questionId) || questionId <= 0) {
                 return null;
             }
-            return { questionId };
+
+            const questionData = parsedValue?.questionData && typeof parsedValue.questionData === 'object'
+                ? parsedValue.questionData
+                : null;
+
+            return { questionId, questionData };
         } catch (error) {
             console.warn('FavoriteManager: dados inválidos encontrados para revisão de favorito.', error);
             return null;
@@ -346,12 +351,19 @@ export default class FavoriteManager {
 
         if (typeof window !== 'undefined' && window.sessionStorage) {
             try {
+                const sanitizedQuestionData = this._sanitizeFavoriteQuestionForReview(favoriteQuestion);
+                const payloadToStore = {
+                    questionId: favoriteQuestion.id_pergunta,
+                    timestamp: Date.now(),
+                };
+
+                if (sanitizedQuestionData) {
+                    payloadToStore.questionData = sanitizedQuestionData;
+                }
+
                 window.sessionStorage.setItem(
                     FAVORITE_REVIEW_STORAGE_KEY,
-                    JSON.stringify({
-                        questionId: favoriteQuestion.id_pergunta,
-                        timestamp: Date.now(),
-                    })
+                    JSON.stringify(payloadToStore)
                 );
             } catch (storageError) {
                 console.warn('FavoriteManager: não foi possível armazenar dados para revisão da questão favorita.', storageError);
@@ -362,6 +374,53 @@ export default class FavoriteManager {
         if (typeof window !== 'undefined' && destinationUrl) {
             window.location.href = destinationUrl;
         }
+    }
+
+    _sanitizeFavoriteQuestionForReview(favoriteQuestion) {
+        if (!favoriteQuestion || typeof favoriteQuestion.id_pergunta === 'undefined') {
+            return null;
+        }
+
+        const sanitizedQuestion = {
+            id_pergunta: favoriteQuestion.id_pergunta,
+            texto_pergunta: favoriteQuestion.texto_pergunta || '',
+            url_imagem: favoriteQuestion.url_imagem || null,
+            referencia_bibliografica: favoriteQuestion.referencia_bibliografica || null,
+            categoria_ids: Array.isArray(favoriteQuestion.categoria_ids)
+                ? [...favoriteQuestion.categoria_ids]
+                : [],
+            nivel_dificuldade: favoriteQuestion.nivel_dificuldade || null,
+            explicacao_resposta: favoriteQuestion.explicacao_resposta || null,
+            is_favorited: true,
+        };
+
+        if (Array.isArray(favoriteQuestion.opcoes)) {
+            sanitizedQuestion.opcoes = favoriteQuestion.opcoes
+                .map(option => ({
+                    id_opcao_resposta: option.id_opcao_resposta,
+                    id_pergunta: option.id_pergunta ?? favoriteQuestion.id_pergunta,
+                    texto_opcao: option.texto_opcao || '',
+                    eh_correta: Boolean(option.eh_correta),
+                    ordem_exibicao: typeof option.ordem_exibicao === 'number' ? option.ordem_exibicao : null,
+                    feedback_opcao: option.feedback_opcao || null,
+                }))
+                .sort((a, b) => {
+                    const orderA = typeof a.ordem_exibicao === 'number' ? a.ordem_exibicao : Number.MAX_SAFE_INTEGER;
+                    const orderB = typeof b.ordem_exibicao === 'number' ? b.ordem_exibicao : Number.MAX_SAFE_INTEGER;
+
+                    if (orderA === orderB) {
+                        const idA = typeof a.id_opcao_resposta === 'number' ? a.id_opcao_resposta : Number.MAX_SAFE_INTEGER;
+                        const idB = typeof b.id_opcao_resposta === 'number' ? b.id_opcao_resposta : Number.MAX_SAFE_INTEGER;
+                        return idA - idB;
+                    }
+
+                    return orderA - orderB;
+                });
+        } else {
+            sanitizedQuestion.opcoes = [];
+        }
+
+        return sanitizedQuestion;
     }
 
     _getQuestionsPageUrl() {


### PR DESCRIPTION
## Summary
- cache sanitized favorite question data in session storage before redirecting to the questions page
- propagate cached data through the app bootstrap so the orchestrator can access it
- fall back to the cached question when the detail API cannot return the resource, avoiding the current 404 error toast

## Testing
- python manage.py test quiz *(fails: missing Django in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce1461f5f88333b3a312fcb0f2ec39