### PR TITLE
Allow reviewing inactive favorite questions

### DIFF
--- a/assets/js/app/flux/ActionOrchestrator.js
+++ b/assets/js/app/flux/ActionOrchestrator.js
@@ -469,6 +469,10 @@ export default class ActionOrchestrator {
             const response = await this.apiService.getQuestionDetail(normalizedId);
             if (response && response.status === 'success' && response.question) {
                 initializeQuizWithQuestion(response.question);
+                if (response.message) {
+                    const messageType = typeof response.message_type === 'string' ? response.message_type : 'info';
+                    this.ui.showWarning(response.message, messageType);
+                }
                 return true;
             }
 

--- a/quiz/api/viewsets.py
+++ b/quiz/api/viewsets.py
@@ -659,7 +659,27 @@ class QuestionViewSet(viewsets.ViewSet):
                 status=status.HTTP_401_UNAUTHORIZED,
             )
 
-        pergunta = get_object_or_404(Pergunta.objects.filter(ativa=True), pk=pergunta_id)
+        pergunta = get_object_or_404(Pergunta, pk=pergunta_id)
+
+        is_favorited = QuestaoFavorita.objects.filter(usuario=request.user, pergunta=pergunta).exists()
+
+        if not pergunta.ativa and not is_favorited:
+            return Response(
+                {
+                    'status': 'error',
+                    'message': 'Esta questão não está mais disponível no banco de questões.',
+                },
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        warning_message = None
+        warning_type = 'info'
+        if not pergunta.ativa and is_favorited:
+            warning_message = (
+                'Esta questão não está mais disponível no banco atual. Exibindo a versão salva '
+                'na sua lista de favoritos.'
+            )
+            warning_type = 'warning'
 
         opcoes_data = [
             {
@@ -682,10 +702,16 @@ class QuestionViewSet(viewsets.ViewSet):
             'nivel_dificuldade': pergunta.nivel_dificuldade,
             'explicacao_resposta': pergunta.explicacao_resposta,
             'opcoes': opcoes_data,
-            'is_favorited': QuestaoFavorita.objects.filter(usuario=request.user, pergunta=pergunta).exists(),
+            'is_favorited': is_favorited,
+            'esta_ativa': pergunta.ativa,
         }
 
-        return Response({'status': 'success', 'question': question_payload})
+        response_payload = {'status': 'success', 'question': question_payload}
+        if warning_message:
+            response_payload['message'] = warning_message
+            response_payload['message_type'] = warning_type
+
+        return Response(response_payload)
 
     @action(detail=True, methods=['post'], url_path='toggle_favorite')
     def toggle_favorite(self, request, pergunta_id=None):


### PR DESCRIPTION
## Summary
- allow the question detail endpoint to return inactive questions that are still in a user's favorites and surface a warning message
- display backend warning messages when reviewing a favorite so the user knows when an inactive question is being shown

## Testing
- python manage.py test *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce16aedcac83339007b3ce04793a42