### PR TITLE
Improve favorite review for inactive questions

### DIFF
--- a/assets/css/sections/conta-section.css
+++ b/assets/css/sections/conta-section.css
@@ -349,6 +349,11 @@
     transition: transform var(--transition-fast), box-shadow var(--transition-fast);
 }
 
+.favorite-question-card--inactive {
+    border-color: rgba(var(--color-accent-red-rgb, 230, 57, 70), 0.25);
+    background: linear-gradient(135deg, rgba(var(--color-accent-yellow-rgb, 255, 215, 0), 0.08), var(--color-white));
+}
+
 .favorite-question-card:hover {
     transform: translateY(-3px);
     box-shadow: var(--shadow-md);
@@ -389,6 +394,24 @@
     font-weight: var(--font-weight-semibold, 600);
     flex: 1;
     word-break: break-word;
+}
+
+.favorite-question-card__status-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.2rem 0.75rem;
+    border-radius: var(--border-radius-pill, 999px);
+    font-size: 0.72rem;
+    font-weight: var(--font-weight-semibold, 600);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.favorite-question-card__status-badge--inactive {
+    background-color: rgba(var(--color-accent-red-rgb, 230, 57, 70), 0.12);
+    color: var(--color-accent-red);
+    border: 1px solid rgba(var(--color-accent-red-rgb, 230, 57, 70), 0.25);
 }
 
 .favorite-question-card__meta {

--- a/assets/js/app/App.js
+++ b/assets/js/app/App.js
@@ -153,7 +153,8 @@ export default class App {
 
         await this.actionOrchestrator.reviewFavoriteQuestion(
             pendingReview.questionId,
-            pendingReview.questionData || null
+            pendingReview.questionData || null,
+            { forceUseCache: pendingReview.forceUseCache === true }
         );
     }
 

--- a/assets/js/app/flux/ActionOrchestrator.js
+++ b/assets/js/app/flux/ActionOrchestrator.js
@@ -421,11 +421,13 @@ export default class ActionOrchestrator {
         }
     }
 
-    async reviewFavoriteQuestion(questionId, cachedQuestionData = null) {
+    async reviewFavoriteQuestion(questionId, cachedQuestionData = null, options = {}) {
         const normalizedId = Number.parseInt(questionId, 10);
         if (!Number.isInteger(normalizedId) || normalizedId <= 0) {
             return false;
         }
+
+        const forceUseCache = options?.forceUseCache === true;
 
         const initializeQuizWithQuestion = question => {
             if (!question) {
@@ -463,6 +465,18 @@ export default class ActionOrchestrator {
         };
 
         this.stopTimer();
+
+        if (forceUseCache) {
+            if (useCachedQuestion(
+                'Esta questão não está mais disponível no banco atual. Exibindo dados salvos da sua lista de favoritos.',
+                'warning'
+            )) {
+                return true;
+            }
+
+            this.ui.showWarning('Não foi possível carregar a questão favorita.', 'error');
+            return false;
+        }
 
         this.ui.showSessionLoadingIndicator(true, "Carregando questão favorita...");
         try {

--- a/assets/js/ui/FavoriteManager.js
+++ b/assets/js/ui/FavoriteManager.js
@@ -118,6 +118,10 @@ export default class FavoriteManager {
             questionCard.className = 'favorite-question-card';
             questionCard.dataset.perguntaId = fav.id_pergunta;
 
+            if (fav.esta_ativa === false) {
+                questionCard.classList.add('favorite-question-card--inactive');
+            }
+
             const header = document.createElement('header');
             header.className = 'favorite-question-card__header';
 
@@ -133,6 +137,13 @@ export default class FavoriteManager {
             title.className = 'favorite-question-card__title';
             title.textContent = fav.texto_pergunta;
             headingWrapper.appendChild(title);
+
+            if (fav.esta_ativa === false) {
+                const statusBadge = document.createElement('span');
+                statusBadge.className = 'favorite-question-card__status-badge favorite-question-card__status-badge--inactive';
+                statusBadge.textContent = 'Questão inativa';
+                headingWrapper.appendChild(statusBadge);
+            }
 
             header.appendChild(headingWrapper);
 
@@ -333,7 +344,8 @@ export default class FavoriteManager {
                 ? parsedValue.questionData
                 : null;
 
-            return { questionId, questionData };
+            const forceUseCache = parsedValue?.forceUseCache === true;
+            return { questionId, questionData, forceUseCache };
         } catch (error) {
             console.warn('FavoriteManager: dados inválidos encontrados para revisão de favorito.', error);
             return null;
@@ -356,6 +368,10 @@ export default class FavoriteManager {
                     questionId: favoriteQuestion.id_pergunta,
                     timestamp: Date.now(),
                 };
+
+                if (favoriteQuestion.esta_ativa === false) {
+                    payloadToStore.forceUseCache = true;
+                }
 
                 if (sanitizedQuestionData) {
                     payloadToStore.questionData = sanitizedQuestionData;
@@ -392,6 +408,7 @@ export default class FavoriteManager {
             nivel_dificuldade: favoriteQuestion.nivel_dificuldade || null,
             explicacao_resposta: favoriteQuestion.explicacao_resposta || null,
             is_favorited: true,
+            esta_ativa: favoriteQuestion.esta_ativa === false ? false : true,
         };
 
         if (Array.isArray(favoriteQuestion.opcoes)) {

--- a/quiz/api/viewsets.py
+++ b/quiz/api/viewsets.py
@@ -625,6 +625,7 @@ class FavoriteQuestionViewSet(viewsets.ViewSet):
                     'nivel_dificuldade': pergunta.nivel_dificuldade,
                     'explicacao_resposta': pergunta.explicacao_resposta,
                     'opcoes': opcoes_data,
+                    'esta_ativa': pergunta.ativa,
                     'data_favoritada': fav.data_favoritada.isoformat(),
                 }
             )

--- a/quiz/tests/test_api_quiz.py
+++ b/quiz/tests/test_api_quiz.py
@@ -112,6 +112,9 @@ class QuizApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         favorites_payload = response.json()
         self.assertEqual(len(favorites_payload['favorite_questions']), 1)
+        favorite_question = favorites_payload['favorite_questions'][0]
+        self.assertIn('esta_ativa', favorite_question)
+        self.assertTrue(favorite_question['esta_ativa'])
 
     def test_question_detail_requires_authentication(self):
         url = reverse('quiz:question-detail', kwargs={'pergunta_id': self.question.pk})
@@ -130,6 +133,27 @@ class QuizApiTests(TestCase):
         self.assertEqual(payload['status'], 'success')
         self.assertEqual(payload['question']['id_pergunta'], self.question.pk)
         self.assertTrue(payload['question']['is_favorited'])
+
+    def test_question_detail_returns_warning_for_inactive_favorite(self):
+        self._auth_client()
+        self.question.ativa = False
+        self.question.save(update_fields=['ativa'])
+
+        QuestaoFavorita.objects.create(usuario=self.user, pergunta=self.question)
+
+        url = reverse('quiz:question-detail', kwargs={'pergunta_id': self.question.pk})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload['status'], 'success')
+        self.assertEqual(payload['question']['id_pergunta'], self.question.pk)
+        self.assertFalse(payload['question']['esta_ativa'])
+        self.assertEqual(
+            payload['message'],
+            'Esta questão não está mais disponível no banco atual. Exibindo a versão salva na sua lista de favoritos.'
+        )
+        self.assertEqual(payload['message_type'], 'warning')
 
     def test_user_statistics_endpoint(self):
         self._auth_client()


### PR DESCRIPTION
## Summary
- include the active status flag when returning favorite questions and cover it with tests
- highlight inactive favorites in the account UI and mark review requests to reuse cached data when needed
- fall back to cached question data without hitting the API when a favorite is inactive and style the status badge

## Testing
- python manage.py test *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68ce19909fdc8333919afbd0b921a12b