### PR TITLE
Ensure favorite review links work across tabs

### DIFF
--- a/assets/js/app/App.js
+++ b/assets/js/app/App.js
@@ -13,7 +13,7 @@ import ResultDisplay from '../ui/ResultDisplay.js';
 import AccountPageManager from '../ui/AccountPageManager.js';
 import BottomNavManager from '../ui/BottomNavManager.js';
 import StatisticsChartManager from '../ui/StatisticsChartManager.js';
-import FavoriteManager from '../ui/FavoriteManager.js';
+import FavoriteManager, { FAVORITE_REVIEW_QUERY_PARAM } from '../ui/FavoriteManager.js';
 import { QUICK_QUIZ_COUNT } from '../utils/constants.js';
 
 export default class App {
@@ -146,7 +146,9 @@ export default class App {
             return;
         }
 
-        const pendingReview = this.favoriteManager.consumePendingReviewRequest();
+        const pendingReviewFromUrl = this._consumeFavoriteReviewFromUrl();
+        const pendingReview = pendingReviewFromUrl || this.favoriteManager.consumePendingReviewRequest();
+
         if (!pendingReview || !pendingReview.questionId) {
             return;
         }
@@ -156,6 +158,48 @@ export default class App {
             pendingReview.questionData || null,
             { forceUseCache: pendingReview.forceUseCache === true }
         );
+    }
+
+    _consumeFavoriteReviewFromUrl() {
+        if (typeof window === 'undefined' || !window.location) {
+            return null;
+        }
+
+        const { search, pathname, hash } = window.location;
+        if (!search || (typeof search === 'string' && !search.includes(`${FAVORITE_REVIEW_QUERY_PARAM}=`))) {
+            return null;
+        }
+
+        try {
+            const searchParams = new URLSearchParams(search);
+            const questionIdValue = searchParams.get(FAVORITE_REVIEW_QUERY_PARAM);
+
+            if (questionIdValue === null) {
+                return null;
+            }
+
+            searchParams.delete(FAVORITE_REVIEW_QUERY_PARAM);
+
+            if (typeof window.history !== 'undefined' && typeof window.history.replaceState === 'function') {
+                const newSearch = searchParams.toString();
+                const newUrl = `${pathname}${newSearch ? `?${newSearch}` : ''}${hash || ''}`;
+                try {
+                    window.history.replaceState(window.history.state, document.title, newUrl);
+                } catch (historyError) {
+                    console.warn('App: falha ao atualizar a URL após processar favorito pendente.', historyError);
+                }
+            }
+
+            const questionId = Number.parseInt(questionIdValue, 10);
+            if (!Number.isInteger(questionId) || questionId <= 0) {
+                return null;
+            }
+
+            return { questionId };
+        } catch (urlError) {
+            console.warn('App: não foi possível ler o parâmetro de revisão de favorito da URL.', urlError);
+            return null;
+        }
     }
 
     handleLoadError(message) {

--- a/assets/js/ui/FavoriteManager.js
+++ b/assets/js/ui/FavoriteManager.js
@@ -1,6 +1,7 @@
 // assets/js/ui/FavoriteManager.js
 
 export const FAVORITE_REVIEW_STORAGE_KEY = 'medquiz.favoriteReviewTarget';
+export const FAVORITE_REVIEW_QUERY_PARAM = 'favorite_question';
 
 export default class FavoriteManager {
     constructor(quizUIInstance) {
@@ -282,7 +283,8 @@ export default class FavoriteManager {
             actionsContainer.className = 'favorite-question-card__actions';
 
             const reviewLink = document.createElement('a');
-            reviewLink.href = questionsPageUrl;
+            const reviewUrl = this._buildQuestionReviewLink(questionsPageUrl, fav.id_pergunta);
+            reviewLink.href = reviewUrl || questionsPageUrl;
             reviewLink.className = 'button button--outline button--small favorite-question-card__action favorite-question-link';
             reviewLink.dataset.perguntaId = fav.id_pergunta;
             reviewLink.title = `Revisar a questão P${fav.id_pergunta} no quiz`;
@@ -353,13 +355,31 @@ export default class FavoriteManager {
     }
 
     _handleReviewLinkClick(event, favoriteQuestion) {
+        if (!favoriteQuestion || typeof favoriteQuestion.id_pergunta === 'undefined') {
+            return;
+        }
+
+        const isModifiedClick = Boolean(
+            event && (
+                event.defaultPrevented ||
+                (typeof event.button === 'number' && event.button !== 0) ||
+                event.metaKey ||
+                event.ctrlKey ||
+                event.shiftKey ||
+                event.altKey
+            )
+        );
+
+        if (isModifiedClick) {
+            return;
+        }
+
         if (event) {
             event.preventDefault();
         }
 
-        if (!favoriteQuestion || typeof favoriteQuestion.id_pergunta === 'undefined') {
-            return;
-        }
+        const baseUrl = this._getQuestionsPageUrl();
+        const destinationUrl = this._buildQuestionReviewLink(baseUrl, favoriteQuestion.id_pergunta) || baseUrl;
 
         if (typeof window !== 'undefined' && window.sessionStorage) {
             try {
@@ -386,9 +406,43 @@ export default class FavoriteManager {
             }
         }
 
-        const destinationUrl = this._getQuestionsPageUrl();
         if (typeof window !== 'undefined' && destinationUrl) {
             window.location.href = destinationUrl;
+        }
+    }
+
+    _buildQuestionReviewLink(baseUrl, questionId) {
+        if (!baseUrl) {
+            return null;
+        }
+
+        const parsedId = Number.parseInt(questionId, 10);
+        if (!Number.isInteger(parsedId) || parsedId <= 0) {
+            return baseUrl;
+        }
+
+        const questionIdString = String(parsedId);
+
+        try {
+            const hashIndex = baseUrl.indexOf('#');
+            const pathAndQuery = hashIndex >= 0 ? baseUrl.slice(0, hashIndex) : baseUrl;
+            const hashFragment = hashIndex >= 0 ? baseUrl.slice(hashIndex) : '';
+
+            const queryIndex = pathAndQuery.indexOf('?');
+            const pathOnly = queryIndex >= 0 ? pathAndQuery.slice(0, queryIndex) : pathAndQuery;
+            const queryString = queryIndex >= 0 ? pathAndQuery.slice(queryIndex + 1) : '';
+
+            const searchParams = new URLSearchParams(queryString);
+            searchParams.set(FAVORITE_REVIEW_QUERY_PARAM, questionIdString);
+
+            const newQuery = searchParams.toString();
+            const newPathAndQuery = newQuery ? `${pathOnly}?${newQuery}` : pathOnly;
+
+            return `${newPathAndQuery}${hashFragment}`;
+        } catch (urlError) {
+            console.warn('FavoriteManager: não foi possível construir URL para revisão da questão favorita.', urlError);
+            const separator = baseUrl.includes('?') ? '&' : '?';
+            return `${baseUrl}${separator}${encodeURIComponent(FAVORITE_REVIEW_QUERY_PARAM)}=${encodeURIComponent(questionIdString)}`;
         }
     }
 

--- a/docs/favorite-question-navigation.md
+++ b/docs/favorite-question-navigation.md
@@ -1,0 +1,18 @@
+# Favorite Question Review Navigation
+
+This document explains how the application routes a user from the favorites list to the questions interface after the addition of the `favorite_question` URL parameter.
+
+## Same-tab navigation
+
+1. Click **Ir para a questão** within the favorites list.
+2. The click handler intercepts an unmodified left click, serialises the favorite question payload into `sessionStorage` under the `medquiz.favoriteReviewTarget` key, and then redirects to `/questions/` with the `favorite_question=<id>` query string appended.
+3. On the questions page load, the bootstrap logic reads the query parameter, falls back to the `sessionStorage` payload if the URL parameter is absent, and calls `actionOrchestrator.reviewFavoriteQuestion` with the resolved identifier.
+4. After consumption, the query string is stripped via `history.replaceState` to avoid repeat loads when navigating within the same tab.
+
+## New-tab navigation
+
+1. Open **Ir para a questão** in a new tab or window (e.g. via context menu or modifier click).
+2. Because modified clicks bypass the in-tab handler, the browser follows the link directly to `/questions/?favorite_question=<id>` without relying on `sessionStorage`.
+3. The questions page bootstrap detects the query parameter, requests the favorite question review, and cleans the query string. Since `sessionStorage` is per-tab, this ensures the favorite question loads even in a fresh browsing context.
+
+Both flows now result in a reliable favorite review experience.


### PR DESCRIPTION
## Summary
- append the `favorite_question` query parameter to favorite review links while only intercepting unmodified clicks
- read and clear the query parameter during questions page bootstrap before falling back to sessionStorage
- document both same-tab and new-tab favorite review flows for future reference

## Testing
- python manage.py test *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68ce1feca42c8333ba3a61f57e33b1d9