### PR TITLE
Handle pending favorite review data from URL and storage

### DIFF
--- a/assets/js/app/App.js
+++ b/assets/js/app/App.js
@@ -147,16 +147,27 @@ export default class App {
         }
 
         const pendingReviewFromUrl = this._consumeFavoriteReviewFromUrl();
-        const pendingReview = pendingReviewFromUrl || this.favoriteManager.consumePendingReviewRequest();
+        const pendingReviewFromStorage = this.favoriteManager.consumePendingReviewRequest();
 
-        if (!pendingReview || !pendingReview.questionId) {
+        const effectiveQuestionId = pendingReviewFromUrl?.questionId
+            ?? pendingReviewFromStorage?.questionId;
+
+        if (!effectiveQuestionId) {
             return;
         }
 
+        let questionData = null;
+        let forceUseCache = false;
+
+        if (pendingReviewFromStorage && pendingReviewFromStorage.questionId === effectiveQuestionId) {
+            questionData = pendingReviewFromStorage.questionData || null;
+            forceUseCache = pendingReviewFromStorage.forceUseCache === true;
+        }
+
         await this.actionOrchestrator.reviewFavoriteQuestion(
-            pendingReview.questionId,
-            pendingReview.questionData || null,
-            { forceUseCache: pendingReview.forceUseCache === true }
+            effectiveQuestionId,
+            questionData,
+            { forceUseCache }
         );
     }
 


### PR DESCRIPTION
## Summary
- load pending favorite review information from both the URL and the stored request
- prioritize the question ID from the URL while keeping cached data that matches the same question

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce241bffd48333bf3b4811a458b38f