### PR TITLE
Remove unnecessary loading indicators on favorites and navigation

### DIFF
--- a/assets/js/app/flux/ActionOrchestrator.js
+++ b/assets/js/app/flux/ActionOrchestrator.js
@@ -92,10 +92,9 @@ export default class ActionOrchestrator {
     }
 
     async tryResumeSession() {
-        this.ui.showSessionLoadingIndicator(true, "Verificando sessão anterior...");
         try {
             const resumeData = await this.apiService.resumeQuizSession();
-            this.ui.showSessionLoadingIndicator(false); 
+            this.ui.showSessionLoadingIndicator(false);
 
             if (resumeData && resumeData.status === 'success' && resumeData.perguntas?.length > 0) {
                 this.store.dispatch({
@@ -388,7 +387,10 @@ export default class ActionOrchestrator {
         }
 
         const btnFav = this.ui.elements.btnToggleFavorite;
-        if (btnFav) this.ui.setButtonLoading(btnFav, true);
+        if (btnFav) {
+            btnFav.disabled = true;
+            btnFav.setAttribute('aria-disabled', 'true');
+        }
 
         try {
             const response = await this.apiService.toggleFavoriteStatus(question.id_pergunta);
@@ -403,7 +405,10 @@ export default class ActionOrchestrator {
         } catch (error) {
             this.ui.showWarning(getFriendlyErrorMessage(error, "Erro de conexão ao favoritar."), 'error');
         } finally {
-            if (btnFav) this.ui.setButtonLoading(btnFav, false);
+            if (btnFav) {
+                btnFav.disabled = false;
+                btnFav.removeAttribute('aria-disabled');
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- stop forcing the session loading overlay when checking for resumable quizzes so the questions page opens without the blocking spinner
- simplify the favorite toggle to only disable the button instead of replacing its label with a loading state, preventing the lingering "Carregando..." text

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce26f98dd48333a51a1a3e66bf0b20