### PR TITLE
Adjust favorite card header and improve category tags

### DIFF
--- a/assets/css/sections/conta-section.css
+++ b/assets/css/sections/conta-section.css
@@ -388,9 +388,9 @@
 
 .favorite-question-card__heading {
     display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: var(--spacing-sm, 12px);
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--spacing-xs, 8px);
     flex: 1;
     min-width: 0;
 }
@@ -407,6 +407,7 @@
     font-size: 0.78rem;
     letter-spacing: 0.05em;
     text-transform: uppercase;
+    align-self: flex-start;
 }
 
 .favorite-question-card__title {

--- a/assets/js/ui/FavoriteManager.js
+++ b/assets/js/ui/FavoriteManager.js
@@ -109,7 +109,14 @@ export default class FavoriteManager {
         container.innerHTML = '';
 
         const allCategories = this.store.getState().geral.allCategories || [];
-        const categoryMap = new Map(allCategories.map(cat => [cat.id_categoria, cat.nome_categoria]));
+        const categoryMap = new Map();
+        allCategories.forEach(cat => {
+            if (cat && typeof cat.id_categoria !== 'undefined') {
+                const name = typeof cat.nome_categoria === 'string' ? cat.nome_categoria.trim() : '';
+                categoryMap.set(cat.id_categoria, name);
+                categoryMap.set(String(cat.id_categoria), name);
+            }
+        });
 
         container.classList.add('favorite-questions-list');
 
@@ -235,12 +242,12 @@ export default class FavoriteManager {
             const tagsContainer = document.createElement('div');
             tagsContainer.className = 'favorite-question-card__tags categories-tags-container';
 
-            if (fav.categoria_ids && fav.categoria_ids.length > 0) {
-                fav.categoria_ids.forEach(id => {
-                    const categoryName = categoryMap.get(id) || `ID ${id}`;
+            const categoryLabels = this._getCategoryLabels(fav, categoryMap);
+            if (categoryLabels.length > 0) {
+                categoryLabels.forEach(label => {
                     const tag = document.createElement('span');
                     tag.className = 'category-tag';
-                    tag.textContent = categoryName;
+                    tag.textContent = label;
                     tagsContainer.appendChild(tag);
                 });
             } else {
@@ -546,6 +553,12 @@ export default class FavoriteManager {
             esta_ativa: favoriteQuestion.esta_ativa === false ? false : true,
         };
 
+        const normalizedCategories = this._normalizeFavoriteCategories(favoriteQuestion);
+        sanitizedQuestion.categorias = normalizedCategories;
+        sanitizedQuestion.categoria_nomes = normalizedCategories
+            .map(category => category.nome_categoria)
+            .filter(name => typeof name === 'string' && name.trim() !== '');
+
         if (Array.isArray(favoriteQuestion.opcoes)) {
             sanitizedQuestion.opcoes = favoriteQuestion.opcoes
                 .map(option => ({
@@ -573,6 +586,127 @@ export default class FavoriteManager {
         }
 
         return sanitizedQuestion;
+    }
+
+    _getCategoryLabels(favoriteQuestion, categoryMap) {
+        if (!favoriteQuestion) {
+            return [];
+        }
+
+        const normalizedCategories = this._normalizeFavoriteCategories(favoriteQuestion);
+        const labelsSet = new Set();
+
+        normalizedCategories.forEach(category => {
+            if (category.nome_categoria) {
+                labelsSet.add(category.nome_categoria);
+            } else if (category.id_categoria !== null) {
+                const resolvedName = this._resolveCategoryNameById(category.id_categoria, categoryMap);
+                if (resolvedName) {
+                    labelsSet.add(resolvedName);
+                }
+            }
+        });
+
+        if (labelsSet.size === 0 && Array.isArray(favoriteQuestion.categoria_ids)) {
+            favoriteQuestion.categoria_ids.forEach(id => {
+                const resolvedName = this._resolveCategoryNameById(id, categoryMap);
+                if (resolvedName) {
+                    labelsSet.add(resolvedName);
+                }
+            });
+        }
+
+        return Array.from(labelsSet);
+    }
+
+    _normalizeFavoriteCategories(favoriteQuestion) {
+        if (!favoriteQuestion) {
+            return [];
+        }
+
+        const normalized = [];
+        const seenKeys = new Set();
+
+        const addCategory = (idValue, nameValue) => {
+            const normalizedName = typeof nameValue === 'string' ? nameValue.trim() : '';
+            const normalizedId = this._normalizeCategoryId(idValue);
+            if (!normalizedName && normalizedId === null) {
+                return;
+            }
+
+            const keyNamePart = normalizedName ? normalizedName.toLowerCase() : '';
+            const keyIdPart = normalizedId !== null ? `id:${normalizedId}` : '';
+            const dedupeKey = `${keyNamePart}|${keyIdPart}`;
+            if (seenKeys.has(dedupeKey)) {
+                return;
+            }
+            seenKeys.add(dedupeKey);
+
+            normalized.push({
+                id_categoria: normalizedId,
+                nome_categoria: normalizedName || null,
+            });
+        };
+
+        if (Array.isArray(favoriteQuestion.categorias)) {
+            favoriteQuestion.categorias.forEach(category => {
+                if (typeof category === 'string') {
+                    addCategory(null, category);
+                } else if (category && typeof category === 'object') {
+                    addCategory(
+                        category.id_categoria ?? category.id ?? category.pk ?? category.value ?? category.idCategoria ?? null,
+                        category.nome_categoria ?? category.nome ?? category.label ?? category.title ?? category.text ?? category.name ?? null,
+                    );
+                }
+            });
+        }
+
+        if (Array.isArray(favoriteQuestion.categoria_nomes)) {
+            favoriteQuestion.categoria_nomes.forEach(name => addCategory(null, name));
+        }
+
+        return normalized;
+    }
+
+    _normalizeCategoryId(rawId) {
+        if (typeof rawId === 'number' && Number.isFinite(rawId)) {
+            return rawId;
+        }
+        if (typeof rawId === 'string') {
+            const trimmed = rawId.trim();
+            if (!trimmed) {
+                return null;
+            }
+            const parsed = Number.parseInt(trimmed, 10);
+            if (!Number.isNaN(parsed)) {
+                return parsed;
+            }
+        }
+        return null;
+    }
+
+    _resolveCategoryNameById(categoryId, categoryMap) {
+        if (!categoryMap || typeof categoryMap.has !== 'function' || typeof categoryMap.get !== 'function') {
+            return null;
+        }
+
+        if (categoryMap.has(categoryId)) {
+            return categoryMap.get(categoryId);
+        }
+
+        const normalizedId = this._normalizeCategoryId(categoryId);
+        if (normalizedId !== null && categoryMap.has(normalizedId)) {
+            return categoryMap.get(normalizedId);
+        }
+
+        if (typeof categoryId === 'string') {
+            const trimmed = categoryId.trim();
+            if (trimmed && categoryMap.has(trimmed)) {
+                return categoryMap.get(trimmed);
+            }
+        }
+
+        return null;
     }
 
     _getQuestionsPageUrl() {

--- a/assets/js/ui/ModalManager.js
+++ b/assets/js/ui/ModalManager.js
@@ -173,8 +173,12 @@ export default class ModalManager {
         this.quizUI.hideElement(explanationModalEmptyState);
     
         if (explanationModalDifficulty) explanationModalDifficulty.textContent = question.nivel_dificuldade || 'Não informada';
-        const categoryNames = question.categoria_ids?.map(id => allCategories.find(c => c.id_categoria === id)?.nome_categoria).filter(Boolean).join(', ') || 'Não informadas';
-        if (explanationModalCategories) explanationModalCategories.textContent = categoryNames;
+        const categoryLabels = this._getCategoryLabelsForModal(question, allCategories);
+        if (explanationModalCategories) {
+            explanationModalCategories.textContent = categoryLabels.length > 0
+                ? categoryLabels.join(', ')
+                : 'Não informadas';
+        }
         this.quizUI.showElement(explanationModalMetaContainer);
     
         if (hasGeneralExplanation && explanationModalGeneralText) {
@@ -337,5 +341,88 @@ export default class ModalManager {
             return true;
         }
         return false;
+    }
+
+    _getCategoryLabelsForModal(question, allCategories = []) {
+        if (!question) {
+            return [];
+        }
+
+        const labelsSet = new Set();
+
+        if (Array.isArray(question.categorias)) {
+            question.categorias.forEach(category => {
+                if (typeof category === 'string') {
+                    const trimmed = category.trim();
+                    if (trimmed) {
+                        labelsSet.add(trimmed);
+                    }
+                } else if (category && typeof category === 'object') {
+                    const name = category.nome_categoria || category.nome || category.label || category.title || category.text || category.name;
+                    if (typeof name === 'string' && name.trim()) {
+                        labelsSet.add(name.trim());
+                    }
+                }
+            });
+        }
+
+        if (labelsSet.size === 0 && Array.isArray(question.categoria_nomes)) {
+            question.categoria_nomes.forEach(name => {
+                if (typeof name === 'string') {
+                    const trimmed = name.trim();
+                    if (trimmed) {
+                        labelsSet.add(trimmed);
+                    }
+                }
+            });
+        }
+
+        if (labelsSet.size === 0 && Array.isArray(question.categoria_ids) && allCategories) {
+            const categoryMap = new Map();
+            allCategories.forEach(cat => {
+                if (cat && typeof cat.id_categoria !== 'undefined') {
+                    const label = typeof cat.nome_categoria === 'string' ? cat.nome_categoria.trim() : '';
+                    categoryMap.set(cat.id_categoria, label);
+                    categoryMap.set(String(cat.id_categoria), label);
+                }
+            });
+
+            question.categoria_ids.forEach(id => {
+                if (categoryMap.has(id)) {
+                    const label = categoryMap.get(id);
+                    if (label) {
+                        labelsSet.add(label);
+                    }
+                    return;
+                }
+
+                const normalizedId = this._normalizeCategoryId(id);
+                if (normalizedId !== null) {
+                    const label = categoryMap.get(normalizedId) || categoryMap.get(String(normalizedId));
+                    if (label) {
+                        labelsSet.add(label);
+                    }
+                }
+            });
+        }
+
+        return Array.from(labelsSet);
+    }
+
+    _normalizeCategoryId(rawId) {
+        if (typeof rawId === 'number' && Number.isFinite(rawId)) {
+            return rawId;
+        }
+        if (typeof rawId === 'string') {
+            const trimmed = rawId.trim();
+            if (!trimmed) {
+                return null;
+            }
+            const parsed = Number.parseInt(trimmed, 10);
+            if (!Number.isNaN(parsed)) {
+                return parsed;
+            }
+        }
+        return null;
     }
 }

--- a/quiz/api/viewsets.py
+++ b/quiz/api/viewsets.py
@@ -616,13 +616,22 @@ class FavoriteQuestionViewSet(viewsets.ViewSet):
                 for o in pergunta.opcoes.all()
             ]
 
+            categorias_relacionadas = list(pergunta.categorias.all())
+
             perguntas_favoritas_data.append(
                 {
                     'id_pergunta': pergunta.pk,
                     'texto_pergunta': pergunta.texto_pergunta,
                     'url_imagem': pergunta.url_imagem,
                     'referencia_bibliografica': pergunta.referencia_bibliografica,
-                    'categoria_ids': [cat.pk for cat in pergunta.categorias.all()],
+                    'categoria_ids': [cat.pk for cat in categorias_relacionadas],
+                    'categorias': [
+                        {
+                            'id_categoria': cat.pk,
+                            'nome_categoria': cat.nome_categoria,
+                        }
+                        for cat in categorias_relacionadas
+                    ],
                     'nivel_dificuldade': pergunta.nivel_dificuldade,
                     'explicacao_resposta': pergunta.explicacao_resposta,
                     'opcoes': opcoes_data,

--- a/quiz/tests/test_api_quiz.py
+++ b/quiz/tests/test_api_quiz.py
@@ -115,6 +115,11 @@ class QuizApiTests(TestCase):
         favorite_question = favorites_payload['favorite_questions'][0]
         self.assertIn('esta_ativa', favorite_question)
         self.assertTrue(favorite_question['esta_ativa'])
+        self.assertIn('categorias', favorite_question)
+        self.assertIsInstance(favorite_question['categorias'], list)
+        self.assertTrue(
+            any(cat.get('nome_categoria') == self.category.nome_categoria for cat in favorite_question['categorias'])
+        )
 
     def test_question_detail_requires_authentication(self):
         url = reverse('quiz:question-detail', kwargs={'pergunta_id': self.question.pk})

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -918,12 +918,21 @@ def get_favorite_questions_view(request):
             for o in p.opcoes.all()
         ]
 
+        categorias_relacionadas = list(p.categorias.all())
+
         perguntas_favoritas_data.append({
             'id_pergunta': p.pk,
             'texto_pergunta': p.texto_pergunta,
             'url_imagem': p.url_imagem,
             'referencia_bibliografica': p.referencia_bibliografica,
-            'categoria_ids': [cat.pk for cat in p.categorias.all()],
+            'categoria_ids': [cat.pk for cat in categorias_relacionadas],
+            'categorias': [
+                {
+                    'id_categoria': cat.pk,
+                    'nome_categoria': cat.nome_categoria,
+                }
+                for cat in categorias_relacionadas
+            ],
             'nivel_dificuldade': p.nivel_dificuldade,
             'explicacao_resposta': p.explicacao_resposta,
             'opcoes': opcoes_data,


### PR DESCRIPTION
## Summary
- stack the favorite question badge above the title for better hierarchy
- expose full category objects in favorite question payloads and consume them on the frontend
- fall back to user-friendly category labels in the modal and update API tests accordingly

## Testing
- `python manage.py test` *(fails: Django dependency not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb7f574648333aa0bc21fe570922b