### PR TITLE
Add question history endpoint and account page integration

### DIFF
--- a/assets/css/sections/conta-section.css
+++ b/assets/css/sections/conta-section.css
@@ -285,21 +285,163 @@
     text-align: right;
 }
 
-#quiz-history-content .data-table td[data-label="Pontos"],
-#quiz-history-content .data-table td[data-label="Acertos"],
 #statistics-content .data-table td[data-label="Pontos"],
 #statistics-content .data-table td[data-label="Acertos"],
 #statistics-content .data-table td[data-label="Precisão"]
 {
     text-align: center;
 }
-#quiz-history-content .data-table th:nth-child(3), 
-#quiz-history-content .data-table th:nth-child(4), 
-#statistics-content .data-table th:nth-child(3), 
+#statistics-content .data-table th:nth-child(3),
 #statistics-content .data-table th:nth-child(4),
 #statistics-content .data-table th:nth-child(5)
 {
     text-align: center;
+}
+
+/* --- Histórico de Quizzes --- */
+.quiz-history__controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-sm, 12px);
+    align-items: flex-end;
+    margin-bottom: var(--spacing-md, 20px);
+}
+
+.quiz-history__form-group {
+    min-width: 220px;
+}
+
+.quiz-history__date-filter {
+    min-width: 160px;
+}
+
+.quiz-history__actions {
+    display: flex;
+    gap: var(--spacing-xs, 8px);
+    align-items: center;
+    padding-top: var(--spacing-xs, 8px);
+}
+
+.quiz-history__table td {
+    vertical-align: top;
+}
+
+.quiz-history__question-text {
+    font-weight: var(--font-weight-semibold);
+    margin-bottom: 4px;
+}
+
+.quiz-history__question-meta {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+}
+
+.quiz-history__question-tag {
+    display: inline-block;
+    margin-top: 6px;
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border-radius: var(--border-radius-pill, 999px);
+    background-color: var(--color-gray-100);
+    color: var(--color-text-secondary);
+}
+
+.quiz-history__answer-text,
+.quiz-history__correct-answer,
+.quiz-history__explanation p,
+.quiz-history__reference {
+    margin: 6px 0 0;
+    font-size: 0.9rem;
+}
+
+.quiz-history__correct-answer {
+    color: var(--color-success-700, #1e7e34);
+}
+
+.quiz-history__result-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 10px;
+    border-radius: var(--border-radius-pill, 999px);
+    font-size: 0.8rem;
+    font-weight: var(--font-weight-semibold);
+    background-color: var(--color-gray-100);
+    color: var(--color-text-secondary);
+}
+
+.quiz-history__result-badge--correct {
+    background-color: rgba(46, 160, 67, 0.12);
+    color: var(--color-success-700, #1e7e34);
+}
+
+.quiz-history__result-badge--incorrect {
+    background-color: rgba(220, 53, 69, 0.12);
+    color: var(--color-danger-600, #c82333);
+}
+
+.quiz-history__result-badge--skipped {
+    background-color: rgba(108, 117, 125, 0.12);
+    color: var(--color-text-muted);
+}
+
+.quiz-history__explanation-empty {
+    color: var(--color-text-muted);
+    font-size: 0.9rem;
+}
+
+.quiz-history__reference {
+    color: var(--color-text-muted);
+    font-size: 0.8rem;
+}
+
+.quiz-history__pagination {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm, 12px);
+    margin-top: var(--spacing-md, 20px);
+}
+
+.quiz-history__pagination .button {
+    min-width: 120px;
+}
+
+.quiz-history__pagination-indicator {
+    flex: 1;
+    text-align: center;
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+}
+
+@media (max-width: 768px) {
+    .quiz-history__controls {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .quiz-history__form-group,
+    .quiz-history__date-filter {
+        width: 100%;
+    }
+
+    .quiz-history__actions {
+        justify-content: flex-start;
+        padding-top: 0;
+    }
+
+    .quiz-history__pagination {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .quiz-history__pagination .button {
+        width: 100%;
+    }
+
+    .quiz-history__pagination-indicator {
+        width: 100%;
+        text-align: center;
+    }
 }
 
 /* Botões de Ação na Seção de Segurança */

--- a/assets/js/app/flux/ActionOrchestrator.js
+++ b/assets/js/app/flux/ActionOrchestrator.js
@@ -221,6 +221,10 @@ export default class ActionOrchestrator {
         }
     }
 
+    async fetchUserQuestionHistory(params = {}, absoluteUrl = null) {
+        return this.apiService.fetchUserQuestionHistory(params, absoluteUrl);
+    }
+
     async fetchFilteredQuestionCount(filterParams) {
         this.store.dispatch(quizActions.fetchFilteredCountRequest());
         try {

--- a/assets/js/app/services/ApiService.js
+++ b/assets/js/app/services/ApiService.js
@@ -141,6 +141,36 @@ export default class ApiService {
         return _request(API_URLS.api_get_user_statistics, 'GET', null, queryParams);
     }
 
+    async fetchUserQuestionHistory(params = {}, absoluteUrl = null) {
+        if (!API_URLS.api_get_user_question_history && !absoluteUrl) {
+            console.error("ApiService.js: URL para api_get_user_question_history não definida em API_URLS.");
+            throw new Error("URL de histórico de questões do usuário não configurada.");
+        }
+
+        if (absoluteUrl) {
+            return _request(absoluteUrl, 'GET');
+        }
+
+        const queryParams = {};
+        if (params.sessionId) {
+            queryParams.session_id = params.sessionId;
+        }
+        if (params.startDate) {
+            queryParams.start_date = params.startDate;
+        }
+        if (params.endDate) {
+            queryParams.end_date = params.endDate;
+        }
+        if (params.page) {
+            queryParams.page = params.page;
+        }
+        if (params.pageSize) {
+            queryParams.page_size = params.pageSize;
+        }
+
+        return _request(API_URLS.api_get_user_question_history, 'GET', null, queryParams);
+    }
+
     async resumeQuizSession() {
         if (!API_URLS.api_resume_quiz_session) {
             console.error("ApiService.js: URL para api_resume_quiz_session não definida em API_URLS.");

--- a/assets/js/ui/AccountPageManager.js
+++ b/assets/js/ui/AccountPageManager.js
@@ -14,22 +14,62 @@ export default class AccountPageManager {
         this.hasInitialized = false;
         this.previousActiveTab = null;
         
-        this.elements = { 
+        this.elements = {
             accountSectionPage: document.getElementById('account-section-page'),
             sidebar: document.querySelector('#account-section-page .account-sidebar'),
             contentArea: document.querySelector('#account-section-page .account-content'),
             backToMenuButton: document.getElementById('account-back-to-menu'),
-            sidebarLinks: null, 
-            contentSections: null, 
+            sidebarLinks: null,
+            contentSections: null,
             btnOpenDeleteModal: this.quizUI.elements.btnOpenDeleteAccountModal,
             deleteAccountForm: this.quizUI.elements.deleteAccountForm,
             passwordInputDelete: this.quizUI.elements.passwordInputDeleteAccount,
+        };
+        this.historyElements = {
+            contentSection: document.getElementById('quiz-history-content'),
+            loadingMessage: document.getElementById('quiz-history-loading'),
+            tableWrapper: document.getElementById('quiz-history-table-wrapper'),
+            tableBody: document.getElementById('quiz-history-table-body'),
+            emptyState: document.getElementById('quiz-history-empty'),
+            errorState: document.getElementById('quiz-history-error'),
+            pagination: {
+                container: document.getElementById('quiz-history-pagination'),
+                prevButton: document.getElementById('quiz-history-prev'),
+                nextButton: document.getElementById('quiz-history-next'),
+                pageIndicator: document.getElementById('quiz-history-page-indicator'),
+            },
+            filters: {
+                sessionSelect: document.getElementById('quiz-history-session-filter'),
+                startDateInput: document.getElementById('quiz-history-start-date'),
+                endDateInput: document.getElementById('quiz-history-end-date'),
+                applyButton: document.getElementById('quiz-history-filter-apply'),
+                resetButton: document.getElementById('quiz-history-filter-reset'),
+            },
         };
         this.bodyElement = document.body;
         // --- INÍCIO DA CORREÇÃO ---
         // A referência ao bottomNavElement foi removida daqui.
         // --- FIM DA CORREÇÃO ---
         this.defaultMenuTargetId = 'profile-info-content';
+        this.historyState = {
+            initialized: false,
+            isLoading: false,
+            error: null,
+            hasFetched: false,
+            items: [],
+            pagination: {
+                count: 0,
+                next: null,
+                previous: null,
+                page: 1,
+                pageSize: 10,
+            },
+            filters: {
+                sessionId: '',
+                startDate: '',
+                endDate: '',
+            },
+        };
     }
 
     setStore(storeInstance) {
@@ -120,9 +160,433 @@ export default class AccountPageManager {
             if (!favoritesState.hasBeenFetched && !favoritesState.isLoading) {
                 this.actionOrchestrator?.loadAndDisplayFavoriteQuestionsForAccountPage();
             }
+        } else if (targetId === 'quiz-history-content') {
+            this._initializeHistoryTab();
         } else if (targetId === 'statistics-content' && this.statisticsChartManager) {
             this.statisticsChartManager.init();
         }
+    }
+
+    _initializeHistoryTab() {
+        if (!this.historyElements.contentSection) {
+            return;
+        }
+
+        if (!this.historyState.initialized) {
+            const { filters, pagination } = this.historyElements;
+
+            filters?.applyButton?.addEventListener('click', (event) => {
+                event.preventDefault();
+                this._applyHistoryFilters();
+            });
+
+            filters?.resetButton?.addEventListener('click', (event) => {
+                event.preventDefault();
+                this._resetHistoryFilters();
+            });
+
+            pagination?.prevButton?.addEventListener('click', (event) => {
+                event.preventDefault();
+                this._goToHistoryPage('previous');
+            });
+
+            pagination?.nextButton?.addEventListener('click', (event) => {
+                event.preventDefault();
+                this._goToHistoryPage('next');
+            });
+
+            this.historyState.initialized = true;
+        }
+
+        if (!this.historyState.hasFetched && !this.historyState.isLoading) {
+            this._fetchAndRenderHistory();
+        }
+    }
+
+    _applyHistoryFilters() {
+        const parsedFilters = this._readHistoryFilters();
+        if (parsedFilters.error) {
+            this._setHistoryError(parsedFilters.error);
+            this.historyState.items = [];
+            this._renderHistoryTable();
+            return;
+        }
+
+        this.historyState.filters = {
+            sessionId: parsedFilters.sessionId,
+            startDate: parsedFilters.startDate,
+            endDate: parsedFilters.endDate,
+        };
+        this.historyState.pagination.page = 1;
+        this.historyState.pagination.next = null;
+        this.historyState.pagination.previous = null;
+        this.historyState.hasFetched = false;
+        this._setHistoryError(null);
+        this._fetchAndRenderHistory();
+    }
+
+    _resetHistoryFilters() {
+        const { sessionSelect, startDateInput, endDateInput } = this.historyElements.filters || {};
+        if (sessionSelect) sessionSelect.value = '';
+        if (startDateInput) startDateInput.value = '';
+        if (endDateInput) endDateInput.value = '';
+
+        this.historyState.filters = { sessionId: '', startDate: '', endDate: '' };
+        this.historyState.pagination.page = 1;
+        this.historyState.pagination.next = null;
+        this.historyState.pagination.previous = null;
+        this.historyState.hasFetched = false;
+        this._setHistoryError(null);
+        this._fetchAndRenderHistory();
+    }
+
+    _readHistoryFilters() {
+        const { sessionSelect, startDateInput, endDateInput } = this.historyElements.filters || {};
+        const sessionId = sessionSelect?.value?.trim() || '';
+        const startDate = startDateInput?.value?.trim() || '';
+        const endDate = endDateInput?.value?.trim() || '';
+
+        if (startDate && endDate && endDate < startDate) {
+            return { error: 'A data final deve ser igual ou posterior à data inicial.' };
+        }
+
+        return {
+            sessionId,
+            startDate,
+            endDate,
+        };
+    }
+
+    async _fetchAndRenderHistory(pageUrl = null) {
+        if (!this.actionOrchestrator) {
+            return;
+        }
+
+        this.historyState.isLoading = true;
+        this._setHistoryLoading(true);
+        this._setHistoryError(null);
+
+        try {
+            const params = {
+                sessionId: this.historyState.filters.sessionId || undefined,
+                startDate: this.historyState.filters.startDate || undefined,
+                endDate: this.historyState.filters.endDate || undefined,
+                page: this.historyState.pagination.page,
+                pageSize: this.historyState.pagination.pageSize,
+            };
+
+            const response = await this.actionOrchestrator.fetchUserQuestionHistory(params, pageUrl);
+
+            if (!response || response.status !== 'success') {
+                throw new Error(response?.message || 'Erro ao carregar histórico.');
+            }
+
+            this.historyState.items = response.results || [];
+            this.historyState.pagination.count = response.count ?? this.historyState.items.length;
+            this.historyState.pagination.next = response.next;
+            this.historyState.pagination.previous = response.previous;
+
+            if (pageUrl) {
+                const derivedPage = this._getPageNumberFromUrl(pageUrl);
+                if (derivedPage) {
+                    this.historyState.pagination.page = derivedPage;
+                }
+            } else {
+                this.historyState.pagination.page = params.page || 1;
+            }
+
+            this.historyState.hasFetched = true;
+            this._renderHistoryTable();
+        } catch (error) {
+            console.error('AccountPageManager: erro ao carregar histórico de questões.', error);
+            this.historyState.items = [];
+            this.historyState.hasFetched = false;
+            this._setHistoryError('Não foi possível carregar seu histórico no momento. Tente novamente mais tarde.');
+            this._renderHistoryTable();
+        } finally {
+            this.historyState.isLoading = false;
+            this._setHistoryLoading(false);
+        }
+    }
+
+    _setHistoryLoading(isLoading) {
+        const { loadingMessage, tableWrapper, pagination, emptyState, errorState } = this.historyElements;
+        if (isLoading) {
+            if (loadingMessage) this.quizUI.showElement(loadingMessage);
+            if (tableWrapper) this.quizUI.hideElement(tableWrapper);
+            if (pagination?.container) this.quizUI.hideElement(pagination.container);
+            if (emptyState) this.quizUI.hideElement(emptyState);
+            if (errorState) this.quizUI.hideElement(errorState);
+        } else if (loadingMessage) {
+            this.quizUI.hideElement(loadingMessage);
+        }
+    }
+
+    _setHistoryError(message) {
+        this.historyState.error = message;
+        const { errorState } = this.historyElements;
+        if (!errorState) return;
+
+        if (message) {
+            errorState.textContent = message;
+            this.quizUI.showElement(errorState);
+        } else {
+            errorState.textContent = '';
+            this.quizUI.hideElement(errorState);
+        }
+    }
+
+    _renderHistoryTable() {
+        const { tableWrapper, tableBody, emptyState, pagination, errorState } = this.historyElements;
+        if (!tableBody) return;
+
+        tableBody.innerHTML = '';
+
+        if (this.historyState.error) {
+            if (emptyState) this.quizUI.hideElement(emptyState);
+            if (tableWrapper) this.quizUI.hideElement(tableWrapper);
+            if (pagination?.container) this.quizUI.hideElement(pagination.container);
+            return;
+        }
+
+        if (errorState) {
+            this.quizUI.hideElement(errorState);
+            errorState.textContent = '';
+        }
+
+        if (!this.historyState.items.length) {
+            if (tableWrapper) this.quizUI.hideElement(tableWrapper);
+            if (emptyState) {
+                emptyState.textContent = 'Nenhuma resposta encontrada para os filtros selecionados.';
+                this.quizUI.showElement(emptyState);
+            }
+            if (pagination?.container) this.quizUI.hideElement(pagination.container);
+            return;
+        }
+
+        if (emptyState) {
+            this.quizUI.hideElement(emptyState);
+        }
+
+        const fragment = document.createDocumentFragment();
+        this.historyState.items.forEach((item) => {
+            fragment.appendChild(this._createHistoryRow(item));
+        });
+        tableBody.appendChild(fragment);
+
+        if (tableWrapper) {
+            this.quizUI.showElement(tableWrapper);
+        }
+
+        this._renderHistoryPagination();
+    }
+
+    _renderHistoryPagination() {
+        const { pagination } = this.historyElements;
+        if (!pagination?.container) return;
+
+        const totalResults = this.historyState.pagination.count || 0;
+        if (totalResults === 0) {
+            this.quizUI.hideElement(pagination.container);
+            return;
+        }
+
+        const totalPages = Math.max(1, Math.ceil(totalResults / this.historyState.pagination.pageSize));
+        if (pagination.pageIndicator) {
+            pagination.pageIndicator.textContent = `Página ${this.historyState.pagination.page} de ${totalPages} (${totalResults} itens)`;
+        }
+
+        if (pagination.prevButton) {
+            pagination.prevButton.disabled = !this.historyState.pagination.previous;
+        }
+        if (pagination.nextButton) {
+            pagination.nextButton.disabled = !this.historyState.pagination.next;
+        }
+
+        this.quizUI.showElement(pagination.container);
+    }
+
+    _createHistoryRow(item) {
+        const row = document.createElement('tr');
+
+        const dateCell = document.createElement('td');
+        dateCell.dataset.label = 'Respondida em:';
+        dateCell.textContent = this._formatDateTime(item?.data_resposta);
+        row.appendChild(dateCell);
+
+        const sessionCell = document.createElement('td');
+        sessionCell.dataset.label = 'Sessão:';
+        sessionCell.textContent = this._formatSessionLabel(item?.session);
+        row.appendChild(sessionCell);
+
+        const questionCell = document.createElement('td');
+        questionCell.dataset.label = 'Pergunta:';
+        questionCell.appendChild(this._buildQuestionCellContent(item));
+        row.appendChild(questionCell);
+
+        const answerCell = document.createElement('td');
+        answerCell.dataset.label = 'Sua Resposta:';
+        answerCell.appendChild(this._buildAnswerCellContent(item));
+        row.appendChild(answerCell);
+
+        const explanationCell = document.createElement('td');
+        explanationCell.dataset.label = 'Explicação:';
+        explanationCell.appendChild(this._buildExplanationCellContent(item));
+        row.appendChild(explanationCell);
+
+        return row;
+    }
+
+    _buildQuestionCellContent(item) {
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('quiz-history__question');
+
+        const questionText = document.createElement('p');
+        questionText.classList.add('quiz-history__question-text');
+        questionText.textContent = item?.question?.texto_pergunta || '—';
+        wrapper.appendChild(questionText);
+
+        if (item?.question?.categorias?.length) {
+            const categories = document.createElement('p');
+            categories.classList.add('quiz-history__question-meta');
+            categories.textContent = item.question.categorias.map(cat => cat.nome_categoria).join(', ');
+            wrapper.appendChild(categories);
+        }
+
+        if (item?.question?.nivel_dificuldade) {
+            const difficulty = document.createElement('span');
+            difficulty.classList.add('quiz-history__question-tag');
+            difficulty.textContent = item.question.nivel_dificuldade;
+            wrapper.appendChild(difficulty);
+        }
+
+        return wrapper;
+    }
+
+    _buildAnswerCellContent(item) {
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('quiz-history__answer');
+
+        const resultBadge = document.createElement('span');
+        resultBadge.classList.add('quiz-history__result-badge');
+
+        if (!item?.foi_respondida) {
+            resultBadge.textContent = 'Não respondida';
+            resultBadge.classList.add('quiz-history__result-badge--skipped');
+        } else if (item?.foi_correta) {
+            resultBadge.textContent = 'Correta';
+            resultBadge.classList.add('quiz-history__result-badge--correct');
+        } else {
+            resultBadge.textContent = 'Incorreta';
+            resultBadge.classList.add('quiz-history__result-badge--incorrect');
+        }
+
+        wrapper.appendChild(resultBadge);
+
+        const answerText = document.createElement('p');
+        answerText.classList.add('quiz-history__answer-text');
+        if (item?.selected_option?.texto_opcao) {
+            answerText.textContent = item.selected_option.texto_opcao;
+        } else if (!item?.foi_respondida) {
+            answerText.textContent = 'Questão pulada ou não respondida.';
+        } else {
+            answerText.textContent = 'Resposta registrada indisponível.';
+        }
+        wrapper.appendChild(answerText);
+
+        if (Array.isArray(item?.correct_option_ids) && item.correct_option_ids.length > 0) {
+            const correctOptions = (item?.question?.opcoes || []).filter(opcao => item.correct_option_ids.includes(opcao.id_opcao_resposta));
+            if (correctOptions.length > 0) {
+                const correctAnswer = document.createElement('p');
+                correctAnswer.classList.add('quiz-history__correct-answer');
+                correctAnswer.textContent = `Resposta correta: ${correctOptions.map(opcao => opcao.texto_opcao).join(', ')}`;
+                wrapper.appendChild(correctAnswer);
+            }
+        }
+
+        return wrapper;
+    }
+
+    _buildExplanationCellContent(item) {
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('quiz-history__explanation');
+
+        const explanationText = item?.question?.explicacao_resposta || item?.selected_option?.feedback_opcao;
+        if (explanationText) {
+            const paragraph = document.createElement('p');
+            paragraph.textContent = explanationText;
+            wrapper.appendChild(paragraph);
+        } else {
+            const placeholder = document.createElement('span');
+            placeholder.classList.add('quiz-history__explanation-empty');
+            placeholder.textContent = 'Nenhuma explicação cadastrada para esta questão.';
+            wrapper.appendChild(placeholder);
+        }
+
+        if (item?.question?.referencia_bibliografica) {
+            const reference = document.createElement('p');
+            reference.classList.add('quiz-history__reference');
+            reference.textContent = `Referência: ${item.question.referencia_bibliografica}`;
+            wrapper.appendChild(reference);
+        }
+
+        return wrapper;
+    }
+
+    _formatDateTime(isoString) {
+        if (!isoString) return '—';
+        try {
+            const date = new Date(isoString);
+            if (Number.isNaN(date.getTime())) {
+                return '—';
+            }
+            return date.toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' });
+        } catch (error) {
+            console.warn('AccountPageManager: falha ao formatar data.', error);
+            return isoString;
+        }
+    }
+
+    _formatSessionLabel(session) {
+        if (!session) return '—';
+        const parts = [];
+        if (session.modo_quiz) {
+            parts.push(session.modo_quiz);
+        }
+        if (session.quiz_definicao?.nome_quiz) {
+            parts.push(session.quiz_definicao.nome_quiz);
+        }
+        const baseLabel = parts.join(' • ') || (session.id_sessao ? `Sessão ${session.id_sessao}` : 'Sessão');
+        const dateLabel = session.data_inicio ? this._formatDateTime(session.data_inicio) : null;
+        return dateLabel ? `${baseLabel} (${dateLabel})` : baseLabel;
+    }
+
+    _goToHistoryPage(direction) {
+        const { next, previous, page } = this.historyState.pagination;
+        if (direction === 'next' && next) {
+            const nextPage = this._getPageNumberFromUrl(next) || (page + 1);
+            this.historyState.pagination.page = nextPage;
+            this._fetchAndRenderHistory(next);
+        } else if (direction === 'previous' && previous) {
+            const previousPage = this._getPageNumberFromUrl(previous) || Math.max(1, page - 1);
+            this.historyState.pagination.page = previousPage;
+            this._fetchAndRenderHistory(previous);
+        }
+    }
+
+    _getPageNumberFromUrl(url) {
+        if (!url) return null;
+        try {
+            const parsed = new URL(url, window.location.origin);
+            const pageParam = parsed.searchParams.get('page');
+            if (pageParam) {
+                const parsedPage = Number.parseInt(pageParam, 10);
+                return Number.isNaN(parsedPage) ? null : parsedPage;
+            }
+        } catch (error) {
+            console.warn('AccountPageManager: não foi possível interpretar o número da página.', error);
+        }
+        return null;
     }
 
     _setInitialTabFromURL() {

--- a/assets/js/utils/constants.js
+++ b/assets/js/utils/constants.js
@@ -15,7 +15,8 @@ export const API_URLS = {
     toggle_favorite_status: (perguntaId) => `/api/question/${perguntaId}/toggle_favorite/`,
     get_favorite_questions: '/api/favorites/',
     api_get_user_statistics: '/api/user-statistics/',
-    api_resume_quiz_session: '/api/quiz/resume-session/'
+    api_resume_quiz_session: '/api/quiz/resume-session/',
+    api_get_user_question_history: '/api/question-history/',
 };
 
 /**

--- a/quiz/api/serializers.py
+++ b/quiz/api/serializers.py
@@ -66,3 +66,22 @@ class EndQuizSessionSerializer(serializers.Serializer):
 
 class StatisticsQuerySerializer(serializers.Serializer):
     period = forms.CharField(required=False)
+
+
+class UserQuestionHistoryQuerySerializer(serializers.Serializer):
+    """Validates filters applied to the question history endpoint."""
+
+    session_id = serializers.IntegerField(required=False)
+    start_date = serializers.DateField(required=False)
+    end_date = serializers.DateField(required=False)
+
+    def validate(self, attrs):
+        start_date = attrs.get('start_date')
+        end_date = attrs.get('end_date')
+
+        if start_date and end_date and end_date < start_date:
+            raise serializers.ValidationError({
+                'end_date': 'A data final deve ser igual ou posterior à data inicial.'
+            })
+
+        return attrs

--- a/quiz/api/viewsets.py
+++ b/quiz/api/viewsets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections import defaultdict
+from datetime import datetime, time
 
 from django.db.models import Case, Count, Q, When
 from django.shortcuts import get_object_or_404
@@ -11,6 +12,7 @@ from django.utils import timezone
 
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
 from quiz.models import (
@@ -43,6 +45,7 @@ from .serializers import (
     RegisterAnswerSerializer,
     StartQuizSessionSerializer,
     StatisticsQuerySerializer,
+    UserQuestionHistoryQuerySerializer,
 )
 
 
@@ -582,6 +585,167 @@ class QuizViewSet(viewsets.ViewSet):
                 {'status': 'error', 'message': 'Erro interno ao tentar retomar sessão.'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
+
+
+class UserQuestionHistoryPagination(PageNumberPagination):
+    """Default pagination for the question history endpoint."""
+
+    page_size = 10
+    page_size_query_param = 'page_size'
+    max_page_size = 50
+
+
+class UserQuestionHistoryViewSet(viewsets.ViewSet):
+    """Provides paginated access to the authenticated user's answered questions."""
+
+    pagination_class = UserQuestionHistoryPagination
+
+    def list(self, request):
+        if not request.user.is_authenticated:
+            return Response(
+                {'status': 'error', 'message': 'Autenticação necessária.'},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        serializer = UserQuestionHistoryQuerySerializer(data=request.GET)
+        try:
+            serializer.is_valid(raise_exception=True)
+        except serializers.ValidationError as exc:
+            return Response(
+                {'status': 'error', 'errors': exc.detail},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        filters = serializer.validated_data
+
+        respostas_qs = (
+            RespostasUsuarioPorSessao.objects.filter(id_sessao_quiz__id_usuario=request.user)
+            .select_related(
+                'id_sessao_quiz',
+                'id_sessao_quiz__id_quiz_definicao',
+                'id_pergunta',
+                'id_opcao_resposta_selecionada',
+            )
+            .prefetch_related('id_pergunta__opcoes', 'id_pergunta__categorias')
+            .order_by('-data_resposta', '-pk')
+        )
+
+        session_id = filters.get('session_id')
+        if session_id:
+            respostas_qs = respostas_qs.filter(id_sessao_quiz_id=session_id)
+
+        start_date = filters.get('start_date')
+        if start_date:
+            start_dt = datetime.combine(start_date, time.min)
+            if timezone.is_naive(start_dt):
+                start_dt = timezone.make_aware(start_dt, timezone.get_current_timezone())
+            respostas_qs = respostas_qs.filter(data_resposta__gte=start_dt)
+
+        end_date = filters.get('end_date')
+        if end_date:
+            end_dt = datetime.combine(end_date, time.max)
+            if timezone.is_naive(end_dt):
+                end_dt = timezone.make_aware(end_dt, timezone.get_current_timezone())
+            respostas_qs = respostas_qs.filter(data_resposta__lte=end_dt)
+
+        paginator = self.pagination_class()
+        page = paginator.paginate_queryset(respostas_qs, request)
+
+        results = []
+        for resposta in page:
+            sessao = resposta.id_sessao_quiz
+            pergunta = resposta.id_pergunta
+            opcao_selecionada = resposta.id_opcao_resposta_selecionada
+            quiz_def = sessao.id_quiz_definicao
+
+            categorias_relacionadas = list(pergunta.categorias.all())
+            opcoes_relacionadas = list(pergunta.opcoes.all())
+
+            opcoes_payload = [
+                {
+                    'id_opcao_resposta': opcao.pk,
+                    'id_pergunta': opcao.pergunta_id,
+                    'texto_opcao': opcao.texto_opcao,
+                    'eh_correta': opcao.eh_correta,
+                    'ordem_exibicao': opcao.ordem_exibicao,
+                    'feedback_opcao': opcao.feedback_opcao,
+                }
+                for opcao in opcoes_relacionadas
+            ]
+
+            selected_option_payload = None
+            if opcao_selecionada is not None:
+                selected_option_payload = {
+                    'id_opcao_resposta': opcao_selecionada.pk,
+                    'id_pergunta': opcao_selecionada.pergunta_id,
+                    'texto_opcao': opcao_selecionada.texto_opcao,
+                    'eh_correta': opcao_selecionada.eh_correta,
+                    'ordem_exibicao': opcao_selecionada.ordem_exibicao,
+                    'feedback_opcao': opcao_selecionada.feedback_opcao,
+                }
+
+            session_payload = {
+                'id_sessao': sessao.pk,
+                'modo_quiz': sessao.modo_quiz,
+                'status_sessao': sessao.status_sessao,
+                'pontuacao_final': sessao.pontuacao_final,
+                'total_perguntas': sessao.total_perguntas_sessao,
+                'total_acertos': sessao.total_acertos,
+                'total_erros': sessao.total_erros,
+                'tempo_total_segundos': sessao.tempo_total_segundos,
+                'data_inicio': sessao.data_inicio.isoformat() if sessao.data_inicio else None,
+                'data_fim': sessao.data_fim.isoformat() if sessao.data_fim else None,
+                'quiz_definicao': None,
+            }
+
+            if quiz_def:
+                session_payload['quiz_definicao'] = {
+                    'id_quiz_definicao': quiz_def.pk,
+                    'nome_quiz': quiz_def.nome_quiz,
+                }
+
+            question_payload = {
+                'id_pergunta': pergunta.pk,
+                'texto_pergunta': pergunta.texto_pergunta,
+                'nivel_dificuldade': pergunta.nivel_dificuldade,
+                'explicacao_resposta': pergunta.explicacao_resposta,
+                'referencia_bibliografica': pergunta.referencia_bibliografica,
+                'url_imagem': pergunta.url_imagem,
+                'categoria_ids': [cat.pk for cat in categorias_relacionadas],
+                'categorias': [
+                    {
+                        'id_categoria': cat.pk,
+                        'nome_categoria': cat.nome_categoria,
+                    }
+                    for cat in categorias_relacionadas
+                ],
+                'opcoes': opcoes_payload,
+            }
+
+            results.append(
+                {
+                    'id_resposta': resposta.pk,
+                    'data_resposta': resposta.data_resposta.isoformat() if resposta.data_resposta else None,
+                    'foi_correta': resposta.foi_correta,
+                    'foi_respondida': opcao_selecionada is not None,
+                    'selected_option': selected_option_payload,
+                    'selected_option_id': opcao_selecionada.pk if opcao_selecionada else None,
+                    'correct_option_ids': [
+                        opcao.pk for opcao in opcoes_relacionadas if opcao.eh_correta
+                    ],
+                    'session': session_payload,
+                    'question': question_payload,
+                }
+            )
+
+        paginated_response = paginator.get_paginated_response(results)
+        paginated_response.data['status'] = 'success'
+        paginated_response.data['applied_filters'] = {
+            'session_id': session_id,
+            'start_date': start_date.isoformat() if start_date else None,
+            'end_date': end_date.isoformat() if end_date else None,
+        }
+        return paginated_response
 
 
 class FavoriteQuestionViewSet(viewsets.ViewSet):

--- a/quiz/templates/quiz/account_page.html
+++ b/quiz/templates/quiz/account_page.html
@@ -119,35 +119,59 @@
                 <div class="card card--conta-perfil">
                     <h2 class="card__title">Histórico de Quizzes</h2>
                     <div class="card__body">
-                        {% if user_sessions %}
-                            <p>Suas últimas {{ user_sessions|length }} sessões de quiz:</p>
-                            <div class="data-table-wrapper">
-                                <table class="data-table">
-                                    <thead>
-                                        <tr>
-                                            <th>Data e Hora</th>
-                                            <th>Modo</th>
-                                            <th>Pontos</th>
-                                            <th>Acertos</th>
-                                            <th>Duração</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
+                        <div class="quiz-history__controls">
+                            <div class="form-group quiz-history__form-group">
+                                <label for="quiz-history-session-filter" class="form-label">Filtrar por sessão</label>
+                                <select id="quiz-history-session-filter" class="form-control form-control--small">
+                                    <option value="">Todas as sessões</option>
                                     {% for session in user_sessions %}
-                                        <tr>
-                                            <td data-label="Data Início:">{{ session.data_inicio|date:"d/m/Y H:i" }}</td>
-                                            <td data-label="Modo:">{{ session.modo_quiz }}</td>
-                                            <td data-label="Pontos:">{{ session.pontuacao_final }}</td>
-                                            <td data-label="Acertos:">{{ session.total_acertos }}/{{ session.total_perguntas_sessao }}</td>
-                                            <td data-label="Duração:">{{ session.duracao_sessao_formatada }}</td>
-                                        </tr>
+                                        <option value="{{ session.pk }}">
+                                            Sessão {{ session.pk }} • {{ session.data_inicio|date:"d/m/Y H:i" }} • {{ session.modo_quiz }}{% if session.id_quiz_definicao %} • {{ session.id_quiz_definicao.nome_quiz }}{% endif %}
+                                        </option>
                                     {% endfor %}
-                                    </tbody>
-                                </table>
+                                </select>
+                                {% if not user_sessions %}
+                                    <p class="form-help-text">As sessões mais recentes aparecerão aqui quando disponíveis.</p>
+                                {% endif %}
                             </div>
-                        {% else %}
-                            <p class="placeholder-text">Você ainda não completou nenhuma sessão de quiz.</p>
-                        {% endif %}
+                            <div class="form-group quiz-history__date-filter">
+                                <label for="quiz-history-start-date" class="form-label">Data inicial</label>
+                                <input type="date" id="quiz-history-start-date" class="form-control form-control--small" />
+                            </div>
+                            <div class="form-group quiz-history__date-filter">
+                                <label for="quiz-history-end-date" class="form-label">Data final</label>
+                                <input type="date" id="quiz-history-end-date" class="form-control form-control--small" />
+                            </div>
+                            <div class="quiz-history__actions">
+                                <button id="quiz-history-filter-apply" class="button button--outline button--small" type="button">Aplicar filtros</button>
+                                <button id="quiz-history-filter-reset" class="button button--text button--small" type="button">Limpar</button>
+                            </div>
+                        </div>
+
+                        <p id="quiz-history-loading" class="placeholder-text" aria-live="polite">Carregando histórico...</p>
+                        <p id="quiz-history-error" class="placeholder-text u-is-hidden" role="alert"></p>
+                        <p id="quiz-history-empty" class="placeholder-text u-is-hidden">Nenhuma resposta encontrada.</p>
+
+                        <div id="quiz-history-table-wrapper" class="data-table-wrapper u-is-hidden">
+                            <table class="data-table quiz-history__table">
+                                <thead>
+                                    <tr>
+                                        <th>Respondida em</th>
+                                        <th>Sessão</th>
+                                        <th>Pergunta</th>
+                                        <th>Sua Resposta</th>
+                                        <th>Explicação</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="quiz-history-table-body"></tbody>
+                            </table>
+                        </div>
+
+                        <div id="quiz-history-pagination" class="quiz-history__pagination u-is-hidden">
+                            <button id="quiz-history-prev" class="button button--outline button--small" type="button">Anterior</button>
+                            <span id="quiz-history-page-indicator" class="quiz-history__pagination-indicator">Página 1</span>
+                            <button id="quiz-history-next" class="button button--outline button--small" type="button">Próxima</button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/quiz/tests/test_api_quiz.py
+++ b/quiz/tests/test_api_quiz.py
@@ -13,6 +13,7 @@ from quiz.models import (
     OpcaoResposta,
     Pergunta,
     QuestaoFavorita,
+    RespostasUsuarioPorSessao,
     SessoesQuizUsuario,
 )
 from quiz.views import get_quiz_config, invalidate_quiz_config_cache
@@ -46,6 +47,60 @@ class QuizApiTests(TestCase):
 
     def _auth_client(self):
         self.client.login(username='apiuser', password='testpass')
+
+    def _create_session_with_responses(self, total_responses=3, days_offset=0):
+        base_datetime = timezone.now() - timedelta(days=days_offset)
+        session = SessoesQuizUsuario.objects.create(
+            id_usuario=self.user,
+            modo_quiz=SessoesQuizUsuario.ModoQuiz.RAPIDO,
+            status_sessao=SessoesQuizUsuario.StatusSessao.COMPLETA,
+            total_perguntas_sessao=total_responses,
+            total_acertos=0,
+            total_erros=0,
+            pontuacao_final=total_responses * 10,
+            data_inicio=base_datetime - timedelta(minutes=total_responses),
+            data_fim=base_datetime,
+            tempo_total_segundos=total_responses * 60,
+        )
+
+        correct_answers = 0
+        for index in range(total_responses):
+            question = Pergunta.objects.create(
+                texto_pergunta=f'Pergunta {session.pk}-{index}',
+                nivel_dificuldade=Pergunta.NivelDificuldade.MEDIO,
+            )
+            question.categorias.add(self.category)
+
+            correct_option = OpcaoResposta.objects.create(
+                pergunta=question,
+                texto_opcao=f'Correta {index}',
+                eh_correta=True,
+                ordem_exibicao=1,
+            )
+            wrong_option = OpcaoResposta.objects.create(
+                pergunta=question,
+                texto_opcao=f'Errada {index}',
+                eh_correta=False,
+                ordem_exibicao=2,
+            )
+
+            selected_option = correct_option if index % 2 == 0 else wrong_option
+            RespostasUsuarioPorSessao.objects.create(
+                id_sessao_quiz=session,
+                id_pergunta=question,
+                id_opcao_resposta_selecionada=selected_option,
+                foi_correta=selected_option.eh_correta,
+                data_resposta=session.data_inicio + timedelta(minutes=index + 1),
+            )
+
+            if selected_option.eh_correta:
+                correct_answers += 1
+
+        session.total_acertos = correct_answers
+        session.total_erros = total_responses - correct_answers
+        session.save(update_fields=['total_acertos', 'total_erros'])
+
+        return session
 
     def test_quiz_summary_endpoint_returns_counts(self):
         url = reverse('quiz:quiz-summary')
@@ -188,3 +243,54 @@ class QuizApiTests(TestCase):
         payload = response.json()
         self.assertEqual(payload['status'], 'success')
         self.assertEqual(payload['key_metrics']['total_questions_answered'], 10)
+
+    def test_question_history_requires_authentication(self):
+        url = reverse('quiz:user-question-history-list')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_question_history_paginates_results(self):
+        self._auth_client()
+        self._create_session_with_responses(total_responses=12)
+
+        url = reverse('quiz:user-question-history-list')
+        response = self.client.get(url, {'page_size': 5})
+        self.assertEqual(response.status_code, 200)
+
+        payload = response.json()
+        self.assertEqual(payload['status'], 'success')
+        self.assertEqual(payload['count'], 12)
+        self.assertEqual(len(payload['results']), 5)
+        self.assertIsNotNone(payload['next'])
+
+        first_result = payload['results'][0]
+        self.assertIn('question', first_result)
+        self.assertIn('session', first_result)
+        self.assertIn('selected_option_id', first_result)
+
+    def test_question_history_filters_by_session_and_date(self):
+        self._auth_client()
+        recent_session = self._create_session_with_responses(total_responses=3, days_offset=0)
+        old_session = self._create_session_with_responses(total_responses=2, days_offset=10)
+
+        url = reverse('quiz:user-question-history-list')
+
+        response = self.client.get(url, {'session_id': recent_session.pk})
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload['count'], 3)
+        self.assertTrue(all(item['session']['id_sessao'] == recent_session.pk for item in payload['results']))
+
+        start_date = (timezone.now().date() - timedelta(days=1)).isoformat()
+        response = self.client.get(url, {'start_date': start_date})
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload['count'], 3)
+        self.assertTrue(all(item['session']['id_sessao'] == recent_session.pk for item in payload['results']))
+
+        end_date = (timezone.now().date() - timedelta(days=5)).isoformat()
+        response = self.client.get(url, {'end_date': end_date})
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload['count'], 2)
+        self.assertTrue(all(item['session']['id_sessao'] == old_session.pk for item in payload['results']))

--- a/quiz/urls.py
+++ b/quiz/urls.py
@@ -9,6 +9,7 @@ from .api.viewsets import (
     QuestionViewSet,
     QuizViewSet,
     UserStatisticsViewSet,
+    UserQuestionHistoryViewSet,
 )
 
 app_name = 'quiz'
@@ -18,6 +19,7 @@ router.register('api/quiz', QuizViewSet, basename='quiz')
 router.register('api/favorites', FavoriteQuestionViewSet, basename='favorites')
 router.register('api/question', QuestionViewSet, basename='question')
 router.register('api/user-statistics', UserStatisticsViewSet, basename='user-statistics')
+router.register('api/question-history', UserQuestionHistoryViewSet, basename='user-question-history')
 
 urlpatterns = [
     path('', views.home_view, name='home'),


### PR DESCRIPTION
## Summary
- add a paginated user question history viewset with session/date filters and register the API route
- cover pagination, filter, and authorization behaviours with new tests
- load the history tab from the new endpoint and render paginated question details with refreshed UI states

## Testing
- python manage.py test *(fails: Django not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cec51eefd88333b60c2bf2bded8999