### PR TITLE
Refine account statistics dashboard layout and insights

### DIFF
--- a/assets/css/components/statistics-dashboard.css
+++ b/assets/css/components/statistics-dashboard.css
@@ -1,5 +1,17 @@
 /* assets/css/components/statistics-dashboard.css */
 
+.account-content .card--conta-perfil.card--statistics-dashboard {
+    background: linear-gradient(140deg, rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.98) 0%, rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.08) 100%);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18);
+    box-shadow: 0 18px 40px -20px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.45);
+    border-radius: var(--border-radius-xl, 20px);
+    padding: clamp(var(--spacing-lg, 28px), 4vw, var(--spacing-xl, 40px));
+}
+
+.account-content .card--conta-perfil.card--statistics-dashboard .card__body {
+    padding: 0;
+}
+
 .statistics-dashboard {
     display: flex;
     flex-direction: column;
@@ -11,13 +23,64 @@
     pointer-events: none;
 }
 
+.statistics-dashboard__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--spacing-lg, 28px);
+    flex-wrap: wrap;
+    padding-bottom: var(--spacing-md, 20px);
+    border-bottom: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18);
+}
+
+.statistics-dashboard__intro {
+    flex: 1 1 320px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs, 8px);
+}
+
+.statistics-subtitle {
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-base, 1rem);
+    line-height: var(--line-height-base, 1.6);
+}
+
+.statistics-period-info {
+    margin: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-xxs, 6px);
+    color: var(--color-primary-medium);
+    font-weight: var(--font-weight-medium);
+    font-size: 0.92rem;
+}
+
+.statistics-period-info::before {
+    content: "\e8df";
+    font-family: 'Material Symbols Outlined';
+    font-size: 1.1rem;
+    line-height: 1;
+    font-variation-settings: 'FILL' 1, 'wght' 400;
+}
+
 .statistics-filters {
     display: flex;
     align-items: center;
     gap: var(--spacing-md, 20px);
     flex-wrap: wrap;
-    padding-bottom: var(--spacing-sm, 12px);
-    border-bottom: 1px solid var(--color-gray-200);
+}
+
+.statistics-filters__group {
+    min-width: 220px;
+}
+
+.statistics-overview {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1.2fr);
+    gap: var(--spacing-lg, 28px);
+    align-items: stretch;
 }
 
 /* === Métricas Chave === */
@@ -28,32 +91,108 @@
 }
 
 .metric-card {
-    background-color: var(--color-white);
-    border: 1px solid var(--color-gray-200);
+    background: linear-gradient(165deg, rgba(var(--color-white-rgb, 255, 255, 255), 0.98) 0%, rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.75) 100%);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
     border-radius: var(--border-radius-lg);
-    padding: var(--spacing-sm, 14px);
+    padding: var(--spacing-md, 20px);
     display: flex;
     flex-direction: column;
-    align-items: center;
-    text-align: center;
-    gap: var(--spacing-xxs, 5px);
+    align-items: flex-start;
+    gap: var(--spacing-xs, 8px);
     box-shadow: var(--shadow-xs);
+    position: relative;
+    overflow: hidden;
 }
 
 .metric-card__icon {
-    font-size: 1.8rem;
+    width: 42px;
+    height: 42px;
+    border-radius: var(--border-radius-circle);
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
     color: var(--color-primary-medium);
+    font-size: 1.6rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 .metric-card__label {
     font-size: var(--font-size-xs, 0.8rem);
-    color: var(--color-text-secondary);
-    font-weight: var(--font-weight-medium);
+    color: var(--color-text-muted);
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
 }
 .metric-card__value {
-    font-size: 1.6rem;
+    font-size: 1.8rem;
     font-weight: var(--font-weight-bold);
-    color: var(--color-text-primary);
-    line-height: 1.2;
+    color: var(--color-primary-dark);
+    line-height: 1.1;
+}
+
+/* === Insights === */
+.statistics-insights {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: var(--spacing-md, 20px);
+}
+
+.insight-card {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--spacing-sm, 14px);
+    padding: var(--spacing-md, 20px);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.95);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.14);
+    border-radius: var(--border-radius-lg);
+    box-shadow: var(--shadow-xs);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    min-height: 120px;
+}
+
+.insight-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+}
+
+.insight-card__icon {
+    width: 44px;
+    height: 44px;
+    border-radius: var(--border-radius-circle);
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
+    color: var(--color-primary-medium);
+    font-size: 1.6rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.insight-card__content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.insight-card__label {
+    margin: 0;
+    color: var(--color-text-muted);
+    font-size: 0.72rem;
+    font-weight: var(--font-weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.insight-card__value {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
+}
+
+.insight-card__description {
+    margin: 0;
+    font-size: 0.88rem;
+    color: var(--color-text-secondary);
+    line-height: 1.45;
 }
 
 /* === Grade dos Gráficos === */
@@ -105,6 +244,34 @@
     color: var(--color-text-muted);
     font-size: 0.9rem;
     text-align: center;
+}
+
+.statistics-empty-state {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md, 20px);
+    padding: var(--spacing-lg, 28px);
+    border: 1px dashed rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.3);
+    border-radius: var(--border-radius-lg);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.92);
+}
+
+.statistics-empty-state__icon {
+    font-size: 2.5rem;
+    color: var(--color-primary-medium);
+}
+
+.statistics-empty-state__title {
+    margin: 0 0 4px 0;
+    font-size: 1.05rem;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
+}
+
+.statistics-empty-state__description {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--color-text-secondary);
 }
 
 /* --- INÍCIO DA MODIFICAÇÃO DISRUPTIVA --- */
@@ -170,6 +337,14 @@
 
 
 @media (max-width: 768px) {
+    .statistics-dashboard__header {
+        flex-direction: column;
+    }
+
+    .statistics-overview {
+        grid-template-columns: 1fr;
+    }
+
     .stats-grid {
         grid-template-columns: 1fr;
     }
@@ -178,5 +353,9 @@
 @media (max-width: 480px) {
     .key-metrics-summary {
         grid-template-columns: repeat(2, 1fr);
+    }
+
+    .insight-card {
+        min-height: auto;
     }
 }

--- a/assets/js/ui/StatisticsChartManager.js
+++ b/assets/js/ui/StatisticsChartManager.js
@@ -42,10 +42,10 @@ export default class StatisticsChartManager {
 		this.actionOrchestrator = null;
 		this.hasInitialized = false;
 
-		this.elements = {
-			overallAccuracyChartEl: document.getElementById(
-				"chart-overall-accuracy"
-			),
+                this.elements = {
+                        overallAccuracyChartEl: document.getElementById(
+                                "chart-overall-accuracy"
+                        ),
 			categoryPerformanceChartEl: document.getElementById(
 				"chart-category-performance"
 			),
@@ -67,17 +67,70 @@ export default class StatisticsChartManager {
 			noStatsDataMessageEl: document.getElementById(
 				"no-stats-data-message"
 			),
-			statisticsDashboardContainer: document.querySelector(
-				".statistics-dashboard"
-			),
-		};
+                        statisticsDashboardContainer: document.querySelector(
+                                ".statistics-dashboard"
+                        ),
+                        statisticsPeriodSummaryEl: document.getElementById(
+                                "statistics-period-summary"
+                        ),
+                        noStatsDataTitleEl: document.querySelector(
+                                "#no-stats-data-message [data-role=\"title\"]"
+                        ),
+                        noStatsDataDescriptionEl: document.querySelector(
+                                "#no-stats-data-message [data-role=\"description\"]"
+                        ),
+                };
                 this.charts = {};
                 this.heatmapTooltip = null;
+
+                this.insightElements = {
+                        bestCategory: {
+                                valueEl: document.getElementById(
+                                        "insight-best-category"
+                                ),
+                                detailEl: document.getElementById(
+                                        "insight-best-category-detail"
+                                ),
+                        },
+                        bestDifficulty: {
+                                valueEl: document.getElementById(
+                                        "insight-best-difficulty"
+                                ),
+                                detailEl: document.getElementById(
+                                        "insight-best-difficulty-detail"
+                                ),
+                        },
+                        productiveDay: {
+                                valueEl: document.getElementById(
+                                        "insight-productive-day"
+                                ),
+                                detailEl: document.getElementById(
+                                        "insight-productive-day-detail"
+                                ),
+                        },
+                        accuracy: {
+                                valueEl: document.getElementById("insight-accuracy"),
+                                detailEl: document.getElementById(
+                                        "insight-accuracy-detail"
+                                ),
+                        },
+                };
+                this.defaultInsightMessages = {
+                        bestCategory:
+                                "Complete quizzes para desbloquear esta informação.",
+                        bestDifficulty:
+                                "Resolva questões para descobrir em qual nível você mais acerta.",
+                        productiveDay:
+                                "Assim que houver atividades recentes, destacaremos o melhor dia.",
+                        accuracy:
+                                "Suas taxas de acerto aparecerão aqui quando você responder questões.",
+                };
 
                 const initialPeriodValue = this.elements.periodSelectEl
                         ? this.elements.periodSelectEl.value
                         : null;
                 this.currentPeriod = this._normalizePeriodValue(initialPeriodValue);
+                this._updatePeriodSummaryLabel();
 
                 if (
                         this.elements.periodSelectEl &&
@@ -118,6 +171,33 @@ export default class StatisticsChartManager {
                 return DEFAULT_PERIOD;
         }
 
+        _getCurrentPeriodLabel() {
+                if (!this.elements.periodSelectEl) {
+                        return null;
+                }
+
+                const selectEl = this.elements.periodSelectEl;
+                const selectedOption = selectEl.options[selectEl.selectedIndex];
+                if (!selectedOption) {
+                        return null;
+                }
+
+                const label =
+                        selectedOption.dataset.label || selectedOption.textContent;
+                return label ? label.trim() : null;
+        }
+
+        _updatePeriodSummaryLabel() {
+                if (!this.elements.statisticsPeriodSummaryEl) {
+                        return;
+                }
+                const label = this._getCurrentPeriodLabel();
+                const text = label
+                        ? `Exibindo desempenho dos ${label}.`
+                        : "Exibindo desempenho recente.";
+                this.elements.statisticsPeriodSummaryEl.textContent = text;
+        }
+
         setStore(storeInstance) {
                 this.store = storeInstance;
                 if (this.store) {
@@ -153,22 +233,24 @@ export default class StatisticsChartManager {
                         }
 
                         this.currentPeriod = normalizedPeriod;
+                        this._updatePeriodSummaryLabel();
                         this._triggerFetchStatistics();
                 });
 
-		const currentStats = this.store.getState().statistics;
-		if (!currentStats.data && !currentStats.isLoading) {
+                const currentStats = this.store.getState().statistics;
+                if (!currentStats.data && !currentStats.isLoading) {
 			this._triggerFetchStatistics();
 		}
 
 		this.hasInitialized = true;
 	}
 
-	_triggerFetchStatistics() {
-		if (this.actionOrchestrator) {
-			this.actionOrchestrator.fetchStatistics(this.currentPeriod);
-		}
-	}
+        _triggerFetchStatistics() {
+                if (this.actionOrchestrator) {
+                        this._updatePeriodSummaryLabel();
+                        this.actionOrchestrator.fetchStatistics(this.currentPeriod);
+                }
+        }
 
 	handleStateUpdate() {
 		if (!this.store) return;
@@ -200,41 +282,67 @@ export default class StatisticsChartManager {
 			return;
 		}
 
-		if (statsData && statsData.status === "success") {
-			this._updateKeyMetrics(statsData.key_metrics);
-			const hasAnyData =
-				statsData.key_metrics?.total_questions_answered > 0;
+                if (statsData && statsData.status === "success") {
+                        this._updateKeyMetrics(statsData.key_metrics);
+                        const hasAnyData =
+                                statsData.key_metrics?.total_questions_answered > 0;
 
-			if (!hasAnyData) {
-				if (this.elements.noStatsDataMessageEl)
-					this.quizUI.showElement(this.elements.noStatsDataMessageEl);
-				document
-					.querySelectorAll(".chart-container .chart-placeholder")
-					.forEach((p) => {
-						this._showNoDataMessageForChart(
-							p.parentElement,
-							"Sem dados para o período."
-						);
-					});
-			} else {
-				if (this.elements.noStatsDataMessageEl)
-					this.quizUI.hideElement(this.elements.noStatsDataMessageEl);
-				this._renderOverallAccuracyChart(statsData.overall_accuracy);
-				this._renderCategoryPerformanceChart(
-					statsData.category_performance
-				);
-				this._renderLearningProgressChart(statsData.learning_progress);
-				this._renderStudyHeatmapChart(statsData.study_heatmap);
-				this._renderStudyTimeChart(statsData.study_time_detail);
-				this._renderDifficultyPerformanceChart(
-					statsData.difficulty_performance
-				);
-			}
-		} else {
-			this._showErrorState(
-				statsData?.message || "Falha ao processar estatísticas."
-			);
-		}
+                        if (!hasAnyData) {
+                                this._showNoDataInsights();
+                                const currentLabel = this._getCurrentPeriodLabel();
+                                if (this.elements.noStatsDataTitleEl) {
+                                        this.elements.noStatsDataTitleEl.textContent =
+                                                "Sem estatísticas por aqui";
+                                        this.elements.noStatsDataTitleEl.style.color = "";
+                                }
+                                if (this.elements.noStatsDataDescriptionEl) {
+                                        const description = currentLabel
+                                                ? `Não encontramos atividade registrada nos ${currentLabel}. Complete um quiz para ver seus números aparecerem por aqui.`
+                                                : "Não encontramos atividade registrada neste período. Complete um quiz para ver seus números aparecerem por aqui.";
+                                        this.elements.noStatsDataDescriptionEl.textContent =
+                                                description;
+                                        this.elements.noStatsDataDescriptionEl.style.color = "";
+                                }
+                                if (this.elements.noStatsDataMessageEl) {
+                                        this.quizUI.showElement(
+                                                this.elements.noStatsDataMessageEl
+                                        );
+                                }
+                                document
+                                        .querySelectorAll(".chart-container .chart-placeholder")
+                                        .forEach((p) => {
+                                                this._showNoDataMessageForChart(
+                                                        p.parentElement,
+                                                        "Sem dados para o período."
+                                                );
+                                        });
+                        } else {
+                                if (this.elements.noStatsDataMessageEl) {
+                                        this.quizUI.hideElement(
+                                                this.elements.noStatsDataMessageEl
+                                        );
+                                }
+                                this._updateInsights(statsData);
+                                this._renderOverallAccuracyChart(
+                                        statsData.overall_accuracy
+                                );
+                                this._renderCategoryPerformanceChart(
+                                        statsData.category_performance
+                                );
+                                this._renderLearningProgressChart(
+                                        statsData.learning_progress
+                                );
+                                this._renderStudyHeatmapChart(statsData.study_heatmap);
+                                this._renderStudyTimeChart(statsData.study_time_detail);
+                                this._renderDifficultyPerformanceChart(
+                                        statsData.difficulty_performance
+                                );
+                        }
+                } else {
+                        this._showErrorState(
+                                statsData?.message || "Falha ao processar estatísticas."
+                        );
+                }
 	}
     
     _renderStudyHeatmapChart(data) {
@@ -423,33 +531,45 @@ export default class StatisticsChartManager {
 				p.style.color = "var(--color-text-muted)";
 				this.quizUI.showElement(p);
 			});
-		Object.keys(this.charts).forEach((chartKey) =>
-			this._destroyChart(chartKey)
-		);
+                Object.keys(this.charts).forEach((chartKey) =>
+                        this._destroyChart(chartKey)
+                );
         if (this.elements.studyHeatmapChartEl) this.elements.studyHeatmapChartEl.innerHTML = '<p class="chart-placeholder" style="display:block; text-align:center;">Carregando gráfico...</p>';
 
-		if (this.elements.noStatsDataMessageEl) {
-			this.quizUI.hideElement(this.elements.noStatsDataMessageEl);
-		}
-	}
+                this._showLoadingInsights();
 
-	_showErrorState(errorMessage) {
-		this._updateKeyMetrics(null);
-		document.querySelectorAll(".chart-container").forEach((container) => {
-			const placeholder = container.querySelector(".chart-placeholder");
-			if (placeholder) {
-				placeholder.textContent = errorMessage;
-				placeholder.style.color = "var(--color-accent-red)";
-				this.quizUI.showElement(placeholder);
-			}
-		});
-		if (this.elements.noStatsDataMessageEl) {
-			this.elements.noStatsDataMessageEl.textContent = errorMessage;
-			this.elements.noStatsDataMessageEl.style.color =
-				"var(--color-accent-red)";
-			this.quizUI.showElement(this.elements.noStatsDataMessageEl);
-		}
-	}
+                if (this.elements.noStatsDataMessageEl) {
+                        this.quizUI.hideElement(this.elements.noStatsDataMessageEl);
+                }
+        }
+
+        _showErrorState(errorMessage) {
+                this._updateKeyMetrics(null);
+                document.querySelectorAll(".chart-container").forEach((container) => {
+                        const placeholder = container.querySelector(".chart-placeholder");
+                        if (placeholder) {
+                                placeholder.textContent = errorMessage;
+                                placeholder.style.color = "var(--color-accent-red)";
+                                this.quizUI.showElement(placeholder);
+                        }
+                });
+                this._showErrorInsights(errorMessage);
+                if (this.elements.noStatsDataTitleEl) {
+                        this.elements.noStatsDataTitleEl.textContent =
+                                "Erro ao carregar estatísticas";
+                        this.elements.noStatsDataTitleEl.style.color =
+                                "var(--color-accent-red)";
+                }
+                if (this.elements.noStatsDataDescriptionEl) {
+                        this.elements.noStatsDataDescriptionEl.textContent =
+                                errorMessage;
+                        this.elements.noStatsDataDescriptionEl.style.color =
+                                "var(--color-accent-red)";
+                }
+                if (this.elements.noStatsDataMessageEl) {
+                        this.quizUI.showElement(this.elements.noStatsDataMessageEl);
+                }
+        }
 
 	_hideLoadingPlaceholder(chartEl) {
 		const placeholder = chartEl?.querySelector(".chart-placeholder");
@@ -471,31 +591,266 @@ export default class StatisticsChartManager {
 		this.quizUI.showElement(placeholder);
 	}
 
-	_updateKeyMetrics(keyMetrics) {
-		const metrics = keyMetrics || {
-			total_questions_answered: 0,
-			max_streak: 0,
-			total_score_all_time: 0,
-			total_study_time_seconds: 0,
-		};
-		if (this.elements.totalQuestionsEl)
-			this.elements.totalQuestionsEl.textContent =
-				metrics.total_questions_answered.toLocaleString("pt-BR");
-		if (this.elements.maxStreakEl)
-			this.elements.maxStreakEl.textContent =
-				metrics.max_streak.toLocaleString("pt-BR");
-		if (this.elements.totalScoreEl)
-			this.elements.totalScoreEl.textContent =
-				metrics.total_score_all_time.toLocaleString("pt-BR");
-		if (this.elements.totalStudyTimeEl) {
-			const totalSeconds = metrics.total_study_time_seconds || 0;
-			const minutes = Math.floor(totalSeconds / 60);
-			const hours = Math.floor(minutes / 60);
-			const remainingMinutes = minutes % 60;
-			this.elements.totalStudyTimeEl.textContent =
-				hours > 0 ? `${hours}h ${remainingMinutes}m` : `${minutes}m`;
-		}
-	}
+        _updateKeyMetrics(keyMetrics) {
+                const metrics = keyMetrics || {
+                        total_questions_answered: 0,
+                        max_streak: 0,
+                        total_score_all_time: 0,
+                        total_study_time_seconds: 0,
+                };
+                if (this.elements.totalQuestionsEl)
+                        this.elements.totalQuestionsEl.textContent =
+                                metrics.total_questions_answered.toLocaleString("pt-BR");
+                if (this.elements.maxStreakEl)
+                        this.elements.maxStreakEl.textContent =
+                                metrics.max_streak.toLocaleString("pt-BR");
+                if (this.elements.totalScoreEl)
+                        this.elements.totalScoreEl.textContent =
+                                metrics.total_score_all_time.toLocaleString("pt-BR");
+                if (this.elements.totalStudyTimeEl) {
+                        const totalSeconds = metrics.total_study_time_seconds || 0;
+                        const minutes = Math.floor(totalSeconds / 60);
+                        const hours = Math.floor(minutes / 60);
+                        const remainingMinutes = minutes % 60;
+                        this.elements.totalStudyTimeEl.textContent =
+                                hours > 0 ? `${hours}h ${remainingMinutes}m` : `${minutes}m`;
+                }
+        }
+
+        _setInsight(insightKey, valueText, detailText) {
+                const entry = this.insightElements
+                        ? this.insightElements[insightKey]
+                        : null;
+                if (!entry) {
+                        return;
+                }
+
+                if (entry.valueEl) {
+                        entry.valueEl.textContent = valueText;
+                }
+                if (entry.detailEl) {
+                        entry.detailEl.textContent = detailText;
+                }
+        }
+
+        _showLoadingInsights() {
+                Object.keys(this.insightElements || {}).forEach((key) => {
+                        this._setInsight(key, "--", "Carregando dados...");
+                });
+        }
+
+        _showNoDataInsights() {
+                const label = this._getCurrentPeriodLabel();
+                let context = "neste período";
+                if (label) {
+                        context = label.toLowerCase().startsWith("últimos")
+                                ? `nos ${label}`
+                                : `em ${label}`;
+                }
+                this._setInsight(
+                        "bestCategory",
+                        "--",
+                        `Complete quizzes ${context} para descobrir sua categoria destaque.`
+                );
+                this._setInsight(
+                        "bestDifficulty",
+                        "--",
+                        `Resolva questões ${context} para ver a dificuldade em que você se destaca.`
+                );
+                this._setInsight(
+                        "productiveDay",
+                        "--",
+                        `Assim que houver atividades registradas ${context}, destacaremos o dia mais focado.`
+                );
+                this._setInsight(
+                        "accuracy",
+                        "--",
+                        `Ainda não há respostas registradas ${context}. Complete um quiz para ver a precisão geral.`
+                );
+        }
+
+        _showErrorInsights(message) {
+                const fallbackMessage = message || "Não foi possível carregar os insights.";
+                Object.keys(this.insightElements || {}).forEach((key) => {
+                        this._setInsight(key, "--", fallbackMessage);
+                });
+        }
+
+        _updateInsights(statsData) {
+                if (!statsData) {
+                        this._showNoDataInsights();
+                        return;
+                }
+
+                const categoryPerformance = Array.isArray(
+                        statsData.category_performance
+                )
+                        ? statsData.category_performance
+                        : [];
+                const topCategory = categoryPerformance.reduce((best, current) => {
+                        if (!current) return best;
+                        if (!best) return current;
+                        const currentAccuracy = Number(current.accuracy) || 0;
+                        const bestAccuracy = Number(best.accuracy) || 0;
+                        return currentAccuracy > bestAccuracy ? current : best;
+                }, null);
+                if (topCategory && topCategory.name) {
+                        const accuracyValue = Number(topCategory.accuracy) || 0;
+                        const totalCount = Number(topCategory.total) || 0;
+                        const detailParts = [];
+                        detailParts.push(`Precisão de ${Math.round(accuracyValue)}%`);
+                        if (totalCount > 0) {
+                                detailParts.push(
+                                        `em ${this._formatQuestionCount(totalCount)}`
+                                );
+                        }
+                        this._setInsight(
+                                "bestCategory",
+                                topCategory.name,
+                                `${detailParts.join(" ")}.`
+                        );
+                } else {
+                        this._setInsight(
+                                "bestCategory",
+                                "--",
+                                this.defaultInsightMessages.bestCategory
+                        );
+                }
+
+                const difficultyPerformance = Array.isArray(
+                        statsData.difficulty_performance
+                )
+                        ? statsData.difficulty_performance
+                        : [];
+                const topDifficulty = difficultyPerformance.reduce((best, current) => {
+                        if (!current) return best;
+                        if (!best) return current;
+                        const currentAccuracy = Number(current.accuracy) || 0;
+                        const bestAccuracy = Number(best.accuracy) || 0;
+                        return currentAccuracy > bestAccuracy ? current : best;
+                }, null);
+                if (topDifficulty && topDifficulty.name) {
+                        const accuracyValue = Number(topDifficulty.accuracy) || 0;
+                        const totalCount = Number(topDifficulty.total) || 0;
+                        const accuracyText = `${Math.round(accuracyValue)}% de acerto`;
+                        const volumeText =
+                                totalCount > 0
+                                        ? `em ${this._formatQuestionCount(totalCount)}`
+                                        : "";
+                        this._setInsight(
+                                "bestDifficulty",
+                                topDifficulty.name,
+                                volumeText
+                                        ? `${accuracyText} ${volumeText}.`
+                                        : `${accuracyText}.`
+                        );
+                } else {
+                        this._setInsight(
+                                "bestDifficulty",
+                                "--",
+                                this.defaultInsightMessages.bestDifficulty
+                        );
+                }
+
+                const heatmapData = Array.isArray(statsData.study_heatmap)
+                        ? statsData.study_heatmap.filter(
+                                (item) =>
+                                        item &&
+                                        item.date_str &&
+                                        Number(item.questions_done) > 0
+                        )
+                        : [];
+                const productiveDay = heatmapData.reduce((best, current) => {
+                        if (!current) return best;
+                        if (!best) return current;
+                        const currentCount = Number(current.questions_done) || 0;
+                        const bestCount = Number(best.questions_done) || 0;
+                        if (currentCount > bestCount) {
+                                return current;
+                        }
+                        if (currentCount === bestCount && current.date_str > best.date_str) {
+                                return current;
+                        }
+                        return best;
+                }, null);
+                if (productiveDay) {
+                        const formattedDate = this._formatDate(productiveDay.date_str, {
+                                day: "numeric",
+                                month: "short",
+                        });
+                        const questionText = this._formatQuestionCount(
+                                productiveDay.questions_done
+                        );
+                        this._setInsight(
+                                "productiveDay",
+                                formattedDate,
+                                `${questionText} respondidas.`
+                        );
+                } else {
+                        this._setInsight(
+                                "productiveDay",
+                                "--",
+                                this.defaultInsightMessages.productiveDay
+                        );
+                }
+
+                const accuracyData = statsData.overall_accuracy || {};
+                const correctAnswers = Number(accuracyData.correct) || 0;
+                const incorrectAnswers = Number(accuracyData.incorrect) || 0;
+                const totalAnswers = correctAnswers + incorrectAnswers;
+                if (totalAnswers > 0) {
+                        const accuracyPercentage =
+                                (correctAnswers / totalAnswers) * 100;
+                        const detail = `Você acertou ${this._formatQuestionCount(
+                                correctAnswers
+                        )} de ${this._formatNumber(totalAnswers)} questões.`;
+                        this._setInsight(
+                                "accuracy",
+                                `${Math.round(accuracyPercentage)}%`,
+                                detail
+                        );
+                } else {
+                        this._setInsight(
+                                "accuracy",
+                                "--",
+                                this.defaultInsightMessages.accuracy
+                        );
+                }
+        }
+
+        _formatNumber(value) {
+                const numericValue = Number(value);
+                if (Number.isNaN(numericValue) || value === null || value === undefined) {
+                        return "0";
+                }
+                return numericValue.toLocaleString("pt-BR");
+        }
+
+        _formatQuestionCount(count) {
+                const numericCount = Number(count) || 0;
+                const label = numericCount === 1 ? "questão" : "questões";
+                return `${this._formatNumber(numericCount)} ${label}`;
+        }
+
+        _formatDate(dateStr, options = { day: "numeric", month: "long" }) {
+                if (!dateStr) {
+                        return "--";
+                }
+
+                const date = new Date(`${dateStr}T00:00:00Z`);
+                if (Number.isNaN(date.getTime())) {
+                        return dateStr;
+                }
+
+                try {
+                        return date.toLocaleDateString("pt-BR", {
+                                timeZone: "UTC",
+                                ...options,
+                        });
+                } catch (error) {
+                        return dateStr;
+                }
+        }
 
 	_destroyChart(chartKey) {
 		if (

--- a/quiz/templates/quiz/account_page.html
+++ b/quiz/templates/quiz/account_page.html
@@ -382,43 +382,85 @@
 
             {# --- Seção: Estatísticas (REFORMULADA) --- #}
             <div id="statistics-content" class="account-content__section">
-                <div class="card card--conta-perfil card--statistics-dashboard"> {# Nova classe para o card principal do dashboard #}
+                <div class="card card--conta-perfil card--statistics-dashboard">
                     <h2 class="card__title">Estatísticas de Desempenho</h2>
                     <div class="card__body">
                         <div class="statistics-dashboard">
-                            <div class="statistics-filters">
-                                <div class="form-group" style="max-width: 250px;">
-                                    <label for="stats-period-select" class="form-label">Visualizar Período:</label>
-                                    <select id="stats-period-select" class="form-control form-control--small">
-                                        <option value="7d">Últimos 7 dias</option>
-                                        <option value="30d" selected>Últimos 30 dias</option>
-                                        <option value="90d">Últimos 90 dias</option>
-                                        <option value="all">Desde o início</option>
-                                    </select>
+                            <header class="statistics-dashboard__header">
+                                <div class="statistics-dashboard__intro">
+                                    <p class="statistics-subtitle">Acompanhe seus avanços, identifique padrões de estudo e descubra onde concentrar seus esforços.</p>
+                                    <p class="statistics-period-info" id="statistics-period-summary">Exibindo desempenho dos últimos 30 dias.</p>
                                 </div>
-                                {# Futuramente: <button id="btn-refresh-stats" class="button button--outline button--small">Atualizar</button> #}
-                            </div>
+                                <div class="statistics-filters">
+                                    <div class="form-group statistics-filters__group">
+                                        <label for="stats-period-select" class="form-label">Visualizar período</label>
+                                        <select id="stats-period-select" class="form-control form-control--small">
+                                            <option value="7d" data-label="últimos 7 dias">Últimos 7 dias</option>
+                                            <option value="30d" data-label="últimos 30 dias" selected>Últimos 30 dias</option>
+                                            <option value="90d" data-label="últimos 90 dias">Últimos 90 dias</option>
+                                            <option value="all" data-label="todo o período">Desde o início</option>
+                                        </select>
+                                    </div>
+                                </div>
+                            </header>
 
-                            <div class="key-metrics-summary" id="key-metrics-summary-container">
-                                <div class="metric-card">
-                                    <span class="material-symbols-outlined metric-card__icon">functions</span>
-                                    <span class="metric-card__label">Total de Questões</span>
-                                    <span class="metric-card__value" id="metric-total-questions">--</span>
+                            <div class="statistics-overview">
+                                <div class="key-metrics-summary" id="key-metrics-summary-container">
+                                    <div class="metric-card">
+                                        <span class="material-symbols-outlined metric-card__icon" aria-hidden="true">functions</span>
+                                        <span class="metric-card__label">Total de questões</span>
+                                        <span class="metric-card__value" id="metric-total-questions">--</span>
+                                    </div>
+                                    <div class="metric-card">
+                                        <span class="material-symbols-outlined metric-card__icon" aria-hidden="true">local_fire_department</span>
+                                        <span class="metric-card__label">Sequência máx.</span>
+                                        <span class="metric-card__value" id="metric-max-streak">--</span>
+                                    </div>
+                                    <div class="metric-card">
+                                        <span class="material-symbols-outlined metric-card__icon" aria-hidden="true">military_tech</span>
+                                        <span class="metric-card__label">Pontuação total</span>
+                                        <span class="metric-card__value" id="metric-total-score">--</span>
+                                    </div>
+                                    <div class="metric-card">
+                                        <span class="material-symbols-outlined metric-card__icon" aria-hidden="true">timer</span>
+                                        <span class="metric-card__label">Tempo de estudo</span>
+                                        <span class="metric-card__value" id="metric-total-study-time">--</span>
+                                    </div>
                                 </div>
-                                <div class="metric-card">
-                                    <span class="material-symbols-outlined metric-card__icon">local_fire_department</span>
-                                    <span class="metric-card__label">Sequência Máx.</span>
-                                    <span class="metric-card__value" id="metric-max-streak">--</span>
-                                </div>
-                                <div class="metric-card">
-                                    <span class="material-symbols-outlined metric-card__icon">military_tech</span>
-                                    <span class="metric-card__label">Pontuação Total</span>
-                                    <span class="metric-card__value" id="metric-total-score">--</span>
-                                </div>
-                                <div class="metric-card">
-                                    <span class="material-symbols-outlined metric-card__icon">timer</span>
-                                    <span class="metric-card__label">Tempo Total Estudo</span>
-                                    <span class="metric-card__value" id="metric-total-study-time">--</span>
+
+                                <div class="statistics-insights" aria-live="polite">
+                                    <article class="insight-card" data-insight="top-category">
+                                        <span class="material-symbols-outlined insight-card__icon" aria-hidden="true">military_tech</span>
+                                        <div class="insight-card__content">
+                                            <p class="insight-card__label">Categoria destaque</p>
+                                            <p class="insight-card__value" id="insight-best-category">--</p>
+                                            <p class="insight-card__description" id="insight-best-category-detail">Complete quizzes para desbloquear esta informação.</p>
+                                        </div>
+                                    </article>
+                                    <article class="insight-card" data-insight="difficulty">
+                                        <span class="material-symbols-outlined insight-card__icon" aria-hidden="true">target</span>
+                                        <div class="insight-card__content">
+                                            <p class="insight-card__label">Dificuldade em alta</p>
+                                            <p class="insight-card__value" id="insight-best-difficulty">--</p>
+                                            <p class="insight-card__description" id="insight-best-difficulty-detail">Resolva questões para descobrir em qual nível você mais acerta.</p>
+                                        </div>
+                                    </article>
+                                    <article class="insight-card" data-insight="productive-day">
+                                        <span class="material-symbols-outlined insight-card__icon" aria-hidden="true">calendar_month</span>
+                                        <div class="insight-card__content">
+                                            <p class="insight-card__label">Dia mais focado</p>
+                                            <p class="insight-card__value" id="insight-productive-day">--</p>
+                                            <p class="insight-card__description" id="insight-productive-day-detail">Assim que houver atividades recentes, destacaremos o melhor dia.</p>
+                                        </div>
+                                    </article>
+                                    <article class="insight-card" data-insight="accuracy">
+                                        <span class="material-symbols-outlined insight-card__icon" aria-hidden="true">monitoring</span>
+                                        <div class="insight-card__content">
+                                            <p class="insight-card__label">Precisão geral</p>
+                                            <p class="insight-card__value" id="insight-accuracy">--</p>
+                                            <p class="insight-card__description" id="insight-accuracy-detail">Suas taxas de acerto aparecerão aqui quando você responder questões.</p>
+                                        </div>
+                                    </article>
                                 </div>
                             </div>
 
@@ -460,15 +502,18 @@
                                     </div>
                                 </div>
                             </div>
-                            <div id="no-stats-data-message" class="u-is-hidden placeholder-text" style="margin-top: var(--spacing-lg);">
-                                <span class="material-symbols-outlined" style="font-size: 3rem; color: var(--color-text-muted); margin-bottom: 10px; display:block;">sentiment_dissatisfied</span>
-                                Nenhuma estatística encontrada para o período selecionado. Comece um quiz para ver seu progresso!
+
+                            <div id="no-stats-data-message" class="statistics-empty-state u-is-hidden" role="status" aria-live="polite">
+                                <span class="material-symbols-outlined statistics-empty-state__icon" aria-hidden="true">sentiment_neutral</span>
+                                <div class="statistics-empty-state__content">
+                                    <h3 class="statistics-empty-state__title" data-role="title">Nenhuma estatística encontrada</h3>
+                                    <p class="statistics-empty-state__description" data-role="description">Complete um quiz para ver seus números aparecerem por aqui.</p>
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
-
             {# --- Seção: Segurança e Dados --- #}
             <div id="security-content" class="account-content__section">
                  <div class="card card--conta-perfil">


### PR DESCRIPTION
## Summary
- redesign the statistics section on the account page with a richer header, insight cards, and improved empty state
- refresh statistics dashboard styling to better match the rest of the site and highlight key metrics and insights
- extend the statistics manager to update the new UI elements, summarize periods, and compute dynamic insights from the API data

## Testing
- python manage.py test quiz *(fails: Django is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ced9ff584483339967f86f033b258d