### PR TITLE
Reformulate user statistics dashboard

### DIFF
--- a/assets/css/components/statistics-dashboard.css
+++ b/assets/css/components/statistics-dashboard.css
@@ -83,6 +83,20 @@
     align-items: stretch;
 }
 
+.statistics-overview__primary {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-lg, 28px);
+    min-width: 0;
+}
+
+.statistics-overview__side {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md, 20px);
+    min-width: 0;
+}
+
 /* === Métricas Chave === */
 .key-metrics-summary {
     display: grid;
@@ -134,6 +148,256 @@
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: var(--spacing-md, 20px);
+}
+
+/* === Cartão de Tendência === */
+.statistics-trend-card {
+    background: linear-gradient(155deg, rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.1) 0%, rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.85) 100%);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
+    border-radius: var(--border-radius-lg);
+    padding: var(--spacing-md, 20px);
+    box-shadow: var(--shadow-xs);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm, 16px);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.statistics-trend-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+}
+
+.statistics-trend-card__header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm, 16px);
+}
+
+.statistics-trend-card__icon {
+    width: 48px;
+    height: 48px;
+    border-radius: var(--border-radius-circle);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
+    color: var(--color-primary-medium);
+    font-size: 1.8rem;
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.statistics-trend-card__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.statistics-trend-card__label {
+    margin: 0;
+    font-size: 0.78rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-muted);
+}
+
+.statistics-trend-card__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    align-self: flex-start;
+    padding: 4px 10px;
+    border-radius: var(--border-radius-pill);
+    font-size: 0.75rem;
+    font-weight: var(--font-weight-semibold);
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
+    color: var(--color-primary-medium);
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.statistics-trend-card__body {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.statistics-trend-card__value {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: clamp(1.7rem, 3vw, 2.1rem);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-primary-dark);
+}
+
+.statistics-trend-card__detail {
+    margin: 0;
+    font-size: 0.92rem;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+}
+
+.statistics-trend-card.is-loading {
+    opacity: 0.6;
+}
+
+.statistics-trend-card--up .statistics-trend-card__value {
+    color: var(--color-secondary-green);
+}
+
+.statistics-trend-card--up .statistics-trend-card__badge,
+.statistics-trend-card--up .statistics-trend-card__icon {
+    background: rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.18);
+    color: var(--color-secondary-green);
+}
+
+.statistics-trend-card--down .statistics-trend-card__value,
+.statistics-trend-card--error .statistics-trend-card__value {
+    color: var(--color-accent-red);
+}
+
+.statistics-trend-card--down .statistics-trend-card__badge,
+.statistics-trend-card--down .statistics-trend-card__icon,
+.statistics-trend-card--error .statistics-trend-card__badge,
+.statistics-trend-card--error .statistics-trend-card__icon {
+    background: rgba(var(--color-accent-red-rgb, 230, 57, 70), 0.18);
+    color: var(--color-accent-red);
+}
+
+.statistics-trend-card--flat .statistics-trend-card__badge,
+.statistics-trend-card--flat .statistics-trend-card__icon {
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.14);
+    color: var(--color-primary-medium);
+}
+
+.statistics-trend-card--empty .statistics-trend-card__value {
+    color: var(--color-text-muted);
+}
+
+.statistics-trend-card--empty .statistics-trend-card__badge,
+.statistics-trend-card--empty .statistics-trend-card__icon {
+    background: rgba(var(--color-gray-200-rgb, 241, 243, 245), 0.8);
+    color: var(--color-text-muted);
+}
+
+.statistics-trend-card--empty .statistics-trend-card__detail {
+    color: var(--color-text-muted);
+}
+
+.statistics-trend-card--error .statistics-trend-card__detail {
+    color: var(--color-accent-red);
+}
+
+/* === Resumo do Período === */
+.period-highlights {
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.96);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
+    border-radius: var(--border-radius-lg);
+    box-shadow: var(--shadow-xs);
+    padding: var(--spacing-md, 20px);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md, 20px);
+}
+
+.period-highlights.is-loading {
+    opacity: 0.6;
+}
+
+.period-highlights__header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.period-highlights__title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
+}
+
+.period-highlights__subtitle {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+}
+
+.period-highlights__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm, 16px);
+}
+
+.period-highlights__item {
+    display: flex;
+    gap: var(--spacing-sm, 16px);
+    align-items: flex-start;
+    padding-bottom: var(--spacing-sm, 16px);
+    border-bottom: 1px solid rgba(var(--color-gray-200-rgb, 241, 243, 245), 0.9);
+}
+
+.period-highlights__item:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.period-highlights__icon {
+    width: 40px;
+    height: 40px;
+    border-radius: var(--border-radius-circle);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.14);
+    color: var(--color-primary-medium);
+    font-size: 1.4rem;
+    flex-shrink: 0;
+}
+
+.period-highlights__content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+}
+
+.period-highlights__label {
+    margin: 0;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-muted);
+}
+
+.period-highlights__value {
+    margin: 0;
+    font-size: 1.35rem;
+    font-weight: var(--font-weight-bold);
+    color: var(--color-primary-dark);
+}
+
+.period-highlights__detail {
+    margin: 0;
+    font-size: 0.88rem;
+    color: var(--color-text-secondary);
+    line-height: 1.45;
+}
+
+.period-highlights__value[data-state="loading"],
+.period-highlights__detail[data-state="loading"],
+.period-highlights__value[data-state="empty"],
+.period-highlights__detail[data-state="empty"] {
+    color: var(--color-text-muted);
+}
+
+.period-highlights__value[data-state="error"],
+.period-highlights__detail[data-state="error"] {
+    color: var(--color-accent-red);
 }
 
 .insight-card {
@@ -345,6 +609,22 @@
         grid-template-columns: 1fr;
     }
 
+    .statistics-overview__side {
+        order: -1;
+    }
+
+    .statistics-trend-card__value {
+        font-size: 1.6rem;
+    }
+
+    .period-highlights__item {
+        padding-bottom: var(--spacing-xs, 12px);
+    }
+
+    .period-highlights__value {
+        font-size: 1.15rem;
+    }
+
     .stats-grid {
         grid-template-columns: 1fr;
     }
@@ -357,5 +637,19 @@
 
     .insight-card {
         min-height: auto;
+    }
+
+    .period-highlights__list {
+        gap: var(--spacing-xs, 12px);
+    }
+
+    .period-highlights__item {
+        gap: var(--spacing-xs, 12px);
+    }
+
+    .period-highlights__icon {
+        width: 34px;
+        height: 34px;
+        font-size: 1.2rem;
     }
 }

--- a/assets/js/ui/StatisticsChartManager.js
+++ b/assets/js/ui/StatisticsChartManager.js
@@ -126,6 +126,64 @@ export default class StatisticsChartManager {
                                 "Suas taxas de acerto aparecerão aqui quando você responder questões.",
                 };
 
+                this.periodHighlightsElements = {
+                        container: document.getElementById("statistics-period-highlights"),
+                        activeDays: {
+                                valueEl: document.getElementById("summary-active-days"),
+                                detailEl: document.getElementById("summary-active-days-detail"),
+                        },
+                        averageQuestions: {
+                                valueEl: document.getElementById("summary-average-questions"),
+                                detailEl: document.getElementById("summary-average-questions-detail"),
+                        },
+                        averageStudyTime: {
+                                valueEl: document.getElementById("summary-average-study-time"),
+                                detailEl: document.getElementById("summary-average-study-time-detail"),
+                        },
+                        sessionsCompleted: {
+                                valueEl: document.getElementById("summary-sessions-completed"),
+                                detailEl: document.getElementById("summary-sessions-completed-detail"),
+                        },
+                };
+
+                this.periodHighlightDefaults = {
+                        activeDays: {
+                                detail: this.periodHighlightsElements.activeDays.detailEl?.textContent?.trim() ||
+                                        "Monte uma rotina consistente de estudos.",
+                        },
+                        averageQuestions: {
+                                detail: this.periodHighlightsElements.averageQuestions.detailEl?.textContent?.trim() ||
+                                        "Resolva perguntas com frequência para ver sua média.",
+                        },
+                        averageStudyTime: {
+                                detail: this.periodHighlightsElements.averageStudyTime.detailEl?.textContent?.trim() ||
+                                        "Complete sessões para calcular seu tempo médio diário.",
+                        },
+                        sessionsCompleted: {
+                                detail: this.periodHighlightsElements.sessionsCompleted.detailEl?.textContent?.trim() ||
+                                        "Inicie um quiz para analisar seu ritmo de conclusão.",
+                        },
+                };
+
+                this.accuracyTrendElements = {
+                        container: document.getElementById("accuracy-trend-card"),
+                        valueEl: document.getElementById("trend-accuracy-value"),
+                        detailEl: document.getElementById("trend-accuracy-detail"),
+                        badgeEl: document.getElementById("trend-accuracy-badge"),
+                        iconEl: document.getElementById("trend-accuracy-icon"),
+                };
+
+                this.trendDefaults = {
+                        detail:
+                                this.accuracyTrendElements.detailEl?.textContent?.trim() ||
+                                "Complete quizzes para acompanhar a evolução do seu desempenho.",
+                        badge: this.accuracyTrendElements.badgeEl?.textContent?.trim() || "Sem dados",
+                };
+
+                this.loadingMessage = "Carregando dados...";
+                this.summaryErrorMessage = "Não foi possível carregar o resumo do período.";
+                this.trendErrorMessage = "Não foi possível carregar a variação de precisão.";
+
                 const initialPeriodValue = this.elements.periodSelectEl
                         ? this.elements.periodSelectEl.value
                         : null;
@@ -289,6 +347,8 @@ export default class StatisticsChartManager {
 
                         if (!hasAnyData) {
                                 this._showNoDataInsights();
+                                this._showNoPeriodHighlights();
+                                this._showEmptyAccuracyTrend();
                                 const currentLabel = this._getCurrentPeriodLabel();
                                 if (this.elements.noStatsDataTitleEl) {
                                         this.elements.noStatsDataTitleEl.textContent =
@@ -322,6 +382,8 @@ export default class StatisticsChartManager {
                                                 this.elements.noStatsDataMessageEl
                                         );
                                 }
+                                this._updatePeriodHighlights(statsData.period_summary);
+                                this._updateAccuracyTrend(statsData.accuracy_trend);
                                 this._updateInsights(statsData);
                                 this._renderOverallAccuracyChart(
                                         statsData.overall_accuracy
@@ -534,9 +596,11 @@ export default class StatisticsChartManager {
                 Object.keys(this.charts).forEach((chartKey) =>
                         this._destroyChart(chartKey)
                 );
-        if (this.elements.studyHeatmapChartEl) this.elements.studyHeatmapChartEl.innerHTML = '<p class="chart-placeholder" style="display:block; text-align:center;">Carregando gráfico...</p>';
+                if (this.elements.studyHeatmapChartEl) this.elements.studyHeatmapChartEl.innerHTML = '<p class="chart-placeholder" style="display:block; text-align:center;">Carregando gráfico...</p>';
 
                 this._showLoadingInsights();
+                this._showLoadingPeriodHighlights();
+                this._showLoadingAccuracyTrend();
 
                 if (this.elements.noStatsDataMessageEl) {
                         this.quizUI.hideElement(this.elements.noStatsDataMessageEl);
@@ -554,6 +618,8 @@ export default class StatisticsChartManager {
                         }
                 });
                 this._showErrorInsights(errorMessage);
+                this._showPeriodHighlightsError(errorMessage);
+                this._showErrorAccuracyTrend(errorMessage);
                 if (this.elements.noStatsDataTitleEl) {
                         this.elements.noStatsDataTitleEl.textContent =
                                 "Erro ao carregar estatísticas";
@@ -615,6 +681,411 @@ export default class StatisticsChartManager {
                         this.elements.totalStudyTimeEl.textContent =
                                 hours > 0 ? `${hours}h ${remainingMinutes}m` : `${minutes}m`;
                 }
+        }
+
+        _applyStateToElement(element, state) {
+                if (!element) {
+                        return;
+                }
+
+                if (state && state !== "default") {
+                        element.dataset.state = state;
+                } else {
+                        delete element.dataset.state;
+                }
+        }
+
+        _setPeriodHighlightState(key, valueText, detailText, state = "default") {
+                if (!this.periodHighlightsElements || !this.periodHighlightsElements[key]) {
+                        return;
+                }
+                const item = this.periodHighlightsElements[key];
+                if (item.valueEl) {
+                        item.valueEl.textContent = valueText;
+                        this._applyStateToElement(item.valueEl, state);
+                }
+                if (item.detailEl) {
+                        item.detailEl.textContent = detailText;
+                        this._applyStateToElement(item.detailEl, state);
+                }
+        }
+
+        _showLoadingPeriodHighlights() {
+                if (!this.periodHighlightsElements) {
+                        return;
+                }
+                this.periodHighlightsElements.container?.classList.add("is-loading");
+                const loadingText = this.loadingMessage;
+                this._setPeriodHighlightState("activeDays", "--", loadingText, "loading");
+                this._setPeriodHighlightState("averageQuestions", "--", loadingText, "loading");
+                this._setPeriodHighlightState("averageStudyTime", "--", loadingText, "loading");
+                this._setPeriodHighlightState("sessionsCompleted", "--", loadingText, "loading");
+        }
+
+        _showNoPeriodHighlights() {
+                if (!this.periodHighlightsElements) {
+                        return;
+                }
+                this.periodHighlightsElements.container?.classList.remove("is-loading");
+                this._setPeriodHighlightState(
+                        "activeDays",
+                        "--",
+                        this.periodHighlightDefaults.activeDays.detail,
+                        "empty"
+                );
+                this._setPeriodHighlightState(
+                        "averageQuestions",
+                        "--",
+                        this.periodHighlightDefaults.averageQuestions.detail,
+                        "empty"
+                );
+                this._setPeriodHighlightState(
+                        "averageStudyTime",
+                        "--",
+                        this.periodHighlightDefaults.averageStudyTime.detail,
+                        "empty"
+                );
+                this._setPeriodHighlightState(
+                        "sessionsCompleted",
+                        "--",
+                        this.periodHighlightDefaults.sessionsCompleted.detail,
+                        "empty"
+                );
+        }
+
+        _showPeriodHighlightsError(message) {
+                if (!this.periodHighlightsElements) {
+                        return;
+                }
+                this.periodHighlightsElements.container?.classList.remove("is-loading");
+                const detail = message || this.summaryErrorMessage;
+                this._setPeriodHighlightState("activeDays", "--", detail, "error");
+                this._setPeriodHighlightState("averageQuestions", "--", detail, "error");
+                this._setPeriodHighlightState("averageStudyTime", "--", detail, "error");
+                this._setPeriodHighlightState("sessionsCompleted", "--", detail, "error");
+        }
+
+        _formatAverageValue(value) {
+                const numeric = Number(value);
+                if (Number.isNaN(numeric) || numeric <= 0) {
+                        return "0";
+                }
+                const useDecimals = numeric < 10 && numeric % 1 !== 0;
+                return this._formatNumber(numeric, {
+                        minimumFractionDigits: useDecimals ? 1 : 0,
+                        maximumFractionDigits: useDecimals ? 1 : 0,
+                });
+        }
+
+        _formatDurationFromSeconds(seconds) {
+                const numeric = Number(seconds);
+                if (Number.isNaN(numeric) || numeric <= 0) {
+                        return "0 min";
+                }
+                const totalMinutes = Math.round(numeric / 60);
+                if (totalMinutes >= 60) {
+                        const hours = Math.floor(totalMinutes / 60);
+                        const remainingMinutes = totalMinutes % 60;
+                        if (remainingMinutes === 0) {
+                                return `${hours}h`;
+                        }
+                        return `${hours}h ${remainingMinutes}m`;
+                }
+                if (totalMinutes > 0) {
+                        return `${totalMinutes} min`;
+                }
+                const secondsValue = Math.max(Math.round(numeric), 1);
+                return `${secondsValue}s`;
+        }
+
+        _updatePeriodHighlights(summaryData) {
+                if (!this.periodHighlightsElements) {
+                        return;
+                }
+                this.periodHighlightsElements.container?.classList.remove("is-loading");
+
+                if (!summaryData || summaryData.has_activity === false) {
+                        this._showNoPeriodHighlights();
+                        return;
+                }
+
+                const activeDays = Number(summaryData.active_days) || 0;
+                const requestedDays = summaryData.requested_days;
+                const trackedDays = Number(summaryData.tracked_days) || 0;
+                const activeDayRatio = Number(summaryData.active_day_ratio) || 0;
+                const totalQuestions = Number(summaryData.total_questions_answered) || 0;
+                const avgQuestionsActive = Number(summaryData.average_questions_per_active_day) || 0;
+                const avgQuestionsPeriod = Number(summaryData.average_questions_per_day) || 0;
+                const totalStudySeconds = Number(summaryData.total_study_time_seconds) || 0;
+                const avgStudySeconds = Number(summaryData.average_study_time_per_active_day_seconds) || 0;
+                const sessionsCompleted = Number(summaryData.sessions_completed) || 0;
+                const avgSessionDurationSeconds = Number(summaryData.average_session_duration_seconds) || 0;
+                const lastActivityDate = summaryData.last_activity_date;
+
+                const activeDaysValueText = activeDays > 0
+                        ? this._formatNumber(activeDays)
+                        : "--";
+                let activeDaysDetailText = this.periodHighlightDefaults.activeDays.detail;
+                let activeState = activeDays > 0 ? "default" : "empty";
+                const totalDaysForRatio = requestedDays || trackedDays;
+                if (activeDays > 0 && totalDaysForRatio) {
+                        const ratioPercent = Math.round((activeDayRatio || 0) * 100);
+                        const ratioText = `${this._formatNumber(ratioPercent, { minimumFractionDigits: 0 })}%`;
+                        activeDaysDetailText = `Atividade em ${this._formatNumber(activeDays)} de ${this._formatNumber(totalDaysForRatio)} dias (${ratioText}).`;
+                } else if (activeDays > 0) {
+                        const plural = activeDays === 1 ? "dia" : "dias";
+                        activeDaysDetailText = `Atividade registrada em ${this._formatNumber(activeDays)} ${plural}.`;
+                }
+                this._setPeriodHighlightState(
+                        "activeDays",
+                        activeDaysValueText,
+                        activeDaysDetailText,
+                        activeState
+                );
+
+                const averageQuestionsValueText = avgQuestionsActive > 0
+                        ? this._formatAverageValue(avgQuestionsActive)
+                        : "--";
+                let averageQuestionsDetailText = this.periodHighlightDefaults.averageQuestions.detail;
+                let averageQuestionsState = avgQuestionsActive > 0 ? "default" : "empty";
+                if (avgQuestionsActive > 0) {
+                        const parts = [
+                                `Média de ${this._formatAverageValue(avgQuestionsActive)} questões nos dias ativos.`,
+                        ];
+                        if (avgQuestionsPeriod > 0 && totalDaysForRatio) {
+                                parts.push(
+                                        `No período completo: ${this._formatAverageValue(avgQuestionsPeriod)} por dia.`
+                                );
+                        }
+                        parts.push(`Total de ${this._formatQuestionCount(totalQuestions)} respondidas.`);
+                        averageQuestionsDetailText = parts.join(" ");
+                }
+                this._setPeriodHighlightState(
+                        "averageQuestions",
+                        averageQuestionsValueText,
+                        averageQuestionsDetailText,
+                        averageQuestionsState
+                );
+
+                const averageStudyValueText = avgStudySeconds > 0
+                        ? `${this._formatDurationFromSeconds(avgStudySeconds)} / dia`
+                        : "--";
+                let averageStudyDetailText = this.periodHighlightDefaults.averageStudyTime.detail;
+                let averageStudyState = avgStudySeconds > 0 ? "default" : "empty";
+                if (avgStudySeconds > 0) {
+                        const parts = [
+                                `Média de ${this._formatDurationFromSeconds(avgStudySeconds)} por dia ativo.`,
+                        ];
+                        if (totalStudySeconds > 0) {
+                                parts.push(`No período: ${this._formatDurationFromSeconds(totalStudySeconds)} dedicados aos estudos.`);
+                        }
+                        if (lastActivityDate) {
+                                const formattedDate = this._formatDate(lastActivityDate, {
+                                        day: "numeric",
+                                        month: "short",
+                                });
+                                parts.push(`Atualizado em ${formattedDate}.`);
+                        }
+                        averageStudyDetailText = parts.join(" ");
+                }
+                this._setPeriodHighlightState(
+                        "averageStudyTime",
+                        averageStudyValueText,
+                        averageStudyDetailText,
+                        averageStudyState
+                );
+
+                const sessionsValueText = sessionsCompleted > 0
+                        ? this._formatNumber(sessionsCompleted)
+                        : "--";
+                let sessionsDetailText = this.periodHighlightDefaults.sessionsCompleted.detail;
+                let sessionsState = sessionsCompleted > 0 ? "default" : "empty";
+                if (sessionsCompleted > 0) {
+                        const plural = sessionsCompleted === 1 ? "sessão" : "sessões";
+                        const parts = [
+                                `${this._formatNumber(sessionsCompleted)} ${plural} concluída${sessionsCompleted === 1 ? '' : 's'}.`,
+                        ];
+                        if (avgSessionDurationSeconds > 0) {
+                                parts.push(`Média de ${this._formatDurationFromSeconds(avgSessionDurationSeconds)} por sessão.`);
+                        }
+                        sessionsDetailText = parts.join(" ");
+                }
+                this._setPeriodHighlightState(
+                        "sessionsCompleted",
+                        sessionsValueText,
+                        sessionsDetailText,
+                        sessionsState
+                );
+        }
+
+        _resetTrendContainerState() {
+                const container = this.accuracyTrendElements?.container;
+                if (!container) {
+                        return;
+                }
+                container.classList.remove(
+                        "statistics-trend-card--up",
+                        "statistics-trend-card--down",
+                        "statistics-trend-card--flat",
+                        "statistics-trend-card--empty",
+                        "statistics-trend-card--error",
+                        "is-loading"
+                );
+        }
+
+        _setAccuracyTrendState({
+                valueText,
+                detailText,
+                badgeText,
+                icon,
+                modifierClass,
+                isLoading = false,
+        }) {
+                const elements = this.accuracyTrendElements;
+                if (!elements || !elements.container) {
+                        return;
+                }
+                this._resetTrendContainerState();
+                if (modifierClass) {
+                        elements.container.classList.add(modifierClass);
+                }
+                if (isLoading) {
+                        elements.container.classList.add("is-loading");
+                }
+                if (elements.valueEl) {
+                        elements.valueEl.textContent = valueText;
+                }
+                if (elements.detailEl) {
+                        elements.detailEl.textContent = detailText;
+                }
+                if (elements.badgeEl) {
+                        elements.badgeEl.textContent = badgeText;
+                }
+                if (elements.iconEl && icon) {
+                        elements.iconEl.textContent = icon;
+                }
+        }
+
+        _showLoadingAccuracyTrend() {
+                if (!this.accuracyTrendElements) {
+                        return;
+                }
+                this._setAccuracyTrendState({
+                        valueText: "--",
+                        detailText: this.loadingMessage,
+                        badgeText: "Carregando",
+                        icon: "hourglass_empty",
+                        modifierClass: "statistics-trend-card--flat",
+                        isLoading: true,
+                });
+        }
+
+        _showEmptyAccuracyTrend() {
+                if (!this.accuracyTrendElements) {
+                        return;
+                }
+                this._setAccuracyTrendState({
+                        valueText: "--",
+                        detailText: this.trendDefaults.detail,
+                        badgeText: this.trendDefaults.badge,
+                        icon: "trending_flat",
+                        modifierClass: "statistics-trend-card--empty",
+                });
+        }
+
+        _showErrorAccuracyTrend(message) {
+                if (!this.accuracyTrendElements) {
+                        return;
+                }
+                this._setAccuracyTrendState({
+                        valueText: "--",
+                        detailText: message || this.trendErrorMessage,
+                        badgeText: "Erro",
+                        icon: "error",
+                        modifierClass: "statistics-trend-card--error",
+                });
+        }
+
+        _updateAccuracyTrend(trendData) {
+                if (!this.accuracyTrendElements) {
+                        return;
+                }
+
+                if (!trendData || trendData.has_data !== true) {
+                        this._showEmptyAccuracyTrend();
+                        return;
+                }
+
+                const finalAccuracy = Number(trendData.end_accuracy);
+                const startAccuracy = Number(trendData.start_accuracy);
+                const delta = Number(trendData.delta) || 0;
+                const direction = trendData.direction || (delta > 0 ? "up" : delta < 0 ? "down" : "flat");
+                const hasMultiplePoints = Boolean(trendData.has_multiple_points);
+                const lastDate = trendData.last_date
+                        ? this._formatDate(trendData.last_date, { day: "numeric", month: "short" })
+                        : null;
+
+                const accuracyValueText = Number.isFinite(finalAccuracy)
+                        ? `${this._formatNumber(finalAccuracy, {
+                                  minimumFractionDigits: 0,
+                                  maximumFractionDigits: 1,
+                          })}%`
+                        : "--";
+
+                let modifierClass = "statistics-trend-card--flat";
+                let badgeText = this.trendDefaults.badge;
+                let iconName = "trending_flat";
+
+                if (direction === "up") {
+                        modifierClass = "statistics-trend-card--up";
+                        badgeText = `${delta > 0 ? "+" : ""}${this._formatNumber(delta, {
+                                minimumFractionDigits: 0,
+                                maximumFractionDigits: 1,
+                        })} pts`;
+                        iconName = "trending_up";
+                } else if (direction === "down") {
+                        modifierClass = "statistics-trend-card--down";
+                        badgeText = `${this._formatNumber(delta, {
+                                minimumFractionDigits: 0,
+                                maximumFractionDigits: 1,
+                        })} pts`;
+                        iconName = "trending_down";
+                } else {
+                        badgeText = "Estável";
+                }
+
+                let detailText = this.trendDefaults.detail;
+                if (hasMultiplePoints && Number.isFinite(startAccuracy) && Number.isFinite(finalAccuracy)) {
+                        const startText = `${this._formatNumber(startAccuracy, {
+                                minimumFractionDigits: 0,
+                                maximumFractionDigits: 1,
+                        })}%`;
+                        const endText = `${this._formatNumber(finalAccuracy, {
+                                minimumFractionDigits: 0,
+                                maximumFractionDigits: 1,
+                        })}%`;
+                        const periodLabel = this._getCurrentPeriodLabel();
+                        const context = periodLabel ? `nos ${periodLabel}` : "no período analisado";
+                        detailText = `Saiu de ${startText} para ${endText} ${context}.`;
+                } else if (Number.isFinite(finalAccuracy)) {
+                        if (lastDate) {
+                                detailText = `Último registro em ${lastDate}: ${accuracyValueText} de acerto.`;
+                        } else {
+                                detailText = `Precisão atual de ${accuracyValueText}.`;
+                        }
+                }
+
+                if (lastDate && hasMultiplePoints) {
+                        detailText += ` Atualizado em ${lastDate}.`;
+                }
+
+                this._setAccuracyTrendState({
+                        valueText: accuracyValueText,
+                        detailText,
+                        badgeText,
+                        icon: iconName,
+                        modifierClass,
+                });
         }
 
         _setInsight(insightKey, valueText, detailText) {
@@ -818,12 +1289,42 @@ export default class StatisticsChartManager {
                 }
         }
 
-        _formatNumber(value) {
+        _formatNumber(value, options = {}) {
                 const numericValue = Number(value);
                 if (Number.isNaN(numericValue) || value === null || value === undefined) {
+                        if (typeof options.fallback === "string") {
+                                return options.fallback;
+                        }
+                        if (typeof options.minimumFractionDigits === "number" && options.minimumFractionDigits > 0) {
+                                return Number(0).toLocaleString("pt-BR", {
+                                        minimumFractionDigits: options.minimumFractionDigits,
+                                        maximumFractionDigits:
+                                                typeof options.maximumFractionDigits === "number"
+                                                        ? Math.max(options.maximumFractionDigits, options.minimumFractionDigits)
+                                                        : options.minimumFractionDigits,
+                                });
+                        }
                         return "0";
                 }
-                return numericValue.toLocaleString("pt-BR");
+                const localeOptions = {};
+                if (typeof options.minimumFractionDigits === "number") {
+                        localeOptions.minimumFractionDigits = options.minimumFractionDigits;
+                }
+                if (typeof options.maximumFractionDigits === "number") {
+                        localeOptions.maximumFractionDigits = Math.max(
+                                options.maximumFractionDigits,
+                                localeOptions.minimumFractionDigits ?? 0
+                        );
+                } else if (
+                        typeof localeOptions.minimumFractionDigits === "number" &&
+                        localeOptions.minimumFractionDigits > 0
+                ) {
+                        localeOptions.maximumFractionDigits = Math.max(
+                                localeOptions.minimumFractionDigits,
+                                2
+                        );
+                }
+                return numericValue.toLocaleString("pt-BR", localeOptions);
         }
 
         _formatQuestionCount(count) {

--- a/quiz/templates/quiz/account_page.html
+++ b/quiz/templates/quiz/account_page.html
@@ -405,63 +405,122 @@
                             </header>
 
                             <div class="statistics-overview">
-                                <div class="key-metrics-summary" id="key-metrics-summary-container">
-                                    <div class="metric-card">
-                                        <span class="material-symbols-outlined metric-card__icon" aria-hidden="true">functions</span>
-                                        <span class="metric-card__label">Total de questões</span>
-                                        <span class="metric-card__value" id="metric-total-questions">--</span>
+                                <div class="statistics-overview__primary">
+                                    <div class="key-metrics-summary" id="key-metrics-summary-container">
+                                        <div class="metric-card">
+                                            <span class="material-symbols-outlined metric-card__icon" aria-hidden="true">functions</span>
+                                            <span class="metric-card__label">Total de questões</span>
+                                            <span class="metric-card__value" id="metric-total-questions">--</span>
+                                        </div>
+                                        <div class="metric-card">
+                                            <span class="material-symbols-outlined metric-card__icon" aria-hidden="true">local_fire_department</span>
+                                            <span class="metric-card__label">Sequência máx.</span>
+                                            <span class="metric-card__value" id="metric-max-streak">--</span>
+                                        </div>
+                                        <div class="metric-card">
+                                            <span class="material-symbols-outlined metric-card__icon" aria-hidden="true">military_tech</span>
+                                            <span class="metric-card__label">Pontuação total</span>
+                                            <span class="metric-card__value" id="metric-total-score">--</span>
+                                        </div>
+                                        <div class="metric-card">
+                                            <span class="material-symbols-outlined metric-card__icon" aria-hidden="true">timer</span>
+                                            <span class="metric-card__label">Tempo de estudo</span>
+                                            <span class="metric-card__value" id="metric-total-study-time">--</span>
+                                        </div>
                                     </div>
-                                    <div class="metric-card">
-                                        <span class="material-symbols-outlined metric-card__icon" aria-hidden="true">local_fire_department</span>
-                                        <span class="metric-card__label">Sequência máx.</span>
-                                        <span class="metric-card__value" id="metric-max-streak">--</span>
-                                    </div>
-                                    <div class="metric-card">
-                                        <span class="material-symbols-outlined metric-card__icon" aria-hidden="true">military_tech</span>
-                                        <span class="metric-card__label">Pontuação total</span>
-                                        <span class="metric-card__value" id="metric-total-score">--</span>
-                                    </div>
-                                    <div class="metric-card">
-                                        <span class="material-symbols-outlined metric-card__icon" aria-hidden="true">timer</span>
-                                        <span class="metric-card__label">Tempo de estudo</span>
-                                        <span class="metric-card__value" id="metric-total-study-time">--</span>
+
+                                    <div class="statistics-insights" aria-live="polite">
+                                        <article class="insight-card" data-insight="top-category">
+                                            <span class="material-symbols-outlined insight-card__icon" aria-hidden="true">military_tech</span>
+                                            <div class="insight-card__content">
+                                                <p class="insight-card__label">Categoria destaque</p>
+                                                <p class="insight-card__value" id="insight-best-category">--</p>
+                                                <p class="insight-card__description" id="insight-best-category-detail">Complete quizzes para desbloquear esta informação.</p>
+                                            </div>
+                                        </article>
+                                        <article class="insight-card" data-insight="difficulty">
+                                            <span class="material-symbols-outlined insight-card__icon" aria-hidden="true">target</span>
+                                            <div class="insight-card__content">
+                                                <p class="insight-card__label">Dificuldade em alta</p>
+                                                <p class="insight-card__value" id="insight-best-difficulty">--</p>
+                                                <p class="insight-card__description" id="insight-best-difficulty-detail">Resolva questões para descobrir em qual nível você mais acerta.</p>
+                                            </div>
+                                        </article>
+                                        <article class="insight-card" data-insight="productive-day">
+                                            <span class="material-symbols-outlined insight-card__icon" aria-hidden="true">calendar_month</span>
+                                            <div class="insight-card__content">
+                                                <p class="insight-card__label">Dia mais focado</p>
+                                                <p class="insight-card__value" id="insight-productive-day">--</p>
+                                                <p class="insight-card__description" id="insight-productive-day-detail">Assim que houver atividades recentes, destacaremos o melhor dia.</p>
+                                            </div>
+                                        </article>
+                                        <article class="insight-card" data-insight="accuracy">
+                                            <span class="material-symbols-outlined insight-card__icon" aria-hidden="true">monitoring</span>
+                                            <div class="insight-card__content">
+                                                <p class="insight-card__label">Precisão geral</p>
+                                                <p class="insight-card__value" id="insight-accuracy">--</p>
+                                                <p class="insight-card__description" id="insight-accuracy-detail">Suas taxas de acerto aparecerão aqui quando você responder questões.</p>
+                                            </div>
+                                        </article>
                                     </div>
                                 </div>
 
-                                <div class="statistics-insights" aria-live="polite">
-                                    <article class="insight-card" data-insight="top-category">
-                                        <span class="material-symbols-outlined insight-card__icon" aria-hidden="true">military_tech</span>
-                                        <div class="insight-card__content">
-                                            <p class="insight-card__label">Categoria destaque</p>
-                                            <p class="insight-card__value" id="insight-best-category">--</p>
-                                            <p class="insight-card__description" id="insight-best-category-detail">Complete quizzes para desbloquear esta informação.</p>
+                                <aside class="statistics-overview__side">
+                                    <section class="statistics-trend-card statistics-trend-card--empty" id="accuracy-trend-card" aria-live="polite">
+                                        <header class="statistics-trend-card__header">
+                                            <span class="material-symbols-outlined statistics-trend-card__icon" id="trend-accuracy-icon" aria-hidden="true">trending_flat</span>
+                                            <div class="statistics-trend-card__meta">
+                                                <p class="statistics-trend-card__label">Variação da precisão</p>
+                                                <span class="statistics-trend-card__badge" id="trend-accuracy-badge">Sem dados</span>
+                                            </div>
+                                        </header>
+                                        <div class="statistics-trend-card__body">
+                                            <p class="statistics-trend-card__value" id="trend-accuracy-value">--</p>
+                                            <p class="statistics-trend-card__detail" id="trend-accuracy-detail">Complete quizzes para acompanhar a evolução do seu desempenho.</p>
                                         </div>
-                                    </article>
-                                    <article class="insight-card" data-insight="difficulty">
-                                        <span class="material-symbols-outlined insight-card__icon" aria-hidden="true">target</span>
-                                        <div class="insight-card__content">
-                                            <p class="insight-card__label">Dificuldade em alta</p>
-                                            <p class="insight-card__value" id="insight-best-difficulty">--</p>
-                                            <p class="insight-card__description" id="insight-best-difficulty-detail">Resolva questões para descobrir em qual nível você mais acerta.</p>
-                                        </div>
-                                    </article>
-                                    <article class="insight-card" data-insight="productive-day">
-                                        <span class="material-symbols-outlined insight-card__icon" aria-hidden="true">calendar_month</span>
-                                        <div class="insight-card__content">
-                                            <p class="insight-card__label">Dia mais focado</p>
-                                            <p class="insight-card__value" id="insight-productive-day">--</p>
-                                            <p class="insight-card__description" id="insight-productive-day-detail">Assim que houver atividades recentes, destacaremos o melhor dia.</p>
-                                        </div>
-                                    </article>
-                                    <article class="insight-card" data-insight="accuracy">
-                                        <span class="material-symbols-outlined insight-card__icon" aria-hidden="true">monitoring</span>
-                                        <div class="insight-card__content">
-                                            <p class="insight-card__label">Precisão geral</p>
-                                            <p class="insight-card__value" id="insight-accuracy">--</p>
-                                            <p class="insight-card__description" id="insight-accuracy-detail">Suas taxas de acerto aparecerão aqui quando você responder questões.</p>
-                                        </div>
-                                    </article>
-                                </div>
+                                    </section>
+
+                                    <section class="period-highlights" aria-live="polite">
+                                        <header class="period-highlights__header">
+                                            <h3 class="period-highlights__title">Resumo do período</h3>
+                                            <p class="period-highlights__subtitle">Visão geral do ritmo de estudos</p>
+                                        </header>
+                                        <ul class="period-highlights__list" id="statistics-period-highlights">
+                                            <li class="period-highlights__item">
+                                                <span class="material-symbols-outlined period-highlights__icon" aria-hidden="true">calendar_today</span>
+                                                <div class="period-highlights__content">
+                                                    <p class="period-highlights__label">Dias ativos</p>
+                                                    <p class="period-highlights__value" id="summary-active-days">--</p>
+                                                    <p class="period-highlights__detail" id="summary-active-days-detail">Monte uma rotina consistente de estudos.</p>
+                                                </div>
+                                            </li>
+                                            <li class="period-highlights__item">
+                                                <span class="material-symbols-outlined period-highlights__icon" aria-hidden="true">task_alt</span>
+                                                <div class="period-highlights__content">
+                                                    <p class="period-highlights__label">Questões por dia</p>
+                                                    <p class="period-highlights__value" id="summary-average-questions">--</p>
+                                                    <p class="period-highlights__detail" id="summary-average-questions-detail">Resolva perguntas com frequência para ver sua média.</p>
+                                                </div>
+                                            </li>
+                                            <li class="period-highlights__item">
+                                                <span class="material-symbols-outlined period-highlights__icon" aria-hidden="true">hourglass_bottom</span>
+                                                <div class="period-highlights__content">
+                                                    <p class="period-highlights__label">Tempo médio de estudo</p>
+                                                    <p class="period-highlights__value" id="summary-average-study-time">--</p>
+                                                    <p class="period-highlights__detail" id="summary-average-study-time-detail">Complete sessões para calcular seu tempo médio diário.</p>
+                                                </div>
+                                            </li>
+                                            <li class="period-highlights__item">
+                                                <span class="material-symbols-outlined period-highlights__icon" aria-hidden="true">workspace_premium</span>
+                                                <div class="period-highlights__content">
+                                                    <p class="period-highlights__label">Sessões concluídas</p>
+                                                    <p class="period-highlights__value" id="summary-sessions-completed">--</p>
+                                                    <p class="period-highlights__detail" id="summary-sessions-completed-detail">Inicie um quiz para analisar seu ritmo de conclusão.</p>
+                                                </div>
+                                            </li>
+                                        </ul>
+                                    </section>
+                                </aside>
                             </div>
 
                             <div class="stats-grid">

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -131,6 +131,24 @@ def _get_key_metrics(user: User, daily_stats_period_qs):
     return StatisticsService.get_key_metrics(user, daily_stats_period_qs)
 
 
+def _resolve_period_day_count(period_str: str | None) -> int | None:
+    """Converte o parâmetro de período (ex.: '30d', '7') para a quantidade de dias."""
+    normalized = str(period_str).strip().lower() if period_str is not None else "30d"
+
+    if normalized == "all":
+        return None
+
+    if normalized.endswith("d"):
+        normalized = normalized[:-1]
+
+    try:
+        days = int(normalized)
+    except (TypeError, ValueError):
+        return None
+
+    return days if days > 0 else None
+
+
 def _get_overall_accuracy_data(daily_stats_period_qs):
     total_questions_answered = daily_stats_period_qs.aggregate(
         total=Sum('perguntas_respondidas_dia'))['total'] or 0
@@ -437,6 +455,115 @@ def _get_study_time_detail_data(user: User):
     return {
         'labels': day_labels_pt_ordered_sun_first,
         'data': ordered_minutes_data
+    }
+
+
+def _get_period_activity_summary(daily_stats_period_qs, user_sessions_period_qs, requested_days: int | None):
+    aggregates = daily_stats_period_qs.aggregate(
+        total_questions=Sum('perguntas_respondidas_dia'),
+        total_study_time=Sum('tempo_estudo_segundos_dia'),
+    )
+    total_questions = aggregates.get('total_questions') or 0
+    total_study_time = aggregates.get('total_study_time') or 0
+
+    active_days = daily_stats_period_qs.filter(
+        perguntas_respondidas_dia__gt=0
+    ).values('data_estatistica').distinct().count()
+    tracked_days = daily_stats_period_qs.values('data_estatistica').distinct().count()
+
+    average_questions_per_active_day = (
+        total_questions / active_days if active_days else 0
+    )
+
+    denominator_days = requested_days or tracked_days or active_days
+    average_questions_per_day = (
+        total_questions / denominator_days if denominator_days else 0
+    )
+
+    average_study_time_per_active_day_seconds = (
+        total_study_time / active_days if active_days else 0
+    )
+
+    session_durations = []
+    for session in user_sessions_period_qs.values(
+        'tempo_total_segundos', 'data_inicio', 'data_fim'
+    ):
+        duration_seconds = session.get('tempo_total_segundos')
+        start_dt = session.get('data_inicio')
+        end_dt = session.get('data_fim')
+        if duration_seconds is None and start_dt and end_dt:
+            duration_seconds = int(max((end_dt - start_dt).total_seconds(), 0))
+        if duration_seconds is not None and duration_seconds >= 0:
+            session_durations.append(duration_seconds)
+
+    average_session_duration_seconds = 0
+    if session_durations:
+        average_session_duration_seconds = sum(session_durations) / len(session_durations)
+
+    last_activity_date = daily_stats_period_qs.order_by('-data_estatistica').values_list(
+        'data_estatistica', flat=True
+    ).first()
+
+    denominator_for_ratio = (denominator_days or 0)
+    active_day_ratio = (
+        (active_days / denominator_for_ratio) if denominator_for_ratio else 0
+    )
+
+    return {
+        'active_days': active_days,
+        'tracked_days': tracked_days,
+        'requested_days': requested_days,
+        'total_questions_answered': total_questions,
+        'average_questions_per_active_day': round(average_questions_per_active_day, 2) if average_questions_per_active_day else 0,
+        'average_questions_per_day': round(average_questions_per_day, 2) if average_questions_per_day else 0,
+        'total_study_time_seconds': total_study_time,
+        'average_study_time_per_active_day_seconds': round(average_study_time_per_active_day_seconds, 2) if average_study_time_per_active_day_seconds else 0,
+        'sessions_completed': user_sessions_period_qs.count(),
+        'sessions_with_duration': len(session_durations),
+        'average_session_duration_seconds': round(average_session_duration_seconds, 2) if average_session_duration_seconds else 0,
+        'active_day_ratio': round(active_day_ratio, 4) if active_day_ratio else 0,
+        'last_activity_date': last_activity_date.isoformat() if last_activity_date else None,
+        'has_activity': bool(total_questions or total_study_time or session_durations),
+    }
+
+
+def _get_accuracy_trend_summary(learning_progress_data):
+    valid_points = [
+        point for point in learning_progress_data
+        if point and point.get('daily_accuracy') is not None and point.get('date_str')
+    ]
+
+    if not valid_points:
+        return {
+            'has_data': False,
+            'data_point_count': 0,
+        }
+
+    first_point = valid_points[0]
+    last_point = valid_points[-1]
+
+    start_accuracy = float(first_point.get('daily_accuracy') or 0)
+    end_accuracy = float(last_point.get('daily_accuracy') or 0)
+    delta = round(end_accuracy - start_accuracy, 1)
+
+    direction_threshold = 0.1
+    if delta > direction_threshold:
+        direction = 'up'
+    elif delta < -direction_threshold:
+        direction = 'down'
+    else:
+        direction = 'flat'
+
+    return {
+        'has_data': True,
+        'data_point_count': len(valid_points),
+        'has_multiple_points': len(valid_points) > 1,
+        'start_accuracy': round(start_accuracy, 1),
+        'end_accuracy': round(end_accuracy, 1),
+        'delta': delta,
+        'direction': direction,
+        'first_date': first_point.get('date_str'),
+        'last_date': last_point.get('date_str'),
     }
 
 
@@ -1147,12 +1274,21 @@ def api_get_user_statistics_view(request):
         )
 
         key_metrics = _get_key_metrics(user, daily_stats_period_qs)
+        requested_days = _resolve_period_day_count(period)
+        period_summary = _get_period_activity_summary(
+            daily_stats_period_qs,
+            user_sessions_period_qs,
+            requested_days,
+        )
         overall_accuracy_data = _get_overall_accuracy_data(
             daily_stats_period_qs)
         category_performance_list = _get_category_performance_data(
             user_sessions_period_qs)
         learning_progress_data = _get_learning_progress_data(
             daily_stats_period_qs)
+        accuracy_trend_summary = _get_accuracy_trend_summary(
+            learning_progress_data
+        )
         study_heatmap_data = _get_study_heatmap_data(daily_stats_period_qs)
         study_time_chart_data = _get_study_time_detail_data(user)
         difficulty_performance_list = _get_difficulty_performance_data(
@@ -1162,9 +1298,11 @@ def api_get_user_statistics_view(request):
             'status': 'success',
             'period_applied': period,
             'key_metrics': key_metrics,
+            'period_summary': period_summary,
             'overall_accuracy': overall_accuracy_data,
             'category_performance': category_performance_list,
             'learning_progress': learning_progress_data,
+            'accuracy_trend': accuracy_trend_summary,
             'study_heatmap': study_heatmap_data,
             'study_time_detail': study_time_chart_data,
             'difficulty_performance': difficulty_performance_list,


### PR DESCRIPTION
## Summary
- redesign the statistics tab layout on the account page with a dedicated trend card and period highlights
- update dashboard styling to match the site’s card patterns and add visual states for the new widgets
- extend statistics fetching to return period summaries and accuracy trends and update the chart manager to surface the new data

## Testing
- `python manage.py test quiz` *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cedf6fe7188333af172f8c56b6e9e2