### PR TITLE
feat: refresh dark mode palette

### DIFF
--- a/assets/css/base/base.css
+++ b/assets/css/base/base.css
@@ -10,12 +10,13 @@ html {
 
 body {
     font-family: var(--font-family-sans);
-    color: var(--color-gray-900);
-    background-color: var(--color-gray-100);
+    color: var(--body-text-color, var(--color-text-primary, var(--color-gray-900)));
+    background-color: var(--body-background-color, var(--color-gray-100));
     line-height: 1.6;
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+    transition: background-color 0.35s ease, color 0.35s ease;
 }
 
 *:focus {

--- a/assets/css/base/variables.css
+++ b/assets/css/base/variables.css
@@ -1,5 +1,6 @@
 /* assets/css/base/variables.css */
 :root {
+    color-scheme: light;
     /* Cores principais */
     --color-primary-dark: #0d3b66;
     --color-primary-dark-rgb: 13, 59, 102; /* Adicionado para rgba() */
@@ -45,6 +46,67 @@
     --color-gray-50: #fbfcfe;
     --color-white: #ffffff;
     --color-dark: #333;
+
+    /* Superfícies e fundos temáticos */
+    --body-background-color: var(--surface-page, var(--color-gray-100));
+    --body-text-color: var(--color-text-primary, var(--color-gray-900));
+    --surface-page: var(--color-gray-50);
+    --surface-card: var(--color-white);
+    --surface-card-muted: var(--color-gray-50);
+    --surface-header: var(--color-white);
+    --surface-nav: var(--color-white);
+    --surface-bottom-nav: var(--color-white);
+    --surface-panel: var(--color-white);
+    --surface-panel-alt: var(--color-gray-50);
+    --surface-overlay: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.18);
+
+    --footer-bg-color: var(--color-gray-900);
+    --footer-text-color: var(--color-gray-300);
+    --footer-border-color: var(--color-gray-800);
+
+    /* Bordas e sombras reutilizáveis */
+    --border-subtle-color: var(--color-gray-300);
+    --border-strong-color: var(--color-gray-400);
+    --card-box-shadow: var(--shadow-md);
+    --card-border-color: var(--color-gray-400);
+    --card-header-border-bottom-color: var(--color-gray-300);
+    --card-footer-border-top-color: var(--color-gray-300);
+    --card-aviso-bg-color: var(--surface-card-muted, var(--color-gray-50));
+    --card-aviso-border-color: var(--border-subtle-color, var(--color-gray-300));
+    --card-placeholder-bg-color: var(--surface-card-muted, var(--color-gray-50));
+    --card-placeholder-border-color: var(--border-subtle-color, var(--color-gray-300));
+    --card-result-bg: var(--surface-card, var(--color-white));
+    --card-result-shadow: 0 20px 60px -10px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.15),
+                0 8px 20px -5px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.1);
+
+    /* Valores padrão usados em componentes específicos */
+    --hero-bg-gradient: linear-gradient(135deg,
+            var(--color-primary-dark) 0%,
+            var(--color-primary-medium) 60%,
+            var(--color-secondary-green) 100%);
+    --hero-text-color: var(--color-white);
+    --question-grid-item-bg: var(--color-white);
+    --question-grid-item-border-color: var(--color-gray-200);
+    --question-grid-item-color: var(--color-text-secondary);
+    --answer-bg-color: var(--color-white);
+    --answer-border-color: var(--color-gray-300);
+    --filter-panel-shadow: -4px 0 25px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.12);
+    --filter-panel-scroll-thumb-hover: var(--color-gray-400, #ced4da);
+    --explanation-modal-shadow: 0 10px 35px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.15),
+                0 4px 12px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.1);
+    --explanation-modal-scroll-track: var(--color-gray-50);
+    --explanation-modal-scroll-thumb: var(--color-gray-300);
+    --explanation-modal-scroll-thumb-hover: var(--color-gray-400);
+    --challenge-hub-shadow: var(--shadow-md);
+    --challenge-hub-bg: var(--surface-card-muted, var(--color-gray-100));
+    --challenge-card-bg: var(--surface-card, var(--color-white));
+    --challenge-card-border-color: var(--border-subtle-color, var(--color-gray-300));
+    --challenge-card-shadow: var(--shadow-sm);
+    --challenge-card-shadow-hover: var(--shadow-lg);
+    --challenge-card-icon-bg: var(--color-primary-light);
+    --challenge-card-disabled-bg: var(--color-gray-200);
+    --score-panel-border-color: var(--border-subtle-color, var(--color-gray-200));
+    --score-panel-divider-color: var(--border-subtle-color, var(--color-gray-300));
 
     /* Texto */
     --color-text-primary: var(--color-gray-900);
@@ -146,4 +208,236 @@
     --main-nav-height: 48px; /* Ajustado para uma nav um pouco menor */
     --footer-height: 60px; /* Ajustado */
     --score-panel-width-desktop: 260px; /* Largura do painel de score no desktop */
+}
+
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme='light']) {
+        color-scheme: dark;
+
+        --color-gray-900: #e2e8f0;
+        --color-gray-800: #cbd5f5;
+        --color-gray-700: #a9b7ca;
+        --color-gray-600: #8c9bb2;
+        --color-gray-500: #6b7a92;
+        --color-gray-400: #4c5567;
+        --color-gray-300: #384152;
+        --color-gray-200: #2c3445;
+        --color-gray-100: #1f2735;
+        --color-gray-50: #171f2b;
+        --color-dark: #0b1120;
+
+        --body-background-color: #0f172a;
+        --body-text-color: var(--color-text-primary);
+        --surface-page: #0f172a;
+        --surface-card: #152235;
+        --surface-card-muted: #111d2c;
+        --surface-header: rgba(15, 23, 42, 0.92);
+        --surface-nav: rgba(15, 23, 42, 0.95);
+        --surface-bottom-nav: rgba(15, 23, 42, 0.95);
+        --surface-panel: #182437;
+        --surface-panel-alt: #1c2a3d;
+        --surface-overlay: rgba(8, 15, 28, 0.72);
+
+        --border-subtle-color: rgba(148, 163, 184, 0.24);
+        --border-strong-color: rgba(148, 163, 184, 0.38);
+        --card-box-shadow: 0 18px 42px rgba(8, 15, 28, 0.55);
+        --card-border-color: rgba(148, 163, 184, 0.22);
+        --card-header-border-bottom-color: rgba(148, 163, 184, 0.16);
+        --card-footer-border-top-color: rgba(148, 163, 184, 0.16);
+        --card-aviso-bg-color: rgba(17, 28, 44, 0.82);
+        --card-aviso-border-color: rgba(148, 163, 184, 0.24);
+        --card-placeholder-bg-color: rgba(17, 28, 44, 0.85);
+        --card-placeholder-border-color: rgba(148, 163, 184, 0.26);
+        --card-result-bg: var(--surface-card);
+        --card-result-shadow: 0 24px 65px rgba(8, 15, 28, 0.6);
+
+        --color-text-primary: #e2e8f0;
+        --color-text-secondary: #c0ccdc;
+        --color-text-muted: #94a3b8;
+        --color-text-link: #8dbbff;
+        --color-text-link-hover: #a8d4ff;
+
+        --hero-text-color: #f5f9ff;
+        --hero-bg-gradient: linear-gradient(135deg, #0b2f55 0%, #154170 55%, #1f7a78 100%);
+
+        --main-nav-bg-color: var(--surface-nav);
+        --main-nav-border-bottom-color: rgba(148, 163, 184, 0.18);
+        --bottom-nav-bg-color: var(--surface-bottom-nav);
+        --bottom-nav-border-top-color: rgba(148, 163, 184, 0.18);
+        --bottom-nav-link-color: #cbd5f5;
+        --bottom-nav-link-hover-color: #f4faff;
+        --bottom-nav-link-active-color: #f8fbff;
+        --bottom-nav-link-hover-bg: rgba(148, 163, 184, 0.14);
+        --bottom-nav-link-active-bg: rgba(59, 130, 246, 0.2);
+
+        --footer-bg-color: #0b1220;
+        --footer-text-color: #94a3b8;
+        --footer-border-color: rgba(148, 163, 184, 0.24);
+
+        --score-panel-bg-color: var(--surface-panel);
+        --score-panel-bg-color-mobile: var(--surface-panel);
+        --score-panel-border-color: rgba(148, 163, 184, 0.22);
+        --score-panel-shadow: 0 18px 45px rgba(8, 15, 28, 0.45);
+        --score-panel-divider-color: rgba(148, 163, 184, 0.18);
+        --timer-color: #f1f5f9;
+        --timer-label-color: #a5b4ca;
+        --stat-label-color: #a5b4ca;
+        --stat-value-color: #e2e8f0;
+
+        --question-grid-item-bg: rgba(17, 26, 40, 0.95);
+        --question-grid-item-border-color: rgba(148, 163, 184, 0.25);
+        --question-grid-item-color: #cbd5f5;
+
+        --answer-bg-color: rgba(18, 29, 44, 0.85);
+        --answer-border-color: rgba(148, 163, 184, 0.28);
+
+        --stat-card-bg: rgba(15, 23, 42, 0.68);
+        --stat-card-border-color: rgba(148, 163, 184, 0.22);
+        --stat-card-hover-bg: rgba(17, 29, 48, 0.85);
+        --stat-card-hover-shadow: 0 12px 35px rgba(8, 15, 28, 0.45);
+
+        --filter-panel-bg-color: var(--surface-panel);
+        --filter-panel-header-bg-color: var(--surface-panel);
+        --filter-panel-border-color: rgba(148, 163, 184, 0.2);
+        --filter-panel-overlay-color: rgba(8, 15, 28, 0.6);
+        --filter-panel-scroll-track: rgba(148, 163, 184, 0.08);
+        --filter-panel-scroll-thumb: rgba(148, 163, 184, 0.22);
+        --filter-panel-scroll-thumb-hover: rgba(148, 163, 184, 0.32);
+        --filter-panel-shadow: -4px 0 35px rgba(8, 15, 28, 0.45);
+
+        --explanation-modal-overlay-color: rgba(8, 15, 28, 0.7);
+        --explanation-modal-bg-color: var(--surface-panel);
+        --explanation-modal-section-bg: rgba(15, 23, 42, 0.9);
+        --explanation-modal-border-color: rgba(148, 163, 184, 0.22);
+        --explanation-modal-shadow: 0 18px 45px rgba(8, 15, 28, 0.5);
+        --explanation-modal-scroll-track: rgba(17, 28, 44, 0.85);
+        --explanation-modal-scroll-thumb: rgba(148, 163, 184, 0.28);
+        --explanation-modal-scroll-thumb-hover: rgba(148, 163, 184, 0.38);
+
+        --challenge-hub-shadow: 0 18px 45px rgba(8, 15, 28, 0.45);
+        --challenge-hub-bg: rgba(17, 28, 44, 0.92);
+        --challenge-card-bg: var(--surface-card);
+        --challenge-card-border-color: rgba(148, 163, 184, 0.22);
+        --challenge-card-shadow: 0 15px 35px rgba(8, 15, 28, 0.5);
+        --challenge-card-shadow-hover: 0 20px 45px rgba(8, 15, 28, 0.6);
+        --challenge-card-icon-bg: rgba(59, 130, 246, 0.18);
+        --challenge-card-disabled-bg: rgba(28, 36, 52, 0.65);
+
+        --modal-backdrop-bg: rgba(8, 15, 28, 0.75);
+    }
+}
+
+:where(:root[data-theme='dark'], body[data-theme='dark'], body.dark-theme) {
+    color-scheme: dark;
+
+    --color-gray-900: #e2e8f0;
+    --color-gray-800: #cbd5f5;
+    --color-gray-700: #a9b7ca;
+    --color-gray-600: #8c9bb2;
+    --color-gray-500: #6b7a92;
+    --color-gray-400: #4c5567;
+    --color-gray-300: #384152;
+    --color-gray-200: #2c3445;
+    --color-gray-100: #1f2735;
+    --color-gray-50: #171f2b;
+    --color-dark: #0b1120;
+
+    --body-background-color: #0f172a;
+    --body-text-color: var(--color-text-primary);
+    --surface-page: #0f172a;
+    --surface-card: #152235;
+    --surface-card-muted: #111d2c;
+    --surface-header: rgba(15, 23, 42, 0.92);
+    --surface-nav: rgba(15, 23, 42, 0.95);
+    --surface-bottom-nav: rgba(15, 23, 42, 0.95);
+    --surface-panel: #182437;
+    --surface-panel-alt: #1c2a3d;
+    --surface-overlay: rgba(8, 15, 28, 0.72);
+
+    --border-subtle-color: rgba(148, 163, 184, 0.24);
+    --border-strong-color: rgba(148, 163, 184, 0.38);
+    --card-box-shadow: 0 18px 42px rgba(8, 15, 28, 0.55);
+    --card-border-color: rgba(148, 163, 184, 0.22);
+    --card-header-border-bottom-color: rgba(148, 163, 184, 0.16);
+    --card-footer-border-top-color: rgba(148, 163, 184, 0.16);
+    --card-aviso-bg-color: rgba(17, 28, 44, 0.82);
+    --card-aviso-border-color: rgba(148, 163, 184, 0.24);
+    --card-placeholder-bg-color: rgba(17, 28, 44, 0.85);
+    --card-placeholder-border-color: rgba(148, 163, 184, 0.26);
+    --card-result-bg: var(--surface-card);
+    --card-result-shadow: 0 24px 65px rgba(8, 15, 28, 0.6);
+
+    --color-text-primary: #e2e8f0;
+    --color-text-secondary: #c0ccdc;
+    --color-text-muted: #94a3b8;
+    --color-text-link: #8dbbff;
+    --color-text-link-hover: #a8d4ff;
+
+    --hero-text-color: #f5f9ff;
+    --hero-bg-gradient: linear-gradient(135deg, #0b2f55 0%, #154170 55%, #1f7a78 100%);
+
+    --main-nav-bg-color: var(--surface-nav);
+    --main-nav-border-bottom-color: rgba(148, 163, 184, 0.18);
+    --bottom-nav-bg-color: var(--surface-bottom-nav);
+    --bottom-nav-border-top-color: rgba(148, 163, 184, 0.18);
+    --bottom-nav-link-color: #cbd5f5;
+    --bottom-nav-link-hover-color: #f4faff;
+    --bottom-nav-link-active-color: #f8fbff;
+    --bottom-nav-link-hover-bg: rgba(148, 163, 184, 0.14);
+    --bottom-nav-link-active-bg: rgba(59, 130, 246, 0.2);
+
+    --footer-bg-color: #0b1220;
+    --footer-text-color: #94a3b8;
+    --footer-border-color: rgba(148, 163, 184, 0.24);
+
+    --score-panel-bg-color: var(--surface-panel);
+    --score-panel-bg-color-mobile: var(--surface-panel);
+    --score-panel-border-color: rgba(148, 163, 184, 0.22);
+    --score-panel-shadow: 0 18px 45px rgba(8, 15, 28, 0.45);
+    --score-panel-divider-color: rgba(148, 163, 184, 0.18);
+    --timer-color: #f1f5f9;
+    --timer-label-color: #a5b4ca;
+    --stat-label-color: #a5b4ca;
+    --stat-value-color: #e2e8f0;
+
+    --question-grid-item-bg: rgba(17, 26, 40, 0.95);
+    --question-grid-item-border-color: rgba(148, 163, 184, 0.25);
+    --question-grid-item-color: #cbd5f5;
+
+    --answer-bg-color: rgba(18, 29, 44, 0.85);
+    --answer-border-color: rgba(148, 163, 184, 0.28);
+
+    --stat-card-bg: rgba(15, 23, 42, 0.68);
+    --stat-card-border-color: rgba(148, 163, 184, 0.22);
+    --stat-card-hover-bg: rgba(17, 29, 48, 0.85);
+    --stat-card-hover-shadow: 0 12px 35px rgba(8, 15, 28, 0.45);
+
+    --filter-panel-bg-color: var(--surface-panel);
+    --filter-panel-header-bg-color: var(--surface-panel);
+    --filter-panel-border-color: rgba(148, 163, 184, 0.2);
+    --filter-panel-overlay-color: rgba(8, 15, 28, 0.6);
+    --filter-panel-scroll-track: rgba(148, 163, 184, 0.08);
+    --filter-panel-scroll-thumb: rgba(148, 163, 184, 0.22);
+    --filter-panel-scroll-thumb-hover: rgba(148, 163, 184, 0.32);
+    --filter-panel-shadow: -4px 0 35px rgba(8, 15, 28, 0.45);
+
+    --explanation-modal-overlay-color: rgba(8, 15, 28, 0.7);
+    --explanation-modal-bg-color: var(--surface-panel);
+    --explanation-modal-section-bg: rgba(15, 23, 42, 0.9);
+    --explanation-modal-border-color: rgba(148, 163, 184, 0.22);
+    --explanation-modal-shadow: 0 18px 45px rgba(8, 15, 28, 0.5);
+    --explanation-modal-scroll-track: rgba(17, 28, 44, 0.85);
+    --explanation-modal-scroll-thumb: rgba(148, 163, 184, 0.28);
+    --explanation-modal-scroll-thumb-hover: rgba(148, 163, 184, 0.38);
+
+    --challenge-hub-shadow: 0 18px 45px rgba(8, 15, 28, 0.45);
+    --challenge-hub-bg: rgba(17, 28, 44, 0.92);
+    --challenge-card-bg: var(--surface-card);
+    --challenge-card-border-color: rgba(148, 163, 184, 0.22);
+    --challenge-card-shadow: 0 15px 35px rgba(8, 15, 28, 0.5);
+    --challenge-card-shadow-hover: 0 20px 45px rgba(8, 15, 28, 0.6);
+    --challenge-card-icon-bg: rgba(59, 130, 246, 0.18);
+    --challenge-card-disabled-bg: rgba(28, 36, 52, 0.65);
+
+    --modal-backdrop-bg: rgba(8, 15, 28, 0.75);
 }

--- a/assets/css/components/card.css
+++ b/assets/css/components/card.css
@@ -1,8 +1,8 @@
 /* assets/css/components/card.css */
 
 .card {
-    background-color: var(--card-bg-color, var(--color-white));
-    border: var(--card-border-width, var(--border-width)) solid var(--card-border-color, var(--color-gray-400));
+    background-color: var(--card-bg-color, var(--surface-card, var(--color-white)));
+    border: var(--card-border-width, var(--border-width)) solid var(--card-border-color, var(--border-subtle-color, var(--color-gray-400)));
     border-radius: var(--card-border-radius, var(--border-radius-md));
     box-shadow: var(--card-box-shadow, var(--shadow-md));
     padding: var(--card-padding, var(--spacing-lg, 30px));
@@ -13,7 +13,7 @@
 .card__header {
     padding-bottom: var(--card-header-padding-bottom, var(--spacing-sm, 16px));
     margin-bottom: var(--card-header-margin-bottom, var(--spacing-sm, 16px));
-    border-bottom: var(--card-header-border-bottom-width, var(--border-width)) solid var(--card-header-border-bottom-color, var(--color-gray-300));
+    border-bottom: var(--card-header-border-bottom-width, var(--border-width)) solid var(--card-header-border-bottom-color, var(--border-subtle-color, var(--color-gray-300)));
 }
 .card__header:last-child {
     border-bottom: none;
@@ -44,7 +44,7 @@
 .card__footer {
     padding-top: var(--card-footer-padding-top, var(--spacing-sm, 16px));
     margin-top: var(--card-footer-margin-top, var(--spacing-sm, 16px));
-    border-top: var(--card-footer-border-top-width, var(--border-width)) solid var(--card-footer-border-top-color, var(--color-gray-300));
+    border-top: var(--card-footer-border-top-width, var(--border-width)) solid var(--card-footer-border-top-color, var(--border-subtle-color, var(--color-gray-300)));
     font-size: var(--font-size-sm, 0.9rem);
     color: var(--color-gray-700);
 }
@@ -69,8 +69,8 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    background-color: var(--color-gray-50);
-    border-color: var(--color-gray-300);
+    background-color: var(--card-aviso-bg-color, var(--surface-card-muted, var(--color-gray-50)));
+    border-color: var(--card-aviso-border-color, var(--border-subtle-color, var(--color-gray-300)));
     box-shadow: none;
 }
 .card--aviso p { color: var(--color-text-secondary); font-size: var(--font-size-base); }
@@ -85,8 +85,8 @@
 .card--question-wrap.is-transparent { opacity: 0; transition: none; }
 
 .card--placeholder-filtros {
-    background-color: var(--color-gray-50);
-    border: 1px dashed var(--color-gray-300);
+    background-color: var(--card-placeholder-bg-color, var(--surface-card-muted, var(--color-gray-50)));
+    border: 1px dashed var(--card-placeholder-border-color, var(--border-subtle-color, var(--color-gray-300)));
     text-align: center;
     padding: var(--spacing-xl, 35px) var(--spacing-lg, 30px);
     margin: var(--spacing-lg, 25px) auto;
@@ -124,10 +124,10 @@
     --result-card-accent: var(--color-primary-dark);
     --result-card-accent-secondary: var(--color-secondary-green);
 
-    background-color: var(--color-white);
-    border-radius: var(--border-radius-xl, 20px); 
-    box-shadow: 0 20px 60px -10px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.15),
-                0 8px 20px -5px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.1);  
+    background-color: var(--card-result-bg, var(--surface-card, var(--color-white)));
+    border-radius: var(--border-radius-xl, 20px);
+    box-shadow: var(--card-result-shadow, 0 20px 60px -10px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.15),
+                0 8px 20px -5px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.1));
     padding: var(--result-card-padding-y) var(--result-card-padding-x);
     
     /* AJUSTE: Largura máxima aumentada para melhor proporção em telas maiores */

--- a/assets/css/components/challenge-hub.css
+++ b/assets/css/components/challenge-hub.css
@@ -11,9 +11,9 @@
     width: 100%;
     max-width: 800px; /* Largura máxima do hub */
     margin: var(--spacing-xl, 30px) auto; /* Margem vertical e centralização horizontal */
-    background-color: var(--color-gray-100); /* Fundo suave para o hub */
+    background-color: var(--challenge-hub-bg, var(--surface-card-muted, var(--color-gray-100))); /* Fundo suave para o hub */
     border-radius: var(--border-radius-lg);
-    box-shadow: var(--shadow-md);
+    box-shadow: var(--challenge-hub-shadow, var(--shadow-md));
     min-height: 400px; /* Altura mínima para melhor visualização */
 }
 
@@ -47,10 +47,10 @@
 }
 
 .challenge-card {
-    background-color: var(--color-white);
-    border: var(--border-width) solid var(--color-gray-300);
+    background-color: var(--challenge-card-bg, var(--surface-card, var(--color-white)));
+    border: var(--border-width) solid var(--challenge-card-border-color, var(--border-subtle-color, var(--color-gray-300)));
     border-radius: var(--border-radius-md); /* Consistente com .card */
-    box-shadow: var(--shadow-sm);
+    box-shadow: var(--challenge-card-shadow, var(--shadow-sm));
     padding: var(--spacing-lg, 25px);
     text-align: left;
     display: flex; /* Para alinhar ícone e conteúdo */
@@ -65,7 +65,7 @@
 .challenge-card:hover,
 .challenge-card:focus-visible {
     transform: translateY(-3px);
-    box-shadow: var(--shadow-lg); /* Sombra mais pronunciada no hover/focus */
+    box-shadow: var(--challenge-card-shadow-hover, var(--shadow-lg)); /* Sombra mais pronunciada no hover/focus */
     border-color: var(--color-primary-medium); /* Destaque na borda */
 }
 
@@ -77,7 +77,7 @@
 
 .challenge-card__icon-wrapper {
     flex-shrink: 0; /* Para o wrapper do ícone não encolher */
-    background-color: var(--color-primary-light); /* Fundo suave para o ícone */
+    background-color: var(--challenge-card-icon-bg, var(--color-primary-light)); /* Fundo suave para o ícone */
     border-radius: var(--border-radius-circle);
     padding: var(--spacing-sm, 12px);
     display: inline-flex; /* Para centralizar o ícone dentro */
@@ -113,7 +113,7 @@
 }
 
 .challenge-card--disabled {
-    background-color: var(--color-gray-200);
+    background-color: var(--challenge-card-disabled-bg, var(--color-gray-200));
     cursor: not-allowed;
     opacity: 0.7;
 }

--- a/assets/css/components/explanation-modal.css
+++ b/assets/css/components/explanation-modal.css
@@ -7,7 +7,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.6);
+    background-color: var(--explanation-modal-overlay-color, rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.6));
     backdrop-filter: blur(5px);
     -webkit-backdrop-filter: blur(5px);
     display: flex;
@@ -28,10 +28,10 @@
 .explanation-modal__dialog {
     width: 90%;
     max-width: 700px; /* Largura máxima um pouco menor para não ser tão largo */
-    background-color: var(--color-white);
+    background-color: var(--explanation-modal-bg-color, var(--surface-panel, var(--color-white)));
     border-radius: var(--border-radius-xl, 16px); /* Cantos mais arredondados */
-    box-shadow: 0 10px 35px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.15),
-                0 4px 12px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.1); /* Sombra sofisticada */
+    box-shadow: var(--explanation-modal-shadow, 0 10px 35px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.15),
+                0 4px 12px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.1)); /* Sombra sofisticada */
     display: flex;
     flex-direction: column;
     max-height: 88vh;
@@ -52,7 +52,7 @@
     justify-content: space-between;
     align-items: center;
     padding: var(--spacing-md, 20px) var(--spacing-lg, 28px); /* Padding ajustado */
-    border-bottom: 1px solid var(--color-gray-100); /* Linha muito sutil */
+    border-bottom: 1px solid var(--explanation-modal-border-color, var(--border-subtle-color, var(--color-gray-100))); /* Linha muito sutil */
     flex-shrink: 0;
 }
 .explanation-modal__title {
@@ -85,10 +85,10 @@
 }
 /* Estilização da Scrollbar */
 .explanation-modal__body::-webkit-scrollbar { width: 8px; }
-.explanation-modal__body::-webkit-scrollbar-track { background: var(--color-gray-50); border-radius: 4px; }
-.explanation-modal__body::-webkit-scrollbar-thumb { background-color: var(--color-gray-300); border-radius: 4px; border: 2px solid var(--color-gray-50); }
-.explanation-modal__body::-webkit-scrollbar-thumb:hover { background-color: var(--color-gray-400); }
-.explanation-modal__body { scrollbar-width: auto; scrollbar-color: var(--color-gray-300) var(--color-gray-50); }
+.explanation-modal__body::-webkit-scrollbar-track { background: var(--explanation-modal-scroll-track, var(--color-gray-50)); border-radius: 4px; }
+.explanation-modal__body::-webkit-scrollbar-thumb { background-color: var(--explanation-modal-scroll-thumb, var(--color-gray-300)); border-radius: 4px; border: 2px solid var(--explanation-modal-scroll-track, var(--color-gray-50)); }
+.explanation-modal__body::-webkit-scrollbar-thumb:hover { background-color: var(--explanation-modal-scroll-thumb-hover, var(--color-gray-400)); }
+.explanation-modal__body { scrollbar-width: auto; scrollbar-color: var(--explanation-modal-scroll-thumb, var(--color-gray-300)) var(--explanation-modal-scroll-track, var(--color-gray-50)); }
 
 .explanation-modal__subtitle {
     font-family: var(--font-family-heading);
@@ -135,11 +135,11 @@
 
 .explanation-modal__options-list li {
     padding: var(--spacing-md, 16px);
-    border: 1px solid var(--color-gray-200); /* Borda geral muito sutil */
+    border: 1px solid var(--explanation-modal-border-color, var(--border-subtle-color, var(--color-gray-200))); /* Borda geral muito sutil */
     border-left-width: 4px; /* Borda esquerda será colorida */
     border-left-color: var(--color-gray-300); /* Cor padrão da borda esquerda (para itens neutros, se houver) */
     border-radius: var(--border-radius-md);
-    background-color: var(--color-white); /* Fundo branco para os itens */
+    background-color: var(--explanation-modal-section-bg, var(--surface-card, var(--color-white))); /* Fundo branco para os itens */
     transition: border-left-color var(--transition-fast), background-color var(--transition-fast);
 }
 /* Classes JS para colorir a borda esquerda e o fundo sutilmente */

--- a/assets/css/components/filter-panel.css
+++ b/assets/css/components/filter-panel.css
@@ -7,7 +7,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.2);
+    background-color: var(--filter-panel-overlay-color, rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.2));
     backdrop-filter: blur(3px);
     -webkit-backdrop-filter: blur(3px);
     z-index: var(--z-index-filter-panel-overlay, 799); /* Abaixo do painel */
@@ -31,9 +31,9 @@
     width: 100%;
     max-width: 390px;
     height: 100dvh; /* Altura dinâmica da viewport */
-    background-color: var(--color-white, #ffffff);
+    background-color: var(--filter-panel-bg-color, var(--surface-panel, var(--color-white)));
     color: var(--color-text-primary, #343a40);
-    box-shadow: -4px 0 25px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.12);
+    box-shadow: var(--filter-panel-shadow, -4px 0 25px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.12));
     z-index: var(--z-index-filter-panel, 800);
     transform: translateX(100%);
     transition: transform 0.35s cubic-bezier(0.25, 0.1, 0.25, 1);
@@ -52,9 +52,9 @@
     justify-content: space-between;
     align-items: center;
     padding: var(--spacing-md, 20px) var(--spacing-lg, 24px);
-    border-bottom: 1px solid var(--color-gray-200, #e9ecef);
+    border-bottom: 1px solid var(--filter-panel-border-color, var(--border-subtle-color, var(--color-gray-200)));
     flex-shrink: 0;
-    background-color: var(--color-white, #ffffff);
+    background-color: var(--filter-panel-header-bg-color, var(--surface-panel, var(--color-white)));
 }
 
 .filter-panel__title {
@@ -95,10 +95,10 @@
 }
 
 .filter-panel__body::-webkit-scrollbar { width: 6px; }
-.filter-panel__body::-webkit-scrollbar-track { background: var(--color-gray-100, #f8f9fa); margin: var(--spacing-xs, 8px) 0; }
-.filter-panel__body::-webkit-scrollbar-thumb { background-color: var(--color-gray-300, #dee2e6); border-radius: 10px; }
-.filter-panel__body::-webkit-scrollbar-thumb:hover { background-color: var(--color-gray-400, #ced4da); }
-.filter-panel__body { scrollbar-width: thin; scrollbar-color: var(--color-gray-300, #dee2e6) var(--color-gray-100, #f8f9fa); }
+.filter-panel__body::-webkit-scrollbar-track { background: var(--filter-panel-scroll-track, var(--color-gray-100, #f8f9fa)); margin: var(--spacing-xs, 8px) 0; }
+.filter-panel__body::-webkit-scrollbar-thumb { background-color: var(--filter-panel-scroll-thumb, var(--color-gray-300, #dee2e6)); border-radius: 10px; }
+.filter-panel__body::-webkit-scrollbar-thumb:hover { background-color: var(--filter-panel-scroll-thumb-hover, var(--color-gray-400, #ced4da)); }
+.filter-panel__body { scrollbar-width: thin; scrollbar-color: var(--filter-panel-scroll-thumb, var(--color-gray-300, #dee2e6)) var(--filter-panel-scroll-track, var(--color-gray-100, #f8f9fa)); }
 
 /* Grupo de Filtros */
 .filter-group__header {
@@ -106,7 +106,7 @@
     align-items: center;
     margin-bottom: var(--spacing-xs, 8px);
     padding-bottom: var(--spacing-xs, 8px);
-    border-bottom: 1px solid var(--color-gray-100, #f8f9fa);
+    border-bottom: 1px solid var(--filter-panel-border-color, var(--border-subtle-color, var(--color-gray-100)));
 }
 
 .filter-group__title {

--- a/assets/css/components/navigation.css
+++ b/assets/css/components/navigation.css
@@ -9,8 +9,8 @@
 /* ===== NAVEGAÇÃO PRINCIPAL (SUPERIOR - DESKTOP) ===== */
 .main-nav {
   flex-shrink: 0;
-  background-color: var(--main-nav-bg-color, var(--color-white));
-  border-bottom: var(--main-nav-border-bottom-width, var(--border-width)) solid var(--main-nav-border-bottom-color, var(--color-gray-400));
+  background-color: var(--main-nav-bg-color, var(--surface-nav, var(--color-white)));
+  border-bottom: var(--main-nav-border-bottom-width, var(--border-width)) solid var(--main-nav-border-bottom-color, var(--border-subtle-color, var(--color-gray-400)));
   height: var(--main-nav-height, 50px);
   display: flex;
   position: relative;
@@ -72,7 +72,7 @@
   outline: var(--focus-outline-width) solid var(--focus-outline-color);
   outline-offset: -2px;
   border-radius: var(--border-radius-sm);
-  background-color: var(--color-gray-100);
+  background-color: var(--surface-card-muted, var(--color-gray-100));
   text-decoration: none;
 }
 
@@ -86,8 +86,8 @@
   width: 100%;
   height: var(--bottom-nav-height, 60px); /* Altura da barra */
   padding-bottom: env(safe-area-inset-bottom, 0);
-  background-color: var(--bottom-nav-bg-color, var(--color-white));
-  border-top: var(--border-width) solid var(--bottom-nav-border-top-color, var(--color-gray-300));
+  background-color: var(--bottom-nav-bg-color, var(--surface-bottom-nav, var(--color-white)));
+  border-top: var(--border-width) solid var(--bottom-nav-border-top-color, var(--border-subtle-color, var(--color-gray-300)));
   box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.08);
   z-index: var(--z-index-bottom-nav, 100);
 }
@@ -146,7 +146,7 @@
 
 .bottom-nav__link:hover {
   color: var(--bottom-nav-link-hover-color, var(--color-primary-dark));
-  background-color: var(--bottom-nav-link-hover-bg, var(--color-gray-100));
+  background-color: var(--bottom-nav-link-hover-bg, var(--surface-card-muted, var(--color-gray-100)));
 }
 
 .bottom-nav__link:active .bottom-nav__icon {
@@ -171,7 +171,7 @@
   outline: var(--focus-outline-width) solid var(--focus-outline-color);
   outline-offset: -2px; /* Ajuste para dentro da barra */
   border-radius: var(--border-radius-sm); /* Adiciona um leve arredondamento no foco */
-  background-color: var(--color-gray-200);
+  background-color: var(--surface-card-muted, var(--color-gray-200));
 }
 
 

--- a/assets/css/components/score-panel.css
+++ b/assets/css/components/score-panel.css
@@ -14,10 +14,10 @@
   padding: var(--score-panel-padding-y, var(--spacing-lg, 28px)) var(--score-panel-padding-x, var(--spacing-md, 22px));
   width: var(--score-panel-width, 260px);
   min-width: var(--score-panel-width, 260px);
-  background-color: var(--score-panel-bg-color, var(--color-white));
-  
+  background-color: var(--score-panel-bg-color, var(--surface-panel, var(--color-white)));
+
   box-shadow: var(--score-panel-shadow, 2px 0px 12px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.04));
-  border-right: 1px solid var(--score-panel-border-color, var(--color-gray-200));
+  border-right: 1px solid var(--score-panel-border-color, var(--border-subtle-color, var(--color-gray-200)));
   flex-shrink: 0;
 
   position: sticky;
@@ -42,7 +42,7 @@
   align-items: center;
   text-align: center;
   padding-bottom: var(--spacing-md, 20px);
-  border-bottom: 1px solid var(--color-gray-300); 
+  border-bottom: 1px solid var(--score-panel-divider-color, var(--border-subtle-color, var(--color-gray-300)));
   margin-bottom: var(--spacing-xs, 6px);
 }
 
@@ -188,7 +188,7 @@
     .score-panel {
         position: static; height: auto; overflow-y: visible; width: 100%;
         min-width: 100%;
-        background-color: var(--score-panel-bg-color-mobile, var(--color-white));
+        background-color: var(--score-panel-bg-color-mobile, var(--surface-panel, var(--color-white)));
         box-shadow: 0 2px 8px rgba(var(--color-primary-dark-rgb), 0.05);
         border-right: none; border-bottom: 1px solid var(--color-gray-200);
         flex-direction: row; justify-content: space-between;

--- a/assets/css/layout/footer.css
+++ b/assets/css/layout/footer.css
@@ -7,14 +7,15 @@
     justify-content: center;
     align-items: center;
     padding: var(--spacing-md, 20px);
-    background-color: var(--color-gray-900);
-    color: var(--color-gray-300);
+    background-color: var(--footer-bg-color, var(--color-gray-900));
+    color: var(--footer-text-color, var(--color-gray-300));
     box-shadow: 0 -3px 6px rgba(0, 0, 0, 0.06);
-    border-top: var(--border-width) solid var(--color-gray-800);
+    border-top: var(--border-width) solid var(--footer-border-color, var(--color-gray-800));
     height: var(--footer-height, 65px);
     flex-shrink: 0;
     position: relative;
     z-index: var(--z-index-default);
+    transition: background-color 0.35s ease, color 0.35s ease, border-color 0.35s ease;
 }
 
 /* Element: .site-footer__text */

--- a/assets/css/layout/header.css
+++ b/assets/css/layout/header.css
@@ -6,10 +6,10 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    background-color: var(--color-white);
+    background-color: var(--surface-header, var(--color-white));
     padding: 0 var(--spacing-xl, 40px);
-    box-shadow: var(--shadow-lg);
-    border-bottom: var(--border-width) solid var(--color-gray-300);
+    box-shadow: var(--site-header-shadow, var(--shadow-lg));
+    border-bottom: var(--border-width) solid var(--site-header-border-color, var(--border-subtle-color, var(--color-gray-300)));
     flex-shrink: 0;
     position: relative;
     z-index: var(--z-index-header, 110);
@@ -66,7 +66,7 @@
 
 .site-header__action-link:hover,
 .site-header__action-link:focus-visible {
-    background-color: var(--color-gray-100);
+    background-color: var(--surface-card-muted, var(--color-gray-100));
 }
 .site-header__action-link:focus-visible {
     outline: var(--focus-outline-width) solid var(--focus-outline-color);


### PR DESCRIPTION
## Summary
- introduce theme surface variables and color overrides to support a refined dark palette
- adapt layout, navigation, card, filter and modal components to use the new theme tokens
- retune panel, challenge hub and footer styling to keep accents legible without color inversion

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf808950bc8333b736aa5562bb2146