### PR TITLE
Revamp challenge hub UI and quick-start features

### DIFF
--- a/assets/css/components/challenge-hub.css
+++ b/assets/css/components/challenge-hub.css
@@ -1,194 +1,515 @@
-/* assets/css/components/challenge-hub.css (Refatoração Completa v3) */
+/* assets/css/components/challenge-hub.css (Reforma Estética v4) */
 
 /* Container Principal do Hub */
 .challenge-hub {
+    position: relative;
+    isolation: isolate;
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-lg, 25px);
+    gap: clamp(28px, 5vw, 40px);
     width: 100%;
-    max-width: 820px;
-    margin: var(--spacing-xl, 30px) auto;
-    padding: clamp(40px, 7vh, 55px) var(--spacing-lg, 30px);
-    background-color: var(--color-gray-100);
-    border-radius: var(--border-radius-lg);
-    box-shadow: var(--shadow-md);
+    max-width: 980px;
+    margin: var(--spacing-xl, 32px) auto;
+    padding: clamp(42px, 8vh, 64px) clamp(24px, 6vw, 48px);
+    border-radius: var(--border-radius-xl, 28px);
+    border: 1px solid color-mix(in srgb, var(--color-primary-light) 18%, transparent);
+    background: linear-gradient(145deg, color-mix(in srgb, var(--color-white) 94%, transparent) 0%, color-mix(in srgb, var(--color-primary-xlight) 22%, var(--color-white)) 100%);
+    box-shadow: var(--shadow-xl, 0 28px 50px rgba(33, 40, 59, 0.16));
+    overflow: hidden;
+}
+
+.challenge-hub::before,
+.challenge-hub::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.challenge-hub::before {
+    background: radial-gradient(circle at 12% 18%, color-mix(in srgb, var(--color-primary-light) 65%, transparent) 0%, transparent 55%),
+        radial-gradient(circle at 88% 82%, color-mix(in srgb, var(--color-secondary-light, #97c4ff) 55%, transparent) 0%, transparent 50%);
+    opacity: 0.55;
+}
+
+.challenge-hub::after {
+    border-radius: inherit;
+    border: 1px solid color-mix(in srgb, var(--color-white) 30%, var(--color-primary-light));
+    mix-blend-mode: soft-light;
+    opacity: 0.3;
+}
+
+.challenge-hub > * {
+    position: relative;
+    z-index: 1;
 }
 
 .challenge-hub__header {
     text-align: center;
-    margin-bottom: var(--spacing-md, 20px);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm, 12px);
+}
+
+.challenge-hub__eyebrow {
+    align-self: center;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 16px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--color-primary-light) 32%, transparent);
+    color: var(--color-primary-dark);
+    font-size: 0.75rem;
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
 }
 
 .challenge-hub__title {
+    margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(1.8rem, 4.5vw, 2.2rem);
+    font-size: clamp(2rem, 4vw, 2.6rem);
+    font-weight: var(--font-weight-extrabold, 800);
     color: var(--color-primary-dark);
-    font-weight: var(--font-weight-bold);
-    margin-top: 0;
-    margin-bottom: var(--spacing-xs, 8px);
 }
 
 .challenge-hub__subtitle {
-    font-family: var(--font-family-sans);
-    font-size: clamp(0.95rem, 2.5vw, 1.1rem);
-    color: var(--color-text-secondary);
-    margin: 0;
-    font-weight: var(--font-weight-normal);
+    margin: 0 auto;
+    max-width: 640px;
+    font-size: clamp(1rem, 2.6vw, 1.15rem);
+    color: color-mix(in srgb, var(--color-text-primary) 82%, transparent);
+    line-height: 1.6;
 }
 
-/* Grade de Opções */
+.challenge-hub__subtitle strong {
+    color: var(--color-primary-dark);
+}
+
+/* Resumo Superior */
+.challenge-hub__summary {
+    display: grid;
+    gap: clamp(20px, 4vw, 32px);
+    align-items: stretch;
+}
+
+@media (min-width: 900px) {
+    .challenge-hub__summary {
+        grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+    }
+}
+
+.challenge-hub__stats {
+    display: grid;
+    gap: var(--spacing-sm, 12px);
+}
+
+@media (min-width: 640px) {
+    .challenge-hub__stats {
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    }
+}
+
+.challenge-stat-card {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm, 12px);
+    padding: 18px 20px;
+    border-radius: 18px;
+    background: color-mix(in srgb, var(--color-white) 85%, transparent 15%);
+    backdrop-filter: blur(12px);
+    border: 1px solid color-mix(in srgb, var(--color-primary-light) 28%, transparent);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+}
+
+.challenge-stat-card__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--color-primary-light) 60%, var(--color-white));
+    color: var(--color-primary-dark);
+    font-size: 1.6rem;
+}
+
+.challenge-stat-card__content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.challenge-stat-card__label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: color-mix(in srgb, var(--color-text-secondary) 80%, transparent);
+}
+
+.challenge-stat-card__value {
+    font-size: 1.45rem;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-primary);
+}
+
+.challenge-hub__callout {
+    border-radius: 22px;
+    padding: clamp(22px, 4vw, 32px);
+    background: linear-gradient(135deg, color-mix(in srgb, var(--color-primary-medium) 22%, transparent) 0%, color-mix(in srgb, var(--color-secondary-light, #92b4ff) 18%, transparent) 100%);
+    border: 1px solid color-mix(in srgb, var(--color-primary-medium) 30%, transparent);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+    color: var(--color-primary-dark);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm, 12px);
+    justify-content: center;
+}
+
+.challenge-hub__callout-title {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: clamp(1.25rem, 2.6vw, 1.6rem);
+    font-weight: var(--font-weight-semibold);
+}
+
+.challenge-hub__callout-text {
+    margin: 0;
+    font-size: 0.95rem;
+    color: color-mix(in srgb, var(--color-primary-dark) 72%, transparent);
+    line-height: 1.5;
+}
+
+.challenge-hub__callout-button {
+    align-self: flex-start;
+    margin-top: 4px;
+    box-shadow: 0 12px 24px rgba(33, 40, 59, 0.18);
+}
+
 .challenge-hub__options-grid {
     display: grid;
     grid-template-columns: 1fr;
-    gap: var(--spacing-lg, 25px);
-    width: 100%;
+    gap: clamp(18px, 4vw, 26px);
 }
 
 @media (min-width: 768px) {
     .challenge-hub__options-grid {
-        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     }
 }
 
-/* ========================================================================== */
-/* == REGRAS DE CARD (BASE E VARIANTES) - REFAFORADO COM FLEXBOX ANINHADO == */
-/* ========================================================================== */
-
-/* Base para todos os cards de desafio */
+/* Cards de desafio */
 .challenge-card {
-    background-color: var(--color-white);
-    border: var(--border-width) solid var(--color-gray-300);
-    border-radius: var(--border-radius-md);
-    box-shadow: var(--shadow-sm);
-    padding: var(--spacing-lg, 25px);
-    text-align: left;
-    color: inherit;
-    text-decoration: none;
-    transition: transform var(--transition-fast), box-shadow var(--transition-fast);
-
-    /* --- Layout Base (para cards simples como "Personalizar" e "Quiz Rápido") --- */
+    position: relative;
     display: flex;
-    align-items: center; /* Centraliza verticalmente ícone e conteúdo */
-    gap: var(--spacing-md, 20px);
+    align-items: flex-start;
+    gap: var(--spacing-md, 18px);
+    padding: clamp(22px, 4vw, 28px);
+    border-radius: var(--border-radius-lg, 20px);
+    background: color-mix(in srgb, var(--color-white) 90%, transparent 10%);
+    border: 1px solid color-mix(in srgb, var(--color-gray-300) 70%, transparent);
+    box-shadow: var(--shadow-sm, 0 18px 28px rgba(33, 40, 59, 0.08));
+    color: var(--color-text-primary);
+    text-align: left;
+    transition: transform var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast);
+    cursor: pointer;
+    overflow: hidden;
 }
 
-/* Efeito de hover para cards clicáveis */
-.challenge-card:not(.challenge-card--resume):hover,
-.challenge-card:not(.challenge-card--resume):focus-visible {
-    transform: translateY(-3px);
-    box-shadow: var(--shadow-lg);
-    border-color: var(--color-primary-medium);
+.challenge-card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: 1px solid transparent;
+    transition: border-color var(--transition-fast);
 }
+
+.challenge-card:hover,
+.challenge-card:focus-visible {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-lg, 0 24px 42px rgba(33, 40, 59, 0.16));
+    border-color: color-mix(in srgb, var(--color-primary-medium) 55%, transparent);
+}
+
 .challenge-card:focus-visible {
     outline: var(--focus-outline-width) solid var(--focus-outline-color);
     outline-offset: var(--focus-outline-offset);
 }
 
-/* Ícone */
 .challenge-card__icon-wrapper {
-    flex-shrink: 0; /* Impede que o ícone seja esmagado */
+    flex-shrink: 0;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    background-color: var(--color-primary-light);
-    border-radius: var(--border-radius-circle);
-    padding: var(--spacing-sm, 12px);
+    width: 56px;
+    height: 56px;
+    border-radius: 16px;
+    background: color-mix(in srgb, var(--color-primary-light) 45%, transparent);
     color: var(--color-primary-dark);
 }
 
 .challenge-card__icon {
     font-size: 2rem;
-    display: block;
 }
 
-/* Conteúdo (Título e Descrição) */
 .challenge-card__content {
-    flex-grow: 1; /* Permite que a área de conteúdo cresça */
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.challenge-card__eyebrow {
+    font-size: 0.75rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--color-text-secondary) 70%, transparent);
 }
 
 .challenge-card__title {
     font-family: var(--font-family-heading);
-    font-size: var(--font-size-h3, 1.3rem);
-    color: var(--color-text-primary);
-    font-weight: var(--font-weight-semibold);
-    margin-top: 0;
-    margin-bottom: var(--spacing-xxs, 4px);
+    font-size: clamp(1.1rem, 2.4vw, 1.4rem);
+    margin: 0;
+    color: inherit;
 }
 
 .challenge-card__description {
-    font-family: var(--font-family-sans);
-    font-size: var(--font-size-sm, 0.9rem);
-    color: var(--color-text-secondary);
-    line-height: var(--line-height-base);
     margin: 0;
-    overflow-wrap: break-word;
+    font-size: 0.95rem;
+    line-height: 1.45;
+    color: color-mix(in srgb, var(--color-text-secondary) 78%, transparent);
 }
 
-/* --- Variante de Card de Resumo (layout mais complexo) --- */
 .challenge-card--resume {
     cursor: default;
-    background-color: var(--color-primary-xlight);
-    border-color: var(--color-primary-medium);
-    grid-column: 1 / -1; /* Ocupa a largura toda da grade */
+    border-color: color-mix(in srgb, var(--color-primary-medium) 65%, transparent);
+    background: linear-gradient(135deg, color-mix(in srgb, var(--color-primary-xlight) 55%, transparent) 0%, color-mix(in srgb, var(--color-white) 92%, transparent) 100%);
+    grid-column: 1 / -1;
 }
 
-/* Novo container principal que agrupa conteúdo e ações */
+.challenge-card--resume .challenge-card__icon-wrapper {
+    background: color-mix(in srgb, var(--color-primary-medium) 30%, var(--color-white));
+    color: var(--color-primary-dark);
+}
+
 .challenge-card__main {
-    flex-grow: 1;
+    flex: 1;
     display: flex;
     flex-direction: column;
-    justify-content: space-between; /* Garante que as ações fiquem no fundo */
-    min-height: 90px; /* Altura mínima para garantir alinhamento em textos curtos */
+    gap: var(--spacing-sm, 12px);
 }
 
-/* Ações (botões) */
 .challenge-card__actions {
     display: flex;
-    justify-content: flex-end; /* Alinha botões à direita */
-    align-items: center;
+    flex-wrap: wrap;
     gap: var(--spacing-sm, 12px);
-    margin-top: var(--spacing-md, 20px); /* Espaço entre a descrição e os botões */
+    justify-content: flex-end;
 }
 
-/* --- Outras Variantes --- */
-.challenge-card--disabled {
-    background-color: var(--color-gray-200);
-    cursor: not-allowed;
-    opacity: 0.7;
+.challenge-card--accent {
+    background: linear-gradient(140deg, var(--color-primary-medium) 0%, var(--color-primary-dark) 100%);
+    color: var(--color-white);
+    border: none;
 }
+
+.challenge-card--accent .challenge-card__icon-wrapper {
+    background: rgba(255, 255, 255, 0.18);
+    color: var(--color-white);
+}
+
+.challenge-card--accent .challenge-card__description,
+.challenge-card--accent .challenge-card__eyebrow {
+    color: rgba(255, 255, 255, 0.76);
+}
+
+.challenge-card--primary {
+    background: linear-gradient(140deg, color-mix(in srgb, var(--color-secondary-light, #a4c8ff) 35%, transparent) 0%, var(--color-primary-medium) 95%);
+    color: var(--color-primary-contrast, #0d1b2a);
+    border: none;
+}
+
+.challenge-card--primary .challenge-card__icon-wrapper {
+    background: rgba(255, 255, 255, 0.28);
+    color: inherit;
+}
+
+.challenge-card--primary .challenge-card__description,
+.challenge-card--primary .challenge-card__eyebrow {
+    color: color-mix(in srgb, currentColor 70%, transparent);
+}
+
+.challenge-card--outline {
+    border: 1px solid color-mix(in srgb, var(--color-primary-medium) 45%, transparent);
+    background: color-mix(in srgb, var(--color-white) 94%, transparent 6%);
+}
+
+.challenge-card--outline .challenge-card__icon-wrapper {
+    background: color-mix(in srgb, var(--color-primary-light) 45%, transparent);
+    color: var(--color-primary-dark);
+}
+
+.challenge-card--disabled {
+    cursor: not-allowed;
+    opacity: 0.65;
+}
+
 .challenge-card--disabled:hover,
 .challenge-card--disabled:focus-visible {
     transform: none;
-    box-shadow: var(--shadow-sm);
-    border-color: var(--color-gray-300);
+    box-shadow: var(--shadow-sm, 0 18px 28px rgba(33, 40, 59, 0.08));
 }
 
-/* Responsividade */
-@media (max-width: 480px) {
-    .challenge-card, .challenge-card--resume {
-        padding: var(--spacing-md, 20px);
-        gap: var(--spacing-sm, 15px);
+/* Sessões complementares */
+.challenge-hub__section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm, 14px);
+}
+
+.challenge-hub__section-header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.challenge-hub__section-title {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: 1.15rem;
+    color: var(--color-text-primary);
+}
+
+.challenge-hub__section-subtitle {
+    margin: 0;
+    color: color-mix(in srgb, var(--color-text-secondary) 80%, transparent);
+    font-size: 0.95rem;
+}
+
+.challenge-hub__empty-state {
+    margin: 0;
+    padding: 14px 18px;
+    border-radius: 14px;
+    background: color-mix(in srgb, var(--color-white) 90%, transparent 10%);
+    border: 1px dashed color-mix(in srgb, var(--color-primary-medium) 30%, transparent);
+    color: color-mix(in srgb, var(--color-text-secondary) 75%, transparent);
+    font-size: 0.92rem;
+}
+
+.challenge-chip-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.challenge-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 18px;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--color-primary-medium) 35%, transparent);
+    background: color-mix(in srgb, var(--color-white) 88%, transparent 12%);
+    color: var(--color-text-primary);
+    font-size: 0.95rem;
+    transition: transform var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast);
+}
+
+.challenge-chip:hover,
+.challenge-chip:focus-visible {
+    transform: translateY(-2px);
+    border-color: var(--color-primary-medium);
+    box-shadow: 0 14px 26px rgba(33, 40, 59, 0.16);
+}
+
+.challenge-chip:focus-visible {
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline-offset: 3px;
+}
+
+.challenge-chip__label {
+    font-weight: var(--font-weight-semibold);
+}
+
+.challenge-chip__meta {
+    font-size: 0.8rem;
+    color: color-mix(in srgb, var(--color-text-secondary) 78%, transparent);
+}
+
+.challenge-quick-actions {
+    display: grid;
+    gap: var(--spacing-sm, 12px);
+}
+
+@media (min-width: 720px) {
+    .challenge-quick-actions {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     }
-    .challenge-card__title {
-        font-size: 1.15rem;
-    }
-    .challenge-card__icon-wrapper {
-        padding: var(--spacing-xs, 10px);
-    }
-    .challenge-card__icon {
-        font-size: 1.8rem;
-    }
+}
+
+.challenge-quick-action {
+    border: 1px solid color-mix(in srgb, var(--color-primary-medium) 32%, transparent);
+    border-radius: 18px;
+    background: color-mix(in srgb, var(--color-white) 92%, transparent 8%);
+    padding: 16px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    text-align: left;
+    transition: transform var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast);
+}
+
+.challenge-quick-action:hover,
+.challenge-quick-action:focus-visible {
+    transform: translateY(-3px);
+    border-color: color-mix(in srgb, var(--color-primary-medium) 55%, transparent);
+    box-shadow: 0 18px 32px rgba(33, 40, 59, 0.14);
+}
+
+.challenge-quick-action__title {
+    font-family: var(--font-family-heading);
+    font-size: 1.05rem;
+    color: var(--color-text-primary);
+}
+
+.challenge-quick-action__meta {
+    font-size: 0.9rem;
+    color: color-mix(in srgb, var(--color-text-secondary) 80%, transparent);
+}
+
+/* Responsividade geral */
+@media (max-width: 640px) {
     .challenge-hub {
-        padding: var(--spacing-lg, 25px) var(--spacing-sm, 15px);
+        padding: clamp(32px, 7vh, 48px) clamp(16px, 5vw, 26px);
+        border-radius: var(--border-radius-lg, 20px);
     }
-    .challenge-card__main {
-        min-height: auto;
+
+    .challenge-hub__stats {
+        grid-template-columns: 1fr;
     }
+
+    .challenge-card,
+    .challenge-card--resume {
+        flex-direction: row;
+        padding: 22px;
+    }
+
     .challenge-card__actions {
-        flex-direction: column;
-        align-items: stretch; /* Faz botões ocuparem 100% da largura */
+        justify-content: flex-start;
     }
-    .challenge-card__actions .button {
+
+    .challenge-chip,
+    .challenge-quick-action {
         width: 100%;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .challenge-hub,
+    .challenge-card,
+    .challenge-chip,
+    .challenge-quick-action {
+        transition: none;
     }
 }

--- a/assets/js/app/App.js
+++ b/assets/js/app/App.js
@@ -117,6 +117,12 @@ export default class App {
             challengeHub.updateTotalQuestionsCount(totalQuestions);
             const quickQuizCount = state.geral.homeSummary?.quickQuizDefaultCount ?? QUICK_QUIZ_COUNT;
             challengeHub.updateQuickQuizCount(quickQuizCount);
+            const totalCategories = state.geral.homeSummary?.totalCategories
+                ?? state.geral.allCategories?.length
+                ?? 0;
+            challengeHub.updateTotalCategoriesCount(totalCategories);
+            challengeHub.updateUserStats(state.user);
+            challengeHub.updateFeaturedCategories(state.geral.allCategories);
             challengeHub.setupEventListeners();
         }
 

--- a/assets/js/app/flux/ActionOrchestrator.js
+++ b/assets/js/app/flux/ActionOrchestrator.js
@@ -253,8 +253,35 @@ export default class ActionOrchestrator {
         await this._fetchAndInitiateQuiz(params);
     }
 
-    async startQuickQuiz() {
-        await this._fetchAndInitiateQuiz({ mode: 'Rápido' });
+    async startQuickQuiz(count = null) {
+        const params = { mode: 'Rápido' };
+        if (Number.isInteger(count) && count > 0) {
+            params.count = count;
+        }
+        await this._fetchAndInitiateQuiz(params);
+    }
+
+    async startCuratedChallenge({
+        categoryIds = [],
+        difficultyLevels = null,
+        numQuestions = null,
+        modeLabel = 'Por Categoria',
+    } = {}) {
+        const params = { mode: modeLabel || 'Por Categoria' };
+
+        if (Array.isArray(categoryIds) && categoryIds.length > 0) {
+            params.category_ids = categoryIds;
+        }
+
+        if (Array.isArray(difficultyLevels) && difficultyLevels.length > 0) {
+            params.difficulty_levels = difficultyLevels;
+        }
+
+        if (Number.isInteger(numQuestions) && numQuestions > 0) {
+            params.num_questions = numQuestions;
+        }
+
+        await this._fetchAndInitiateQuiz(params);
     }
 
     async startPredefinedQuiz(quizDefinicaoId) {

--- a/assets/js/ui/ChallengeHub.js
+++ b/assets/js/ui/ChallengeHub.js
@@ -20,14 +20,40 @@ export default class ChallengeHub {
             hubQuickQuizCount: this.quizUI.elements.hubQuickQuizCount,
             placeholderFiltrosContainer: this.quizUI.elements.placeholderFiltrosContainer,
             closeFiltersAndShowHubBtn: this.quizUI.elements.closeFiltersAndShowHubBtn,
-            
-            // --- INÍCIO DA CORREÇÃO: Mapeando para os novos IDs e estrutura ---
+
             resumeCard: document.getElementById('hub-resume-quiz-card'),
             resumeCardDescription: document.getElementById('hub-resume-card-description'),
             confirmResumeBtn: document.getElementById('hub-confirm-resume-btn'),
             discardResumeBtn: document.getElementById('hub-discard-resume-btn'),
-            // --- FIM DA CORREÇÃO ---
+
+            hubDailyChallengeBtn: document.getElementById('hub-daily-challenge-btn'),
+            hubFocusedReviewBtn: document.getElementById('hub-focused-review-btn'),
+            hubTotalCategoriesCount: document.getElementById('hub-total-categories-count'),
+            statTotalPoints: document.getElementById('hub-stat-total-points'),
+            statQuestionsMastered: document.getElementById('hub-stat-questions-mastered'),
+            statQuestionsToReview: document.getElementById('hub-stat-questions-to-review'),
+            categoryChipList: document.getElementById('hub-category-chip-list'),
+            quickFilterList: document.getElementById('hub-quick-filter-list'),
         };
+    }
+
+    _formatNumber(value) {
+        if (value === null || value === undefined) {
+            return '0';
+        }
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return value.toLocaleString('pt-BR');
+        }
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (trimmed === '') return '0';
+            const parsed = Number(trimmed.replace(/\./g, '').replace(',', '.'));
+            if (!Number.isNaN(parsed)) {
+                return parsed.toLocaleString('pt-BR');
+            }
+            return trimmed;
+        }
+        return '0';
     }
 
     /**
@@ -75,13 +101,15 @@ export default class ChallengeHub {
      * @param {number|string} count - O número de questões.
      */
     updateTotalQuestionsCount(count) {
+        const formattedCount = this._formatNumber(count);
+
         if (this.elements.hubTotalQuestionsCount) {
-            this.elements.hubTotalQuestionsCount.textContent = count || '0';
+            this.elements.hubTotalQuestionsCount.textContent = formattedCount;
         }
-        
+
         const totalQuestionsSpanHome = document.getElementById('hub-total-questions-count');
         if (totalQuestionsSpanHome && totalQuestionsSpanHome !== this.elements.hubTotalQuestionsCount) {
-            totalQuestionsSpanHome.textContent = count || '0';
+            totalQuestionsSpanHome.textContent = formattedCount;
         }
     }
 
@@ -90,9 +118,115 @@ export default class ChallengeHub {
      * @param {number|string} count - O número de questões para o quiz rápido.
      */
     updateQuickQuizCount(count) {
+        const formattedCount = this._formatNumber(count);
         if (this.elements.hubQuickQuizCount) {
-            this.elements.hubQuickQuizCount.textContent = count || '0';
+            this.elements.hubQuickQuizCount.textContent = formattedCount;
         }
+    }
+
+    updateTotalCategoriesCount(count) {
+        const formattedCount = this._formatNumber(count);
+        if (this.elements.hubTotalCategoriesCount) {
+            this.elements.hubTotalCategoriesCount.textContent = formattedCount;
+        }
+    }
+
+    updateUserStats(stats = {}) {
+        const {
+            pontos = 0,
+            acertos = 0,
+            erros = 0,
+        } = stats;
+
+        if (this.elements.statTotalPoints) {
+            this.elements.statTotalPoints.textContent = this._formatNumber(pontos);
+        }
+        if (this.elements.statQuestionsMastered) {
+            this.elements.statQuestionsMastered.textContent = this._formatNumber(acertos);
+        }
+        if (this.elements.statQuestionsToReview) {
+            this.elements.statQuestionsToReview.textContent = this._formatNumber(erros);
+        }
+    }
+
+    updateFeaturedCategories(categories = []) {
+        const container = this.elements.categoryChipList;
+        if (!container) return;
+
+        container.innerHTML = '';
+
+        const validCategories = Array.isArray(categories)
+            ? categories.filter(cat => cat && cat.id_categoria !== undefined && cat.nome_categoria)
+            : [];
+
+        if (!validCategories.length) {
+            const emptyState = document.createElement('p');
+            emptyState.className = 'challenge-hub__empty-state';
+            emptyState.textContent = 'As trilhas serão carregadas assim que os dados estiverem disponíveis.';
+            container.appendChild(emptyState);
+            return;
+        }
+
+        const topCategories = validCategories.slice(0, 6);
+
+        topCategories.forEach(cat => {
+            const chip = document.createElement('button');
+            chip.type = 'button';
+            chip.className = 'challenge-chip';
+            chip.dataset.categoryId = cat.id_categoria;
+            chip.setAttribute('role', 'listitem');
+
+            const titleSpan = document.createElement('span');
+            titleSpan.className = 'challenge-chip__label';
+            titleSpan.textContent = cat.nome_categoria;
+            chip.appendChild(titleSpan);
+
+            const description = typeof cat.descricao_categoria === 'string' ? cat.descricao_categoria.trim() : '';
+            if (description) {
+                const truncated = description.length > 72 ? `${description.slice(0, 69)}…` : description;
+                const descriptionSpan = document.createElement('span');
+                descriptionSpan.className = 'challenge-chip__meta';
+                descriptionSpan.textContent = truncated;
+                chip.appendChild(descriptionSpan);
+                chip.title = `${cat.nome_categoria} • ${description}`;
+            } else {
+                chip.title = cat.nome_categoria;
+            }
+
+            container.appendChild(chip);
+        });
+    }
+
+    _openFilterPanelWithPreset({ categoryIds = [], difficultyLevels = ['all'], numQuestions = null } = {}) {
+        if (!this.quizUI.modalManager) {
+            console.error('ChallengeHub: modalManager não encontrado para abrir painel de filtros.');
+            return;
+        }
+
+        const normalizedCategoryIds = Array.isArray(categoryIds)
+            ? categoryIds.filter(Boolean).map(id => id.toString())
+            : [];
+
+        if (this.quizUI.filterPanelInstance) {
+            this.quizUI.filterPanelInstance.setCategoryTreeState(normalizedCategoryIds);
+            if (Array.isArray(difficultyLevels) && difficultyLevels.length > 0) {
+                this.quizUI.filterPanelInstance.setDifficultyState(difficultyLevels);
+            }
+
+            if (Number.isInteger(numQuestions) && numQuestions > 0) {
+                this.quizUI.filterPanelInstance.setNumberOfQuestionsState(numQuestions);
+            } else {
+                this.quizUI.filterPanelInstance.setNumberOfQuestionsState(null);
+            }
+
+            this.quizUI.filterPanelInstance.setSearchQuery('');
+        }
+
+        this.hideHub();
+        if (this.elements.placeholderFiltrosContainer) {
+            this.quizUI.showElement(this.elements.placeholderFiltrosContainer);
+        }
+        this.quizUI.modalManager.toggleFilterPanel(true);
     }
 
     /**
@@ -122,15 +256,7 @@ export default class ChallengeHub {
      */
     setupEventListeners() {
         this.elements.hubCustomizeQuizBtn?.addEventListener('click', () => {
-            if (!this.quizUI.modalManager) { 
-                console.error("ChallengeHub: modalManager não encontrado para abrir painel de filtros.");
-                return;
-            }
-            this.hideHub();
-            if (this.elements.placeholderFiltrosContainer) {
-                this.quizUI.showElement(this.elements.placeholderFiltrosContainer);
-            }
-            this.quizUI.modalManager.toggleFilterPanel(true);
+            this._openFilterPanelWithPreset();
         });
 
         this.elements.hubQuickQuizBtn?.addEventListener('click', () => {
@@ -141,7 +267,28 @@ export default class ChallengeHub {
                 console.error("ChallengeHub: actionOrchestrator indisponível ao clicar em Quiz Rápido.");
             }
         });
-        
+
+        this.elements.hubDailyChallengeBtn?.addEventListener('click', () => {
+            if (this.actionOrchestrator) {
+                this.hideHub();
+                this.actionOrchestrator.startQuickQuiz(20);
+            } else {
+                console.error('ChallengeHub: actionOrchestrator indisponível ao iniciar o Desafio do Dia.');
+            }
+        });
+
+        this.elements.hubFocusedReviewBtn?.addEventListener('click', () => {
+            if (this.actionOrchestrator) {
+                this.hideHub();
+                this.actionOrchestrator.startCuratedChallenge({
+                    difficultyLevels: ['difícil'],
+                    numQuestions: 12,
+                });
+            } else {
+                console.error('ChallengeHub: actionOrchestrator indisponível ao iniciar Revisão Focada.');
+            }
+        });
+
         // --- INÍCIO DA CORREÇÃO: Listeners agora nos botões corretos e separados ---
         this.elements.confirmResumeBtn?.addEventListener('click', () => {
              if (this.actionOrchestrator) {
@@ -155,5 +302,33 @@ export default class ChallengeHub {
             }
         });
         // --- FIM DA CORREÇÃO ---
+
+        this.elements.categoryChipList?.addEventListener('click', (event) => {
+            const target = event.target.closest('.challenge-chip[data-category-id]');
+            if (!target) return;
+
+            const categoryId = target.dataset.categoryId;
+            if (!categoryId) return;
+
+            this._openFilterPanelWithPreset({ categoryIds: [categoryId] });
+        });
+
+        this.elements.quickFilterList?.addEventListener('click', (event) => {
+            const actionButton = event.target.closest('.challenge-quick-action');
+            if (!actionButton) return;
+            if (!this.actionOrchestrator) {
+                console.error('ChallengeHub: actionOrchestrator indisponível ao utilizar atalhos rápidos.');
+                return;
+            }
+
+            const difficulty = actionButton.dataset.hubDifficulty;
+            const numQuestions = Number.parseInt(actionButton.dataset.hubNumQuestions, 10);
+
+            this.hideHub();
+            this.actionOrchestrator.startCuratedChallenge({
+                difficultyLevels: difficulty ? [difficulty] : undefined,
+                numQuestions: Number.isInteger(numQuestions) && numQuestions > 0 ? numQuestions : undefined,
+            });
+        });
     }
 }

--- a/assets/js/ui/QuizUI.js
+++ b/assets/js/ui/QuizUI.js
@@ -113,6 +113,40 @@ export default class QuizUI {
             } else if (hadResumableSession && !hasResumableSession) {
                 this.challengeHubInstance.hideResumeOption();
             }
+
+            const prevTotalQuestions = this.previousState.geral?.totalQuestionsAvailable;
+            const currentTotalQuestions = currentState.geral?.totalQuestionsAvailable;
+            if (prevTotalQuestions !== currentTotalQuestions) {
+                this.challengeHubInstance.updateTotalQuestionsCount(currentTotalQuestions);
+            }
+
+            const prevQuickCount = this.previousState.geral?.homeSummary?.quickQuizDefaultCount;
+            const currentQuickCount = currentState.geral?.homeSummary?.quickQuizDefaultCount;
+            if (prevQuickCount !== currentQuickCount) {
+                this.challengeHubInstance.updateQuickQuizCount(currentQuickCount);
+            }
+
+            const prevCategoryCount = this.previousState.geral?.homeSummary?.totalCategories;
+            const currentCategoryCount = currentState.geral?.homeSummary?.totalCategories;
+            if (prevCategoryCount !== currentCategoryCount) {
+                this.challengeHubInstance.updateTotalCategoriesCount(currentCategoryCount);
+            }
+
+            const prevCategories = this.previousState.geral?.allCategories;
+            const currentCategories = currentState.geral?.allCategories;
+            if (prevCategories !== currentCategories) {
+                this.challengeHubInstance.updateFeaturedCategories(currentCategories);
+            }
+
+            const prevUserStats = this.previousState.user;
+            const currentUserStats = currentState.user;
+            if (
+                prevUserStats?.pontos !== currentUserStats?.pontos
+                || prevUserStats?.acertos !== currentUserStats?.acertos
+                || prevUserStats?.erros !== currentUserStats?.erros
+            ) {
+                this.challengeHubInstance.updateUserStats(currentUserStats);
+            }
         }
         // --- FIM DA ALTERAÇÃO ---
 
@@ -197,6 +231,14 @@ export default class QuizUI {
             challengeHubContainer: document.getElementById('challenge-hub-container'),
             hubTotalQuestionsCount: document.getElementById('hub-total-questions-count'),
             hubQuickQuizCount: document.getElementById('hub-quick-quiz-count'),
+            hubTotalCategoriesCount: document.getElementById('hub-total-categories-count'),
+            hubDailyChallengeBtn: document.getElementById('hub-daily-challenge-btn'),
+            hubFocusedReviewBtn: document.getElementById('hub-focused-review-btn'),
+            hubQuickFilterList: document.getElementById('hub-quick-filter-list'),
+            hubCategoryChipList: document.getElementById('hub-category-chip-list'),
+            hubStatTotalPoints: document.getElementById('hub-stat-total-points'),
+            hubStatQuestionsMastered: document.getElementById('hub-stat-questions-mastered'),
+            hubStatQuestionsToReview: document.getElementById('hub-stat-questions-to-review'),
             hubCustomizeQuizBtn: document.getElementById('hub-customize-quiz-btn'),
             hubQuickQuizBtn: document.getElementById('hub-quick-quiz-btn'),
             placeholderFiltrosContainer: document.getElementById('placeholder-filtros-container'),

--- a/quiz/templates/quiz/questions_page.html
+++ b/quiz/templates/quiz/questions_page.html
@@ -40,11 +40,52 @@
             
             <div id="challenge-hub-container" class="challenge-hub">
                 <div class="challenge-hub__header">
-                    <h2 class="challenge-hub__title">Escolha seu Desafio</h2>
-                    <p class="challenge-hub__subtitle">Explore nosso banco de <span id="hub-total-questions-count">0</span> questões.</p>
+                    <span class="challenge-hub__eyebrow">Hub de desafios</span>
+                    <h2 class="challenge-hub__title">Escolha a próxima jornada</h2>
+                    <p class="challenge-hub__subtitle">
+                        Acesse <strong><span id="hub-total-questions-count">0</span></strong> questões distribuídas em
+                        <strong><span id="hub-total-categories-count">0</span></strong> trilhas temáticas para montar o estudo ideal.
+                    </p>
                 </div>
+
+                <div class="challenge-hub__summary">
+                    <div class="challenge-hub__stats" role="list">
+                        <article class="challenge-stat-card" role="listitem">
+                            <span class="material-symbols-outlined challenge-stat-card__icon" aria-hidden="true">military_tech</span>
+                            <div class="challenge-stat-card__content">
+                                <span class="challenge-stat-card__label">Pontuação total</span>
+                                <strong id="hub-stat-total-points" class="challenge-stat-card__value">0</strong>
+                            </div>
+                        </article>
+                        <article class="challenge-stat-card" role="listitem">
+                            <span class="material-symbols-outlined challenge-stat-card__icon" aria-hidden="true">task_alt</span>
+                            <div class="challenge-stat-card__content">
+                                <span class="challenge-stat-card__label">Questões dominadas</span>
+                                <strong id="hub-stat-questions-mastered" class="challenge-stat-card__value">0</strong>
+                            </div>
+                        </article>
+                        <article class="challenge-stat-card" role="listitem">
+                            <span class="material-symbols-outlined challenge-stat-card__icon" aria-hidden="true">refresh</span>
+                            <div class="challenge-stat-card__content">
+                                <span class="challenge-stat-card__label">Para revisar</span>
+                                <strong id="hub-stat-questions-to-review" class="challenge-stat-card__value">0</strong>
+                            </div>
+                        </article>
+                    </div>
+                    <div class="challenge-hub__callout">
+                        <h3 class="challenge-hub__callout-title">Personalize seus estudos</h3>
+                        <p class="challenge-hub__callout-text">
+                            Combine filtros avançados, salve suas preferências e crie desafios sob medida quando quiser.
+                        </p>
+                        <button id="hub-customize-quiz-btn" class="button button--primary challenge-hub__callout-button">
+                            <span class="material-symbols-outlined button__icon" aria-hidden="true">tune</span>
+                            <span class="button__label">Abrir filtros inteligentes</span>
+                        </button>
+                    </div>
+                </div>
+
                 <div class="challenge-hub__options-grid">
-                    
+
                     {# ========================================================================== #}
                     {# ============ CARD DE RESUMO REFAFORADO (COM HTML MELHORADO) ============ #}
                     {# ========================================================================== #}
@@ -54,6 +95,7 @@
                         </div>
                         <div class="challenge-card__main">
                             <div class="challenge-card__content">
+                                <span class="challenge-card__eyebrow">Retomar sessão</span>
                                 <h3 class="challenge-card__title">Continuar Desafio</h3>
                                 <p class="challenge-card__description" id="hub-resume-card-description">
                                     Você tem uma sessão em andamento.
@@ -67,24 +109,67 @@
                     </div>
                     {# ======================= FIM DA REFAFORAÇÃO DO CARD ====================== #}
 
-                    <button id="hub-customize-quiz-btn" class="challenge-card">
-                        <div class="challenge-card__icon-wrapper">
-                            <span class="material-symbols-outlined challenge-card__icon">tune</span>
-                        </div>
-                        <div class="challenge-card__content">
-                            <h3 class="challenge-card__title">Personalizar Quiz</h3>
-                            <p class="challenge-card__description">Escolha temas, dificuldade e modo de estudo.</p>
-                        </div>
-                    </button>
-                    <button id="hub-quick-quiz-btn" class="challenge-card">
+                    <button id="hub-quick-quiz-btn" class="challenge-card challenge-card--accent">
                         <div class="challenge-card__icon-wrapper">
                             <span class="material-symbols-outlined challenge-card__icon">bolt</span>
                         </div>
                         <div class="challenge-card__content">
+                            <span class="challenge-card__eyebrow">Comece agora</span>
                             <h3 class="challenge-card__title">Quiz Rápido</h3>
-                            <p class="challenge-card__description">Um desafio de <span id="hub-quick-quiz-count">10</span> questões aleatórias para começar.</p>
+                            <p class="challenge-card__description">Um desafio de <span id="hub-quick-quiz-count">10</span> questões aleatórias para aquecer.</p>
                         </div>
                     </button>
+
+                    <button id="hub-daily-challenge-btn" class="challenge-card challenge-card--primary">
+                        <div class="challenge-card__icon-wrapper">
+                            <span class="material-symbols-outlined challenge-card__icon">calendar_today</span>
+                        </div>
+                        <div class="challenge-card__content">
+                            <span class="challenge-card__eyebrow">Rotina guiada</span>
+                            <h3 class="challenge-card__title">Desafio do Dia</h3>
+                            <p class="challenge-card__description">20 questões selecionadas automaticamente para manter o ritmo.</p>
+                        </div>
+                    </button>
+
+                    <button id="hub-focused-review-btn" class="challenge-card challenge-card--outline">
+                        <div class="challenge-card__icon-wrapper">
+                            <span class="material-symbols-outlined challenge-card__icon">target</span>
+                        </div>
+                        <div class="challenge-card__content">
+                            <span class="challenge-card__eyebrow">Modo intensivo</span>
+                            <h3 class="challenge-card__title">Revisão Focada</h3>
+                            <p class="challenge-card__description">Sessão com 12 questões de dificuldade alta para consolidar aprendizados.</p>
+                        </div>
+                    </button>
+                </div>
+
+                <div class="challenge-hub__section">
+                    <div class="challenge-hub__section-header">
+                        <h3 class="challenge-hub__section-title">Coleções recomendadas</h3>
+                        <p class="challenge-hub__section-subtitle">Selecione uma trilha para abrir o painel de filtros já configurado.</p>
+                    </div>
+                    <div id="hub-category-chip-list" class="challenge-chip-list" role="list"></div>
+                </div>
+
+                <div class="challenge-hub__section">
+                    <div class="challenge-hub__section-header">
+                        <h3 class="challenge-hub__section-title">Atalhos rápidos</h3>
+                        <p class="challenge-hub__section-subtitle">Gere quizzes instantâneos por nível de dificuldade.</p>
+                    </div>
+                    <div id="hub-quick-filter-list" class="challenge-quick-actions">
+                        <button class="challenge-quick-action" data-hub-difficulty="fácil" data-hub-num-questions="10">
+                            <span class="challenge-quick-action__title">Aquecimento</span>
+                            <span class="challenge-quick-action__meta">10 questões fáceis</span>
+                        </button>
+                        <button class="challenge-quick-action" data-hub-difficulty="médio" data-hub-num-questions="15">
+                            <span class="challenge-quick-action__title">Ritmo Constante</span>
+                            <span class="challenge-quick-action__meta">15 questões intermediárias</span>
+                        </button>
+                        <button class="challenge-quick-action" data-hub-difficulty="difícil" data-hub-num-questions="12">
+                            <span class="challenge-quick-action__title">Modo Desafio</span>
+                            <span class="challenge-quick-action__meta">12 questões avançadas</span>
+                        </button>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- redesign the challenge hub layout with stats, curated sections, extra quick-start cards and category shortcuts
- refresh the challenge hub visual style with modern gradients, card variants, chips, and quick action components
- extend the JavaScript controllers to drive the new metrics, curated challenge flows, and category presets, including orchestrator support

## Testing
- python manage.py check *(fails: Django not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d03d62ad1083338bc06a576fdad405