### PR TITLE
Revise scoring system and add gamification

### DIFF
--- a/quiz/admin.py
+++ b/quiz/admin.py
@@ -11,6 +11,7 @@ from .models import (
     QuestaoFavorita, # Adicionado se não estiver lá
     QuizDefinicao, QuizDefinicaoPergunta, ConfiguracoesGeraisQuiz, # Novos modelos
     UserPreferences,
+    NivelGamificacao, Conquista, PerfilGamificacaoUsuario, ConquistaUsuario,
 )
 
 # Inline para OpcoesResposta dentro de PerguntaAdmin
@@ -159,16 +160,17 @@ class RespostasUsuarioPorSessaoInline(admin.TabularInline):
 class SessoesQuizUsuarioAdmin(admin.ModelAdmin):
     list_display = (
         'id', 'link_usuario', 'data_inicio_formatada', 'duracao_sessao_formatada',
-        'modo_quiz', 'status_sessao', 'pontuacao_final',
-        'total_acertos', 'percentual_acertos',
-        'total_erros', 'total_perguntas_sessao', 'link_quiz_definicao'
+        'modo_quiz', 'status_sessao', 'pontuacao_final', 'xp_total_sessao',
+        'total_acertos', 'percentual_acertos', 'total_erros',
+        'sequencia_acertos_atual', 'melhor_sequencia_acertos',
+        'total_perguntas_sessao', 'link_quiz_definicao'
     )
     list_filter = ('modo_quiz', 'status_sessao', 'data_inicio', 'id_usuario__username', 'id_quiz_definicao')
     search_fields = ('id_usuario__username', 'id_usuario__email', 'id', 'id_quiz_definicao__nome_quiz')
     readonly_fields = (
-        'data_inicio', 'data_fim', 'tempo_total_segundos', 'pontuacao_final',
+        'data_inicio', 'data_fim', 'tempo_total_segundos', 'pontuacao_final', 'xp_total_sessao',
         'total_acertos', 'total_erros', 'total_perguntas_sessao',
-        'duracao_sessao_formatada', 'percentual_acertos',
+        'duracao_sessao_formatada', 'percentual_acertos', 'sequencia_acertos_atual', 'melhor_sequencia_acertos',
         'ids_perguntas_json', 'indice_ultima_pergunta_vista' # Novos campos como readonly
     )
     autocomplete_fields = ['id_usuario', 'id_quiz_definicao']
@@ -191,7 +193,11 @@ class SessoesQuizUsuarioAdmin(admin.ModelAdmin):
             'classes': ('collapse',),
         }),
         ('Resultados (Automático)', {
-            'fields': ('pontuacao_final', 'total_perguntas_sessao', 'total_acertos', 'percentual_acertos', 'total_erros'),
+            'fields': (
+                'pontuacao_final', 'xp_total_sessao', 'total_perguntas_sessao',
+                'total_acertos', 'percentual_acertos', 'total_erros',
+                'sequencia_acertos_atual', 'melhor_sequencia_acertos'
+            ),
             'classes': ('collapse',),
         }),
     )
@@ -217,10 +223,13 @@ class SessoesQuizUsuarioAdmin(admin.ModelAdmin):
 
 @admin.register(RespostasUsuarioPorSessao)
 class RespostasUsuarioPorSessaoAdmin(admin.ModelAdmin):
-    list_display = ('id', 'link_sessao_quiz_formatado', 'link_pergunta_curta', 'link_opcao_selecionada_curta', 'foi_correta', 'data_resposta_formatada')
+    list_display = (
+        'id', 'link_sessao_quiz_formatado', 'link_pergunta_curta', 'link_opcao_selecionada_curta',
+        'foi_correta', 'pontos_obtidos', 'xp_obtido', 'multiplicador_aplicado', 'data_resposta_formatada'
+    )
     list_filter = ('foi_correta', 'data_resposta', 'id_sessao_quiz__id_usuario__username', 'id_pergunta__nivel_dificuldade', 'id_sessao_quiz__modo_quiz')
     search_fields = ('id_sessao_quiz__id', 'id_pergunta__texto_pergunta', 'id_opcao_resposta_selecionada__texto_opcao', 'id_sessao_quiz__id_usuario__username')
-    readonly_fields = ('data_resposta',)
+    readonly_fields = ('data_resposta', 'pontos_obtidos', 'xp_obtido', 'multiplicador_aplicado')
     autocomplete_fields = ['id_sessao_quiz', 'id_pergunta', 'id_opcao_resposta_selecionada']
     list_select_related = ('id_sessao_quiz__id_usuario', 'id_pergunta', 'id_opcao_resposta_selecionada')
     date_hierarchy = 'data_resposta'
@@ -254,7 +263,7 @@ class EstatisticasDiariasUsuarioAdmin(admin.ModelAdmin):
     list_display = (
         'id', 'link_usuario_stats', 'data_estatistica', 'perguntas_respondidas_dia',
         'acertos_dia', 'precisao_dia',
-        'pontos_dia', 'sequencia_dias_quiz',
+        'pontos_dia', 'xp_ganho_dia', 'sequencia_dias_quiz',
         'tempo_estudo_formatado',
         'data_atualizacao_estatistica_fmt'
     )
@@ -267,7 +276,7 @@ class EstatisticasDiariasUsuarioAdmin(admin.ModelAdmin):
 
     fieldsets = (
         (None, {'fields': ('id_usuario', 'data_estatistica')}),
-        ('Desempenho Diário', {'fields': ('perguntas_respondidas_dia', 'acertos_dia', 'precisao_dia', 'pontos_dia', 'tempo_estudo_segundos_dia', 'tempo_estudo_formatado')}),
+        ('Desempenho Diário', {'fields': ('perguntas_respondidas_dia', 'acertos_dia', 'precisao_dia', 'pontos_dia', 'xp_ganho_dia', 'tempo_estudo_segundos_dia', 'tempo_estudo_formatado')}),
         ('Engajamento', {'fields': ('sequencia_dias_quiz',)}),
         ('Datas de Auditoria', {'fields': ('data_atualizacao_estatistica',), 'classes': ('collapse',)}),
     )
@@ -348,11 +357,34 @@ class QuizDefinicaoAdmin(admin.ModelAdmin):
 
 @admin.register(ConfiguracoesGeraisQuiz)
 class ConfiguracoesGeraisQuizAdmin(admin.ModelAdmin):
-    list_display = ('__str__', 'numero_perguntas_quiz_rapido', 'pontuacao_por_acerto', 'penalidade_por_erro', 'data_modificacao_formatada')
+    list_display = (
+        '__str__',
+        'numero_perguntas_quiz_rapido',
+        'pontuacao_por_acerto',
+        'penalidade_por_erro',
+        'multiplicador_bonus_maximo',
+        'data_modificacao_formatada',
+    )
     readonly_fields = ('data_modificacao',)
     fieldsets = (
         (None, {
-            'fields': ('numero_perguntas_quiz_rapido', 'pontuacao_por_acerto', 'penalidade_por_erro')
+            'fields': (
+                'numero_perguntas_quiz_rapido',
+                'pontuacao_por_acerto',
+                'penalidade_por_erro',
+                'multiplicador_bonus_maximo',
+            )
+        }),
+        ('Pontuação Dinâmica', {
+            'fields': (
+                'configuracao_pontuacao_dificuldade',
+                'bonus_sequencia_acertos',
+            ),
+            'classes': ('collapse',),
+            'description': (
+                'Configure recompensas específicas por dificuldade e os bônus aplicados a sequências de acertos. '
+                'Essas estruturas JSON permitem integrar regras avançadas sem alterar o código.'
+            ),
         }),
         ('Datas de Auditoria', {
             'fields': ('data_modificacao',),
@@ -393,3 +425,35 @@ class UserPreferencesAdmin(admin.ModelAdmin):
 # @admin.register(User)
 # class CustomUserAdmin(BaseUserAdmin):
 #     pass
+
+@admin.register(NivelGamificacao)
+class NivelGamificacaoAdmin(admin.ModelAdmin):
+    list_display = ('nome', 'ordem', 'xp_minimo', 'xp_maximo')
+    search_fields = ('nome', 'identificador')
+    list_editable = ('ordem',)
+    ordering = ('ordem', 'xp_minimo')
+
+
+@admin.register(Conquista)
+class ConquistaAdmin(admin.ModelAdmin):
+    list_display = ('nome', 'slug', 'ordem_exibicao')
+    search_fields = ('nome', 'slug')
+    list_editable = ('ordem_exibicao',)
+    ordering = ('ordem_exibicao', 'nome')
+
+
+@admin.register(PerfilGamificacaoUsuario)
+class PerfilGamificacaoUsuarioAdmin(admin.ModelAdmin):
+    list_display = ('user', 'xp_total', 'nivel_atual', 'melhor_sequencia_geral', 'sequencia_atual', 'ultima_atualizacao')
+    search_fields = ('user__username', 'user__email')
+    list_select_related = ('user', 'nivel_atual')
+    readonly_fields = ('ultima_atualizacao',)
+    autocomplete_fields = ('user', 'nivel_atual', 'conquistas')
+
+
+@admin.register(ConquistaUsuario)
+class ConquistaUsuarioAdmin(admin.ModelAdmin):
+    list_display = ('perfil', 'conquista', 'data_conquista')
+    search_fields = ('perfil__user__username', 'conquista__nome')
+    list_filter = ('conquista', 'data_conquista')
+    autocomplete_fields = ('perfil', 'conquista')

--- a/quiz/api/viewsets.py
+++ b/quiz/api/viewsets.py
@@ -28,6 +28,8 @@ from quiz.models import (
 )
 from quiz.services.quiz_service import QuizDataService
 from quiz.services.statistics_service import StatisticsService
+from quiz.services.scoring_service import ScoringService
+from quiz.services.gamification_service import GamificationService
 from quiz.views import (
     _get_category_performance_data,
     _get_difficulty_performance_data,
@@ -52,6 +54,10 @@ from .serializers import (
 
 class QuizViewSet(viewsets.ViewSet):
     """Aggregates all quiz related endpoints used by the front-end."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._gamification_service = GamificationService()
 
     def _parse_csv(self, value):
         if not value:
@@ -213,6 +219,48 @@ class QuizViewSet(viewsets.ViewSet):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
+    def _recalculate_session_metrics(self, sessao_quiz, quiz_config):
+        responses = list(
+            RespostasUsuarioPorSessao.objects.filter(id_sessao_quiz=sessao_quiz)
+            .select_related('id_pergunta')
+            .order_by('data_resposta', 'pk')
+        )
+
+        scoring_service = ScoringService(quiz_config)
+        score_result = scoring_service.compute_session_result(responses)
+
+        if responses:
+            for response_obj, response_score in zip(responses, score_result.response_scores):
+                response_obj.pontos_obtidos = response_score.pontos
+                response_obj.xp_obtido = response_score.xp
+                response_obj.multiplicador_aplicado = response_score.multiplicador
+            RespostasUsuarioPorSessao.objects.bulk_update(
+                responses,
+                ['pontos_obtidos', 'xp_obtido', 'multiplicador_aplicado'],
+            )
+
+        fields_to_update = [
+            'total_acertos',
+            'total_erros',
+            'pontuacao_final',
+            'xp_total_sessao',
+            'sequencia_acertos_atual',
+            'melhor_sequencia_acertos',
+        ]
+
+        sessao_quiz.total_acertos = score_result.total_correct
+        sessao_quiz.total_erros = score_result.total_incorrect
+        sessao_quiz.pontuacao_final = score_result.total_points
+        sessao_quiz.xp_total_sessao = score_result.total_xp
+        sessao_quiz.sequencia_acertos_atual = score_result.current_streak
+        sessao_quiz.melhor_sequencia_acertos = score_result.best_streak
+        if score_result.total_answered > sessao_quiz.total_perguntas_sessao:
+            sessao_quiz.total_perguntas_sessao = score_result.total_answered
+            fields_to_update.append('total_perguntas_sessao')
+
+        sessao_quiz.save(update_fields=fields_to_update)
+        return score_result
+
     @action(detail=False, methods=['post'], url_path='start-session')
     def start_session(self, request):
         if not request.user.is_authenticated:
@@ -292,6 +340,8 @@ class QuizViewSet(viewsets.ViewSet):
 
         return Response({'status': 'success', 'session_id': nova_sessao.pk})
 
+
+
     @action(detail=False, methods=['post'], url_path='register-answer')
     def register_answer(self, request):
         if not request.user.is_authenticated:
@@ -347,35 +397,31 @@ class QuizViewSet(viewsets.ViewSet):
                 },
             )
 
-            respostas_da_sessao = RespostasUsuarioPorSessao.objects.filter(id_sessao_quiz=sessao_quiz)
-            sessao_quiz.total_acertos = respostas_da_sessao.filter(foi_correta=True).count()
-            sessao_quiz.total_erros = respostas_da_sessao.filter(
-                foi_correta=False,
-                id_opcao_resposta_selecionada__isnull=False,
-            ).count()
-            sessao_quiz.pontuacao_final = max(
-                0,
-                (sessao_quiz.total_acertos * quiz_config.pontuacao_por_acerto)
-                - (sessao_quiz.total_erros * quiz_config.penalidade_por_erro),
-            )
+            score_result = self._recalculate_session_metrics(sessao_quiz, quiz_config)
 
+            indice_updated = False
             if current_question_index is not None:
                 try:
                     idx = int(current_question_index)
                     if sessao_quiz.ids_perguntas_json and 0 <= idx < len(sessao_quiz.ids_perguntas_json):
                         sessao_quiz.indice_ultima_pergunta_vista = idx
+                        indice_updated = True
                 except ValueError:
                     pass
-
-            sessao_quiz.save()
+            if indice_updated:
+                sessao_quiz.save(update_fields=['indice_ultima_pergunta_vista'])
 
             return Response({
                 'status': 'success',
                 'message': 'Resposta registrada.',
                 'foi_correta': foi_correta_calculada,
                 'pontuacao_sessao': sessao_quiz.pontuacao_final,
+                'xp_sessao': sessao_quiz.xp_total_sessao,
                 'total_acertos_sessao': sessao_quiz.total_acertos,
                 'total_erros_sessao': sessao_quiz.total_erros,
+                'sequencia_atual': sessao_quiz.sequencia_acertos_atual,
+                'melhor_sequencia_sessao': sessao_quiz.melhor_sequencia_acertos,
+                'multiplicador_atual': score_result.last_multiplier,
             })
         except SessoesQuizUsuario.DoesNotExist:
             return Response(
@@ -397,6 +443,7 @@ class QuizViewSet(viewsets.ViewSet):
                 {'status': 'error', 'message': 'Erro interno ao registrar resposta.'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
+
 
     @action(detail=False, methods=['post'], url_path='end-session')
     def end_session(self, request):
@@ -433,12 +480,15 @@ class QuizViewSet(viewsets.ViewSet):
                     'pontuacao_final': sessao_quiz.pontuacao_final,
                     'total_acertos': sessao_quiz.total_acertos,
                     'total_erros': sessao_quiz.total_erros,
+                    'xp_final': sessao_quiz.xp_total_sessao,
                 })
+
+            score_result = self._recalculate_session_metrics(sessao_quiz, get_quiz_config())
 
             sessao_quiz.data_fim = timezone.now()
             sessao_quiz.tempo_total_segundos = tempo_total_segundos_frontend
             sessao_quiz.status_sessao = SessoesQuizUsuario.StatusSessao.COMPLETA
-            sessao_quiz.save()
+            sessao_quiz.save(update_fields=['data_fim', 'tempo_total_segundos', 'status_sessao'])
 
             stats = get_or_create_daily_stats(request.user)
             perguntas_respondidas_na_sessao = RespostasUsuarioPorSessao.objects.filter(
@@ -449,8 +499,15 @@ class QuizViewSet(viewsets.ViewSet):
             stats.perguntas_respondidas_dia += perguntas_respondidas_na_sessao
             stats.acertos_dia += sessao_quiz.total_acertos
             stats.pontos_dia += sessao_quiz.pontuacao_final
+            stats.xp_ganho_dia += sessao_quiz.xp_total_sessao
             stats.tempo_estudo_segundos_dia += tempo_total_segundos_frontend
             stats.save()
+
+            gamification_result = self._gamification_service.apply_session_result(
+                request.user,
+                sessao_quiz,
+                score_result,
+            )
 
             return Response({
                 'status': 'success',
@@ -458,6 +515,9 @@ class QuizViewSet(viewsets.ViewSet):
                 'pontuacao_final': sessao_quiz.pontuacao_final,
                 'total_acertos': sessao_quiz.total_acertos,
                 'total_erros': sessao_quiz.total_erros,
+                'xp_final': sessao_quiz.xp_total_sessao,
+                'sequencia_final': sessao_quiz.melhor_sequencia_acertos,
+                'conquistas_desbloqueadas': gamification_result.conquistas_desbloqueadas,
             })
         except SessoesQuizUsuario.DoesNotExist:
             return Response(
@@ -599,8 +659,11 @@ class QuizViewSet(viewsets.ViewSet):
                 'respostas_dadas': respostas_dadas_map,
                 'indice_ultima_pergunta_vista': sessao_ativa.indice_ultima_pergunta_vista,
                 'pontuacao_atual': sessao_ativa.pontuacao_final,
+                'xp_atual': sessao_ativa.xp_total_sessao,
                 'total_acertos_atual': sessao_ativa.total_acertos,
                 'total_erros_atual': sessao_ativa.total_erros,
+                'sequencia_atual': sessao_ativa.sequencia_acertos_atual,
+                'melhor_sequencia': sessao_ativa.melhor_sequencia_acertos,
                 'data_inicio_sessao_iso': sessao_ativa.data_inicio.isoformat(),
             })
         except Exception:

--- a/quiz/migrations/0009_gamification_and_scoring.py
+++ b/quiz/migrations/0009_gamification_and_scoring.py
@@ -1,0 +1,162 @@
+from django.db import migrations, models
+import django.core.validators
+import quiz.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('quiz', '0008_userpreferences'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='configuracoesgeraisquiz',
+            name='bonus_sequencia_acertos',
+            field=models.JSONField(
+                default=quiz.models.default_streak_bonus_rules,
+                help_text="Lista ordenada de objetos contendo 'streak' e 'bonus_percent', representando o aumento percentual aplicado ao acerto conforme a sequência atual.",
+                verbose_name='Bônus por Sequência de Acertos',
+            ),
+        ),
+        migrations.AddField(
+            model_name='configuracoesgeraisquiz',
+            name='configuracao_pontuacao_dificuldade',
+            field=models.JSONField(
+                default=quiz.models.default_difficulty_rewards,
+                help_text="Estrutura JSON com pontos, XP e penalidades por nível de dificuldade. Exemplo: {'Fácil': {'points': 10, 'xp': 5, 'penalty': 2}}",
+                verbose_name='Regras de Pontuação por Dificuldade',
+            ),
+        ),
+        migrations.AddField(
+            model_name='configuracoesgeraisquiz',
+            name='multiplicador_bonus_maximo',
+            field=models.FloatField(
+                default=2.0,
+                help_text='Limita o multiplicador total aplicado por bônus de sequência para evitar valores extremos.',
+                validators=[django.core.validators.MinValueValidator(1.0)],
+                verbose_name='Multiplicador Máximo de Bônus',
+            ),
+        ),
+        migrations.AddField(
+            model_name='estatisticasdiariasusuario',
+            name='xp_ganho_dia',
+            field=models.IntegerField(default=0, validators=[django.core.validators.MinValueValidator(0)], verbose_name='XP Ganhado no Dia'),
+        ),
+        migrations.AddField(
+            model_name='respostasusuarioporsessao',
+            name='multiplicador_aplicado',
+            field=models.FloatField(
+                default=1.0,
+                help_text='Fator de multiplicação aplicado em função de bônus de sequência.',
+                verbose_name='Multiplicador Aplicado',
+            ),
+        ),
+        migrations.AddField(
+            model_name='respostasusuarioporsessao',
+            name='pontos_obtidos',
+            field=models.IntegerField(default=0, help_text='Pontuação líquida obtida nesta resposta específica.', verbose_name='Pontos da Resposta'),
+        ),
+        migrations.AddField(
+            model_name='respostasusuarioporsessao',
+            name='xp_obtido',
+            field=models.IntegerField(default=0, help_text='Experiência concedida por esta resposta.', validators=[django.core.validators.MinValueValidator(0)], verbose_name='XP Obtido'),
+        ),
+        migrations.AddField(
+            model_name='sessoesquizusuario',
+            name='melhor_sequencia_acertos',
+            field=models.IntegerField(
+                default=0,
+                help_text='Maior sequência contínua de acertos registrada na sessão.',
+                validators=[django.core.validators.MinValueValidator(0)],
+                verbose_name='Melhor Sequência de Acertos',
+            ),
+        ),
+        migrations.AddField(
+            model_name='sessoesquizusuario',
+            name='sequencia_acertos_atual',
+            field=models.IntegerField(
+                default=0,
+                validators=[django.core.validators.MinValueValidator(0)],
+                verbose_name='Sequência Atual de Acertos',
+            ),
+        ),
+        migrations.AddField(
+            model_name='sessoesquizusuario',
+            name='xp_total_sessao',
+            field=models.IntegerField(
+                default=0,
+                help_text='Experiência total acumulada pelo usuário nesta sessão.',
+                validators=[django.core.validators.MinValueValidator(0)],
+                verbose_name='XP Ganha na Sessão',
+            ),
+        ),
+        migrations.CreateModel(
+            name='NivelGamificacao',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('identificador', models.CharField(help_text='Slug único para integrações ou referências em código.', max_length=100, unique=True, verbose_name='Identificador Interno')),
+                ('nome', models.CharField(max_length=150, verbose_name='Nome do Nível')),
+                ('descricao', models.TextField(blank=True, verbose_name='Descrição do Nível')),
+                ('ordem', models.PositiveIntegerField(default=1, help_text='Determina a ordem dos níveis (menor valor aparece primeiro).', verbose_name='Ordem de Exibição')),
+                ('xp_minimo', models.PositiveIntegerField(verbose_name='XP Mínimo')),
+                ('xp_maximo', models.PositiveIntegerField(blank=True, help_text='Opcional. Se vazio, considera-se que o nível não possui limite superior.', null=True, verbose_name='XP Máximo')),
+                ('recompensas_json', models.JSONField(blank=True, default=dict, help_text='Campo flexível para descrever benefícios concedidos ao alcançar o nível (ex: descontos, acesso antecipado).', verbose_name='Recompensas')),
+            ],
+            options={
+                'ordering': ['ordem', 'xp_minimo'],
+                'verbose_name': 'Nível de Gamificação',
+                'verbose_name_plural': 'Níveis de Gamificação',
+            },
+        ),
+        migrations.CreateModel(
+            name='Conquista',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('slug', models.SlugField(help_text='Identificador único usado para integrar regras de gamificação.', max_length=150, unique=True, verbose_name='Slug da Conquista')),
+                ('nome', models.CharField(max_length=150, verbose_name='Nome da Conquista')),
+                ('descricao', models.TextField(blank=True, verbose_name='Descrição')),
+                ('criterio_json', models.JSONField(blank=True, default=dict, help_text="Estrutura flexível descrevendo a regra para desbloqueio (ex: {'tipo': 'xp_total', 'valor': 1000}).", verbose_name='Critério')),
+                ('icone', models.CharField(blank=True, help_text='Nome de ícone ou caminho para imagem a ser exibida ao usuário.', max_length=255, verbose_name='Ícone')),
+                ('ordem_exibicao', models.PositiveIntegerField(default=0, help_text='Permite priorizar a exibição de conquistas em coleções.', verbose_name='Ordem de Exibição')),
+            ],
+            options={
+                'ordering': ['ordem_exibicao', 'nome'],
+                'verbose_name': 'Conquista',
+                'verbose_name_plural': 'Conquistas',
+            },
+        ),
+        migrations.CreateModel(
+            name='PerfilGamificacaoUsuario',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('xp_total', models.PositiveIntegerField(default=0, verbose_name='XP Total')),
+                ('melhor_sequencia_geral', models.PositiveIntegerField(default=0, verbose_name='Melhor Sequência Geral')),
+                ('sequencia_atual', models.PositiveIntegerField(default=0, verbose_name='Sequência Atual')),
+                ('ultima_atualizacao', models.DateTimeField(auto_now=True, verbose_name='Última Atualização')),
+                ('conquistas', models.ManyToManyField(blank=True, related_name='perfis_dos_usuarios', through='quiz.ConquistaUsuario', to='quiz.conquista', verbose_name='Conquistas Desbloqueadas')),
+                ('nivel_atual', models.ForeignKey(blank=True, null=True, on_delete=models.deletion.SET_NULL, related_name='perfis_associados', to='quiz.nivelgamificacao', verbose_name='Nível Atual')),
+                ('user', models.OneToOneField(on_delete=models.deletion.CASCADE, related_name='gamification_profile', to='auth.user', verbose_name='Usuário')),
+            ],
+            options={
+                'verbose_name': 'Perfil de Gamificação do Usuário',
+                'verbose_name_plural': 'Perfis de Gamificação dos Usuários',
+            },
+        ),
+        migrations.CreateModel(
+            name='ConquistaUsuario',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('data_conquista', models.DateTimeField(auto_now_add=True, verbose_name='Data da Conquista')),
+                ('metadata', models.JSONField(blank=True, default=dict, help_text='Informações extras sobre o desbloqueio (ex: motivo, valores alcançados).', verbose_name='Metadados')),
+                ('conquista', models.ForeignKey(on_delete=models.deletion.CASCADE, related_name='desbloqueios', to='quiz.conquista')),
+                ('perfil', models.ForeignKey(on_delete=models.deletion.CASCADE, related_name='conquistas_usuarios', to='quiz.perfilgamificacaousuario')),
+            ],
+            options={
+                'ordering': ['-data_conquista'],
+                'verbose_name': 'Conquista do Usuário',
+                'verbose_name_plural': 'Conquistas dos Usuários',
+                'unique_together': {('perfil', 'conquista')},
+            },
+        ),
+    ]

--- a/quiz/models.py
+++ b/quiz/models.py
@@ -5,6 +5,26 @@ from django.utils import timezone
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from datetime import timedelta
+from typing import Dict, List
+
+
+def default_difficulty_rewards() -> Dict[str, Dict[str, int]]:
+    """Configuração padrão para pontuação, XP e penalidades por dificuldade."""
+    return {
+        "Fácil": {"points": 10, "xp": 5, "penalty": 2},
+        "Médio": {"points": 20, "xp": 12, "penalty": 5},
+        "Difícil": {"points": 35, "xp": 20, "penalty": 8},
+    }
+
+
+def default_streak_bonus_rules() -> List[Dict[str, int]]:
+    """Bônus padrão progressivo baseado em sequência de acertos."""
+    return [
+        {"streak": 3, "bonus_percent": 5},
+        {"streak": 5, "bonus_percent": 12},
+        {"streak": 8, "bonus_percent": 18},
+        {"streak": 12, "bonus_percent": 25},
+    ]
 
 # --- Modelos de Conteúdo do Quiz ---
 
@@ -481,6 +501,23 @@ class SessoesQuizUsuario(models.Model):
     )
     total_acertos = models.IntegerField(default=0, verbose_name="Total de Acertos", validators=[MinValueValidator(0)])
     total_erros = models.IntegerField(default=0, verbose_name="Total de Erros", validators=[MinValueValidator(0)])
+    xp_total_sessao = models.IntegerField(
+        default=0,
+        verbose_name="XP Ganha na Sessão",
+        validators=[MinValueValidator(0)],
+        help_text="Experiência total acumulada pelo usuário nesta sessão.",
+    )
+    sequencia_acertos_atual = models.IntegerField(
+        default=0,
+        verbose_name="Sequência Atual de Acertos",
+        validators=[MinValueValidator(0)],
+    )
+    melhor_sequencia_acertos = models.IntegerField(
+        default=0,
+        verbose_name="Melhor Sequência de Acertos",
+        validators=[MinValueValidator(0)],
+        help_text="Maior sequência contínua de acertos registrada na sessão.",
+    )
 
     class ModoQuiz(models.TextChoices):
         POR_CATEGORIA = 'Por Categoria', 'Por Categoria'
@@ -544,6 +581,12 @@ class SessoesQuizUsuario(models.Model):
             raise ValidationError({'total_acertos': 'O número de acertos não pode ser maior que o total de perguntas.'})
         if self.total_erros > self.total_perguntas_sessao:
             raise ValidationError({'total_erros': 'O número de erros não pode ser maior que o total de perguntas.'})
+        if self.xp_total_sessao < 0:
+            raise ValidationError({'xp_total_sessao': 'O XP total da sessão deve ser zero ou positivo.'})
+        if self.sequencia_acertos_atual < 0:
+            raise ValidationError({'sequencia_acertos_atual': 'Sequência atual não pode ser negativa.'})
+        if self.melhor_sequencia_acertos < 0:
+            raise ValidationError({'melhor_sequencia_acertos': 'Melhor sequência não pode ser negativa.'})
         
         # Validação de modo_quiz e id_quiz_definicao
         if self.modo_quiz == self.ModoQuiz.DEFINIDO and not self.id_quiz_definicao:
@@ -632,6 +675,22 @@ class RespostasUsuarioPorSessao(models.Model):
         help_text="True se correta, False se incorreta, Nulo se pulada/não respondida."
     )
     data_resposta = models.DateTimeField(auto_now_add=True, verbose_name="Data da Resposta")
+    pontos_obtidos = models.IntegerField(
+        default=0,
+        verbose_name="Pontos da Resposta",
+        help_text="Pontuação líquida obtida nesta resposta específica.",
+    )
+    xp_obtido = models.IntegerField(
+        default=0,
+        verbose_name="XP Obtido",
+        help_text="Experiência concedida por esta resposta.",
+        validators=[MinValueValidator(0)],
+    )
+    multiplicador_aplicado = models.FloatField(
+        default=1.0,
+        verbose_name="Multiplicador Aplicado",
+        help_text="Fator de multiplicação aplicado em função de bônus de sequência.",
+    )
 
     def __str__(self):
         status_resposta = "Pulada/Não Avaliada"
@@ -663,6 +722,11 @@ class EstatisticasDiariasUsuario(models.Model):
     perguntas_respondidas_dia = models.IntegerField(default=0, verbose_name="Perguntas Respondidas", validators=[MinValueValidator(0)])
     acertos_dia = models.IntegerField(default=0, verbose_name="Acertos no Dia", validators=[MinValueValidator(0)])
     pontos_dia = models.IntegerField(default=0, verbose_name="Pontos Ganhos no Dia")
+    xp_ganho_dia = models.IntegerField(
+        default=0,
+        verbose_name="XP Ganhado no Dia",
+        validators=[MinValueValidator(0)],
+    )
     sequencia_dias_quiz = models.IntegerField(default=0, verbose_name="Sequência de Dias Consecutivos de Quiz", validators=[MinValueValidator(0)])
     tempo_estudo_segundos_dia = models.IntegerField(default=0, verbose_name="Tempo de Estudo no Dia (segundos)", validators=[MinValueValidator(0)])
     data_atualizacao_estatistica = models.DateTimeField(auto_now=True, verbose_name="Última Atualização")
@@ -752,6 +816,28 @@ class ConfiguracoesGeraisQuiz(models.Model):
         verbose_name="Penalidade por Erro",
         help_text="Número de pontos deduzidos por cada resposta incorreta (use 0 se não houver penalidade)."
     )
+    configuracao_pontuacao_dificuldade = models.JSONField(
+        default=default_difficulty_rewards,
+        verbose_name="Regras de Pontuação por Dificuldade",
+        help_text=(
+            "Estrutura JSON com pontos, XP e penalidades por nível de dificuldade. "
+            "Exemplo: {'Fácil': {'points': 10, 'xp': 5, 'penalty': 2}}"
+        ),
+    )
+    bonus_sequencia_acertos = models.JSONField(
+        default=default_streak_bonus_rules,
+        verbose_name="Bônus por Sequência de Acertos",
+        help_text=(
+            "Lista ordenada de objetos contendo 'streak' e 'bonus_percent', representando o aumento percentual "
+            "aplicado ao acerto conforme a sequência atual."
+        ),
+    )
+    multiplicador_bonus_maximo = models.FloatField(
+        default=2.0,
+        verbose_name="Multiplicador Máximo de Bônus",
+        help_text="Limita o multiplicador total aplicado por bônus de sequência para evitar valores extremos.",
+        validators=[MinValueValidator(1.0)],
+    )
     # Adicione outros campos de configuração global aqui conforme necessário
     # Ex: permitir_pular_questoes = models.BooleanField(default=True, ...)
     # Ex: tempo_limite_padrao_quiz_minutos = models.PositiveIntegerField(default=30, ...)
@@ -767,6 +853,8 @@ class ConfiguracoesGeraisQuiz(models.Model):
             raise ValidationError('Só pode haver uma instância de ConfiguracoesGeraisQuiz. Edite a existente.')
         if self.penalidade_por_erro < 0:
             raise ValidationError({'penalidade_por_erro': 'A penalidade por erro não pode ser negativa.'})
+        self._validate_dificuldades()
+        self._validate_bonus()
         result = super().save(*args, **kwargs)
         try:
             from .views import invalidate_quiz_config_cache
@@ -776,6 +864,262 @@ class ConfiguracoesGeraisQuiz(models.Model):
             pass
         return result
 
+    def _validate_dificuldades(self) -> None:
+        payload = self.configuracao_pontuacao_dificuldade or {}
+        if not isinstance(payload, dict):
+            raise ValidationError({'configuracao_pontuacao_dificuldade': 'A configuração deve ser um objeto JSON.'})
+
+        required = {'points', 'xp', 'penalty'}
+        for difficulty, rule in payload.items():
+            if not isinstance(rule, dict):
+                raise ValidationError({
+                    'configuracao_pontuacao_dificuldade': f"A configuração de '{difficulty}' deve ser um objeto com pontos/xp/penalidade."
+                })
+            missing = required - set(rule.keys())
+            if missing:
+                raise ValidationError({
+                    'configuracao_pontuacao_dificuldade': f"A configuração de '{difficulty}' está sem as chaves: {', '.join(sorted(missing))}."
+                })
+            for key in required:
+                value = rule[key]
+                if not isinstance(value, (int, float)):
+                    raise ValidationError({
+                        'configuracao_pontuacao_dificuldade': f"O valor de '{key}' para '{difficulty}' deve ser numérico."
+                    })
+                if key != 'penalty' and value < 0:
+                    raise ValidationError({
+                        'configuracao_pontuacao_dificuldade': f"O valor de '{key}' para '{difficulty}' deve ser não negativo."
+                    })
+                if key == 'penalty' and value < 0:
+                    raise ValidationError({
+                        'configuracao_pontuacao_dificuldade': f"A penalidade para '{difficulty}' deve ser zero ou positiva."
+                    })
+
+    def _validate_bonus(self) -> None:
+        payload = self.bonus_sequencia_acertos or []
+        if not isinstance(payload, list):
+            raise ValidationError({'bonus_sequencia_acertos': 'A configuração deve ser uma lista de objetos ordenados.'})
+
+        last_streak = 0
+        for index, rule in enumerate(payload):
+            if not isinstance(rule, dict):
+                raise ValidationError({'bonus_sequencia_acertos': f"A posição {index} deve conter um objeto com 'streak' e 'bonus_percent'."})
+            if 'streak' not in rule or 'bonus_percent' not in rule:
+                raise ValidationError({'bonus_sequencia_acertos': f"A posição {index} deve conter as chaves 'streak' e 'bonus_percent'."})
+            streak_value = rule['streak']
+            bonus_value = rule['bonus_percent']
+            if not isinstance(streak_value, int) or streak_value <= 0:
+                raise ValidationError({'bonus_sequencia_acertos': f"O valor de sequência na posição {index} deve ser um inteiro positivo."})
+            if streak_value <= last_streak:
+                raise ValidationError({'bonus_sequencia_acertos': 'As sequências devem ser fornecidas em ordem crescente.'})
+            if not isinstance(bonus_value, (int, float)):
+                raise ValidationError({'bonus_sequencia_acertos': f"O bônus na posição {index} deve ser numérico."})
+            last_streak = streak_value
+
+    def get_difficulty_rule(self, difficulty: str) -> Dict[str, float]:
+        payload = self.configuracao_pontuacao_dificuldade or {}
+        if difficulty in payload:
+            return payload[difficulty]
+        normalized = difficulty.lower()
+        for key, value in payload.items():
+            if key.lower() == normalized:
+                return value
+        return {
+            'points': float(self.pontuacao_por_acerto),
+            'xp': float(self.pontuacao_por_acerto),
+            'penalty': float(self.penalidade_por_erro),
+        }
+
+    def get_bonus_percent_for_streak(self, streak: int) -> float:
+        if streak <= 0:
+            return 0.0
+        applicable = 0.0
+        for rule in self.bonus_sequencia_acertos or []:
+            try:
+                if streak >= int(rule.get('streak', 0)):
+                    applicable = float(rule.get('bonus_percent', 0))
+            except (TypeError, ValueError):
+                continue
+        return applicable
+
+    def get_max_bonus_multiplier(self) -> float:
+        try:
+            return float(self.multiplicador_bonus_maximo)
+        except (TypeError, ValueError):
+            return 2.0
+
     class Meta:
         verbose_name = "Configuração Geral do Quiz"
         verbose_name_plural = "Configurações Gerais do Quiz" # Embora seja singleton, o admin usa isso.
+
+
+class NivelGamificacao(models.Model):
+    """Representa os níveis de progressão disponíveis na plataforma."""
+
+    identificador = models.CharField(
+        max_length=100,
+        unique=True,
+        verbose_name="Identificador Interno",
+        help_text="Slug único para integrações ou referências em código.",
+    )
+    nome = models.CharField(max_length=150, verbose_name="Nome do Nível")
+    descricao = models.TextField(blank=True, verbose_name="Descrição do Nível")
+    ordem = models.PositiveIntegerField(
+        default=1,
+        verbose_name="Ordem de Exibição",
+        help_text="Determina a ordem dos níveis (menor valor aparece primeiro).",
+    )
+    xp_minimo = models.PositiveIntegerField(verbose_name="XP Mínimo")
+    xp_maximo = models.PositiveIntegerField(
+        verbose_name="XP Máximo",
+        null=True,
+        blank=True,
+        help_text="Opcional. Se vazio, considera-se que o nível não possui limite superior.",
+    )
+    recompensas_json = models.JSONField(
+        default=dict,
+        blank=True,
+        verbose_name="Recompensas",
+        help_text="Campo flexível para descrever benefícios concedidos ao alcançar o nível (ex: descontos, acesso antecipado).",
+    )
+
+    class Meta:
+        verbose_name = "Nível de Gamificação"
+        verbose_name_plural = "Níveis de Gamificação"
+        ordering = ['ordem', 'xp_minimo']
+
+    def __str__(self):
+        return f"{self.nome} (XP {self.xp_minimo}+ )"
+
+    def clean(self):
+        super().clean()
+        if self.xp_maximo is not None and self.xp_maximo < self.xp_minimo:
+            raise ValidationError({'xp_maximo': 'O XP máximo deve ser maior ou igual ao XP mínimo.'})
+
+
+class Conquista(models.Model):
+    """Define conquistas/badges desbloqueáveis pelos usuários."""
+
+    slug = models.SlugField(
+        max_length=150,
+        unique=True,
+        verbose_name="Slug da Conquista",
+        help_text="Identificador único usado para integrar regras de gamificação.",
+    )
+    nome = models.CharField(max_length=150, verbose_name="Nome da Conquista")
+    descricao = models.TextField(blank=True, verbose_name="Descrição")
+    criterio_json = models.JSONField(
+        default=dict,
+        blank=True,
+        verbose_name="Critério",
+        help_text="Estrutura flexível descrevendo a regra para desbloqueio (ex: {'tipo': 'xp_total', 'valor': 1000}).",
+    )
+    icone = models.CharField(
+        max_length=255,
+        blank=True,
+        verbose_name="Ícone",
+        help_text="Nome de ícone ou caminho para imagem a ser exibida ao usuário.",
+    )
+    ordem_exibicao = models.PositiveIntegerField(
+        default=0,
+        verbose_name="Ordem de Exibição",
+        help_text="Permite priorizar a exibição de conquistas em coleções.",
+    )
+
+    class Meta:
+        verbose_name = "Conquista"
+        verbose_name_plural = "Conquistas"
+        ordering = ['ordem_exibicao', 'nome']
+
+    def __str__(self):
+        return self.nome
+
+
+class PerfilGamificacaoUsuario(models.Model):
+    """Perfil agregador das métricas de gamificação de cada usuário."""
+
+    user = models.OneToOneField(
+        User,
+        on_delete=models.CASCADE,
+        related_name='gamification_profile',
+        verbose_name="Usuário",
+    )
+    xp_total = models.PositiveIntegerField(default=0, verbose_name="XP Total")
+    nivel_atual = models.ForeignKey(
+        NivelGamificacao,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='perfis_associados',
+        verbose_name="Nível Atual",
+    )
+    melhor_sequencia_geral = models.PositiveIntegerField(
+        default=0,
+        verbose_name="Melhor Sequência Geral",
+    )
+    sequencia_atual = models.PositiveIntegerField(
+        default=0,
+        verbose_name="Sequência Atual",
+    )
+    conquistas = models.ManyToManyField(
+        Conquista,
+        through='ConquistaUsuario',
+        related_name='perfis_dos_usuarios',
+        blank=True,
+        verbose_name="Conquistas Desbloqueadas",
+    )
+    ultima_atualizacao = models.DateTimeField(auto_now=True, verbose_name="Última Atualização")
+
+    class Meta:
+        verbose_name = "Perfil de Gamificação do Usuário"
+        verbose_name_plural = "Perfis de Gamificação dos Usuários"
+
+    def __str__(self):
+        return f"Perfil de Gamificação de {self.user.get_username()}"
+
+    def atualizar_nivel(self):
+        """Atualiza o nível do usuário com base no XP total."""
+        nivel_compativel = (
+            NivelGamificacao.objects.filter(
+                xp_minimo__lte=self.xp_total,
+            )
+            .filter(
+                models.Q(xp_maximo__gte=self.xp_total) | models.Q(xp_maximo__isnull=True)
+            )
+            .order_by('ordem', 'xp_minimo')
+            .last()
+        )
+        if nivel_compativel != self.nivel_atual:
+            self.nivel_atual = nivel_compativel
+            self.save(update_fields=['nivel_atual', 'ultima_atualizacao'])
+
+
+class ConquistaUsuario(models.Model):
+    """Relaciona um perfil de gamificação com uma conquista desbloqueada."""
+
+    perfil = models.ForeignKey(
+        PerfilGamificacaoUsuario,
+        on_delete=models.CASCADE,
+        related_name='conquistas_usuarios',
+    )
+    conquista = models.ForeignKey(
+        Conquista,
+        on_delete=models.CASCADE,
+        related_name='desbloqueios',
+    )
+    data_conquista = models.DateTimeField(auto_now_add=True, verbose_name="Data da Conquista")
+    metadata = models.JSONField(
+        default=dict,
+        blank=True,
+        verbose_name="Metadados",
+        help_text="Informações extras sobre o desbloqueio (ex: motivo, valores alcançados).",
+    )
+
+    class Meta:
+        verbose_name = "Conquista do Usuário"
+        verbose_name_plural = "Conquistas dos Usuários"
+        unique_together = ('perfil', 'conquista')
+        ordering = ['-data_conquista']
+
+    def __str__(self):
+        return f"{self.perfil.user.get_username()} -> {self.conquista.nome}"

--- a/quiz/services/gamification_service.py
+++ b/quiz/services/gamification_service.py
@@ -1,0 +1,98 @@
+"""Utilities for updating gamification profiles and achievements."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.db import transaction
+
+from quiz.models import (
+    Conquista,
+    ConquistaUsuario,
+    PerfilGamificacaoUsuario,
+    SessoesQuizUsuario,
+)
+from quiz.services.scoring_service import SessionScoreResult
+
+
+@dataclass
+class GamificationUpdateResult:
+    """Resumo da atualização de gamificação."""
+
+    profile: PerfilGamificacaoUsuario
+    conquistas_desbloqueadas: int
+
+
+class GamificationService:
+    """Aplica regras de gamificação ao final de uma sessão."""
+
+    def ensure_profile(self, user) -> PerfilGamificacaoUsuario:
+        profile, _ = PerfilGamificacaoUsuario.objects.get_or_create(user=user)
+        return profile
+
+    @transaction.atomic
+    def apply_session_result(
+        self,
+        user,
+        sessao: SessoesQuizUsuario,
+        score_result: SessionScoreResult,
+    ) -> GamificationUpdateResult:
+        profile = self.ensure_profile(user)
+
+        fields_to_update = ['xp_total', 'sequencia_atual', 'ultima_atualizacao']
+        profile.xp_total += max(score_result.total_xp, 0)
+        profile.sequencia_atual = score_result.current_streak
+        if score_result.best_streak > profile.melhor_sequencia_geral:
+            profile.melhor_sequencia_geral = score_result.best_streak
+            fields_to_update.append('melhor_sequencia_geral')
+
+        profile.save(update_fields=fields_to_update)
+        profile.atualizar_nivel()
+
+        conquistas_novas = self._unlock_achievements(profile, sessao, score_result)
+        return GamificationUpdateResult(profile=profile, conquistas_desbloqueadas=conquistas_novas)
+
+    def _unlock_achievements(
+        self,
+        profile: PerfilGamificacaoUsuario,
+        sessao: SessoesQuizUsuario,
+        score_result: SessionScoreResult,
+    ) -> int:
+        conquistas_disponiveis = Conquista.objects.all()
+        ja_desbloqueadas = set(profile.conquistas.values_list('id', flat=True))
+        a_criar = []
+
+        for conquista in conquistas_disponiveis:
+            if conquista.id in ja_desbloqueadas:
+                continue
+
+            criterio = conquista.criterio_json or {}
+            tipo = str(criterio.get('tipo', '')).lower()
+            valor = criterio.get('valor')
+            if not valor:
+                continue
+
+            try:
+                valor_num = float(valor)
+            except (TypeError, ValueError):
+                continue
+
+            if tipo == 'xp_total' and profile.xp_total >= valor_num:
+                a_criar.append((conquista, {'xp_total': profile.xp_total}))
+            elif tipo == 'melhor_sequencia' and score_result.best_streak >= valor_num:
+                a_criar.append((conquista, {'melhor_sequencia': score_result.best_streak}))
+            elif tipo == 'pontuacao_sessao' and sessao.pontuacao_final >= valor_num:
+                a_criar.append((conquista, {'pontuacao': sessao.pontuacao_final}))
+            elif tipo == 'respostas_corretas_sessao' and score_result.total_correct >= valor_num:
+                a_criar.append((conquista, {'acertos': score_result.total_correct}))
+
+        criadas = 0
+        for conquista, metadata in a_criar:
+            ConquistaUsuario.objects.create(
+                perfil=profile,
+                conquista=conquista,
+                metadata=metadata,
+            )
+            criadas += 1
+
+        return criadas

--- a/quiz/services/scoring_service.py
+++ b/quiz/services/scoring_service.py
@@ -1,0 +1,129 @@
+"""Rules and helpers for computing session scores and gamification XP."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+from django.utils import timezone
+
+from quiz.models import ConfiguracoesGeraisQuiz, RespostasUsuarioPorSessao
+
+
+@dataclass
+class ResponseScore:
+    """Represents the scoring outcome for a single response."""
+
+    response_id: int
+    pontos: int
+    xp: int
+    multiplicador: float
+    foi_correta: Optional[bool]
+    dificuldade: Optional[str]
+
+
+@dataclass
+class SessionScoreResult:
+    """Aggregated totals for a quiz session."""
+
+    total_points: int
+    total_xp: int
+    total_correct: int
+    total_incorrect: int
+    total_answered: int
+    current_streak: int
+    best_streak: int
+    response_scores: List[ResponseScore]
+
+    @property
+    def last_multiplier(self) -> float:
+        if not self.response_scores:
+            return 1.0
+        return self.response_scores[-1].multiplicador
+
+
+class ScoringService:
+    """Encapsula a lógica de pontuação dinâmica baseada em configurações."""
+
+    def __init__(self, config: ConfiguracoesGeraisQuiz):
+        self.config = config
+
+    def compute_session_result(
+        self,
+        responses: Iterable[RespostasUsuarioPorSessao],
+    ) -> SessionScoreResult:
+        """Calcula a pontuação consolidada de uma sessão."""
+
+        responses_list = list(responses)
+        responses_list.sort(key=lambda r: (r.data_resposta or timezone.now(), r.pk))
+
+        total_points_raw = 0.0
+        total_xp = 0.0
+        total_correct = 0
+        total_incorrect = 0
+        total_answered = 0
+        current_streak = 0
+        best_streak = 0
+        response_scores: List[ResponseScore] = []
+
+        for response in responses_list:
+            pergunta = getattr(response, "id_pergunta", None)
+            dificuldade = getattr(pergunta, "nivel_dificuldade", None)
+            rule = self.config.get_difficulty_rule(dificuldade or "")
+
+            base_points = float(rule.get("points", self.config.pontuacao_por_acerto))
+            base_xp = float(rule.get("xp", self.config.pontuacao_por_acerto))
+            penalty = float(rule.get("penalty", self.config.penalidade_por_erro))
+
+            pontos_resposta = 0.0
+            xp_resposta = 0.0
+            multiplicador = 1.0
+
+            if response.id_opcao_resposta_selecionada_id is not None:
+                total_answered += 1
+
+            if response.foi_correta:
+                total_correct += 1
+                current_streak += 1
+                multiplicador = 1.0 + (self.config.get_bonus_percent_for_streak(current_streak) / 100.0)
+                multiplicador = min(multiplicador, self.config.get_max_bonus_multiplier())
+                pontos_resposta = base_points * multiplicador
+                xp_resposta = base_xp * multiplicador
+            elif response.foi_correta is False and response.id_opcao_resposta_selecionada_id is not None:
+                total_incorrect += 1
+                current_streak = 0
+                pontos_resposta = -abs(penalty)
+                multiplicador = 1.0
+            else:
+                # Pergunta pulada ou ainda não respondida
+                current_streak = 0
+                multiplicador = 1.0
+
+            best_streak = max(best_streak, current_streak)
+            total_points_raw += pontos_resposta
+            total_xp += xp_resposta
+
+            response_scores.append(
+                ResponseScore(
+                    response_id=response.pk,
+                    pontos=int(round(pontos_resposta)),
+                    xp=int(round(max(xp_resposta, 0))),
+                    multiplicador=float(multiplicador),
+                    foi_correta=response.foi_correta,
+                    dificuldade=dificuldade,
+                )
+            )
+
+        total_points = int(round(max(total_points_raw, 0)))
+        total_xp_int = int(round(max(total_xp, 0)))
+
+        return SessionScoreResult(
+            total_points=total_points,
+            total_xp=total_xp_int,
+            total_correct=total_correct,
+            total_incorrect=total_incorrect,
+            total_answered=total_answered,
+            current_streak=current_streak,
+            best_streak=best_streak,
+            response_scores=response_scores,
+        )

--- a/quiz/services/statistics_service.py
+++ b/quiz/services/statistics_service.py
@@ -73,6 +73,9 @@ class StatisticsService:
         total_study_time_seconds_period = daily_stats_period_qs.aggregate(
             total=Sum("tempo_estudo_segundos_dia")
         )["total"] or 0
+        total_xp_period = daily_stats_period_qs.aggregate(
+            total=Sum("xp_ganho_dia")
+        )["total"] or 0
 
         latest_daily_stat = (
             EstatisticasDiariasUsuario.objects.filter(id_usuario=user).order_by("-data_estatistica").first()
@@ -82,10 +85,15 @@ class StatisticsService:
         total_score_all_time = SessoesQuizUsuario.objects.filter(
             id_usuario=user, status_sessao=SessoesQuizUsuario.StatusSessao.COMPLETA
         ).aggregate(total_score=Sum("pontuacao_final"))["total_score"] or 0
+        total_xp_all_time = SessoesQuizUsuario.objects.filter(
+            id_usuario=user, status_sessao=SessoesQuizUsuario.StatusSessao.COMPLETA
+        ).aggregate(total_xp=Sum("xp_total_sessao"))["total_xp"] or 0
 
         return {
             "total_questions_answered": total_questions_answered_period,
             "max_streak": max_streak,
             "total_score_all_time": total_score_all_time,
+            "total_xp_all_time": total_xp_all_time,
             "total_study_time_seconds": total_study_time_seconds_period,
+            "total_xp_period": total_xp_period,
         }

--- a/quiz/signals.py
+++ b/quiz/signals.py
@@ -2,7 +2,7 @@ from django.contrib.auth.models import User
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from .models import UserPreferences
+from .models import UserPreferences, PerfilGamificacaoUsuario
 
 
 @receiver(post_save, sender=User)
@@ -12,3 +12,4 @@ def ensure_user_preferences(sender, instance, **kwargs):
         return
 
     UserPreferences.objects.get_or_create(user=instance)
+    PerfilGamificacaoUsuario.objects.get_or_create(user=instance)

--- a/quiz/tests/test_services.py
+++ b/quiz/tests/test_services.py
@@ -102,6 +102,7 @@ class StatisticsServiceTests(TestCase):
             total_acertos=3,
             total_erros=2,
             pontuacao_final=45,
+            xp_total_sessao=36,
         )
         self.session_old = SessoesQuizUsuario.objects.create(
             id_usuario=self.user,
@@ -111,6 +112,7 @@ class StatisticsServiceTests(TestCase):
             total_acertos=2,
             total_erros=2,
             pontuacao_final=30,
+            xp_total_sessao=24,
             data_inicio=timezone.now() - timedelta(days=120),
         )
         self.stat_recent = EstatisticasDiariasUsuario.objects.create(
@@ -121,6 +123,7 @@ class StatisticsServiceTests(TestCase):
             pontos_dia=90,
             sequencia_dias_quiz=4,
             tempo_estudo_segundos_dia=1200,
+            xp_ganho_dia=72,
         )
         self.stat_old = EstatisticasDiariasUsuario.objects.create(
             id_usuario=self.user,
@@ -130,6 +133,7 @@ class StatisticsServiceTests(TestCase):
             pontos_dia=30,
             sequencia_dias_quiz=1,
             tempo_estudo_segundos_dia=600,
+            xp_ganho_dia=18,
         )
 
     def test_filter_queryset_by_period_limits_records(self):
@@ -144,4 +148,6 @@ class StatisticsServiceTests(TestCase):
         self.assertEqual(metrics['total_questions_answered'], 13)
         self.assertEqual(metrics['max_streak'], self.stat_recent.sequencia_dias_quiz)
         self.assertEqual(metrics['total_score_all_time'], 75)
+        self.assertEqual(metrics['total_xp_all_time'], 60)
+        self.assertEqual(metrics['total_xp_period'], 90)
         self.assertGreater(metrics['total_study_time_seconds'], 0)

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -24,6 +24,8 @@ from .models import (
     QuizDefinicaoPergunta,  # NOVO MODELO
     ConfiguracoesGeraisQuiz,  # NOVO MODELO
     UserPreferences,
+    default_difficulty_rewards,
+    default_streak_bonus_rules,
 )
 from .forms import (
     CustomUserCreationForm,
@@ -35,6 +37,8 @@ from .forms import (
 
 from .services.quiz_service import QuizDataService
 from .services.statistics_service import StatisticsService
+from .services.scoring_service import ScoringService
+from .services.gamification_service import GamificationService
 
 # region Lógica de Negócio e Utilitários de Dados
 
@@ -61,7 +65,10 @@ def get_quiz_config():
             defaults={
                 'numero_perguntas_quiz_rapido': 10,  # Valor padrão
                 'pontuacao_por_acerto': 15,       # Valor padrão
-                'penalidade_por_erro': 5          # Valor padrão
+                'penalidade_por_erro': 5,         # Valor padrão
+                'configuracao_pontuacao_dificuldade': default_difficulty_rewards(),
+                'bonus_sequencia_acertos': default_streak_bonus_rules(),
+                'multiplicador_bonus_maximo': 2.0,
             }
         )
         if created:
@@ -894,6 +901,7 @@ def start_quiz_session_view(request):
 @require_POST
 def register_answer_view(request):
     quiz_config = get_quiz_config()
+    scoring_service = ScoringService(quiz_config)
 
     try:
         data = json.loads(request.body.decode('utf-8'))
@@ -932,15 +940,30 @@ def register_answer_view(request):
             }
         )
 
-        respostas_da_sessao = RespostasUsuarioPorSessao.objects.filter(
-            id_sessao_quiz=sessao_quiz)
-        sessao_quiz.total_acertos = respostas_da_sessao.filter(
-            foi_correta=True).count()
-        sessao_quiz.total_erros = respostas_da_sessao.filter(
-            foi_correta=False, id_opcao_resposta_selecionada__isnull=False).count()
+        respostas_da_sessao = list(
+            RespostasUsuarioPorSessao.objects.filter(id_sessao_quiz=sessao_quiz)
+            .select_related('id_pergunta')
+            .order_by('data_resposta', 'pk')
+        )
+        score_result = scoring_service.compute_session_result(respostas_da_sessao)
+        if respostas_da_sessao:
+            for resp_obj, resp_score in zip(respostas_da_sessao, score_result.response_scores):
+                resp_obj.pontos_obtidos = resp_score.pontos
+                resp_obj.xp_obtido = resp_score.xp
+                resp_obj.multiplicador_aplicado = resp_score.multiplicador
+            RespostasUsuarioPorSessao.objects.bulk_update(
+                respostas_da_sessao,
+                ['pontos_obtidos', 'xp_obtido', 'multiplicador_aplicado']
+            )
 
-        sessao_quiz.pontuacao_final = max(0, (sessao_quiz.total_acertos * quiz_config.pontuacao_por_acerto) -
-                                             (sessao_quiz.total_erros * quiz_config.penalidade_por_erro))
+        sessao_quiz.total_acertos = score_result.total_correct
+        sessao_quiz.total_erros = score_result.total_incorrect
+        sessao_quiz.pontuacao_final = score_result.total_points
+        sessao_quiz.xp_total_sessao = score_result.total_xp
+        sessao_quiz.sequencia_acertos_atual = score_result.current_streak
+        sessao_quiz.melhor_sequencia_acertos = score_result.best_streak
+        if score_result.total_answered > sessao_quiz.total_perguntas_sessao:
+            sessao_quiz.total_perguntas_sessao = score_result.total_answered
 
         if current_question_index is not None:
             try:
@@ -954,14 +977,21 @@ def register_answer_view(request):
                 print(
                     f"Warning: Valor de current_question_index não numérico ({current_question_index}) para sessão {sessao_quiz.pk}.")
 
-        sessao_quiz.save()
+        sessao_quiz.save(update_fields=[
+            'total_acertos', 'total_erros', 'pontuacao_final', 'xp_total_sessao',
+            'sequencia_acertos_atual', 'melhor_sequencia_acertos', 'total_perguntas_sessao'
+        ])
 
         return JsonResponse({
             'status': 'success', 'message': 'Resposta registrada.',
             'foi_correta': foi_correta_calculada,
             'pontuacao_sessao': sessao_quiz.pontuacao_final,
+            'xp_sessao': sessao_quiz.xp_total_sessao,
             'total_acertos_sessao': sessao_quiz.total_acertos,
-            'total_erros_sessao': sessao_quiz.total_erros
+            'total_erros_sessao': sessao_quiz.total_erros,
+            'sequencia_atual': sessao_quiz.sequencia_acertos_atual,
+            'melhor_sequencia_sessao': sessao_quiz.melhor_sequencia_acertos,
+            'multiplicador_atual': score_result.last_multiplier,
         })
 
     except SessoesQuizUsuario.DoesNotExist:
@@ -979,6 +1009,8 @@ def register_answer_view(request):
 @require_POST
 def end_quiz_session_view(request):
     quiz_config = get_quiz_config()
+    gamification_service = GamificationService()
+    scoring_service = ScoringService(quiz_config)
     try:
         data = json.loads(request.body.decode('utf-8'))
         session_id = data.get('session_id')
@@ -993,13 +1025,43 @@ def end_quiz_session_view(request):
                 'status': 'info', 'message': 'Sessão já finalizada.',
                 'pontuacao_final': sessao_quiz.pontuacao_final,
                 'total_acertos': sessao_quiz.total_acertos,
-                'total_erros': sessao_quiz.total_erros
+                'total_erros': sessao_quiz.total_erros,
+                'xp_final': sessao_quiz.xp_total_sessao,
             }, status=200)
+
+        respostas_da_sessao = list(
+            RespostasUsuarioPorSessao.objects.filter(id_sessao_quiz=sessao_quiz)
+            .select_related('id_pergunta')
+            .order_by('data_resposta', 'pk')
+        )
+        score_result = scoring_service.compute_session_result(respostas_da_sessao)
+        if respostas_da_sessao:
+            for resp_obj, resp_score in zip(respostas_da_sessao, score_result.response_scores):
+                resp_obj.pontos_obtidos = resp_score.pontos
+                resp_obj.xp_obtido = resp_score.xp
+                resp_obj.multiplicador_aplicado = resp_score.multiplicador
+            RespostasUsuarioPorSessao.objects.bulk_update(
+                respostas_da_sessao,
+                ['pontos_obtidos', 'xp_obtido', 'multiplicador_aplicado']
+            )
+
+        sessao_quiz.total_acertos = score_result.total_correct
+        sessao_quiz.total_erros = score_result.total_incorrect
+        sessao_quiz.pontuacao_final = score_result.total_points
+        sessao_quiz.xp_total_sessao = score_result.total_xp
+        sessao_quiz.sequencia_acertos_atual = score_result.current_streak
+        sessao_quiz.melhor_sequencia_acertos = score_result.best_streak
+        if score_result.total_answered > sessao_quiz.total_perguntas_sessao:
+            sessao_quiz.total_perguntas_sessao = score_result.total_answered
 
         sessao_quiz.data_fim = timezone.now()
         sessao_quiz.tempo_total_segundos = tempo_total_segundos_frontend
         sessao_quiz.status_sessao = SessoesQuizUsuario.StatusSessao.COMPLETA
-        sessao_quiz.save()
+        sessao_quiz.save(update_fields=[
+            'data_fim', 'tempo_total_segundos', 'status_sessao', 'total_acertos',
+            'total_erros', 'pontuacao_final', 'xp_total_sessao',
+            'sequencia_acertos_atual', 'melhor_sequencia_acertos', 'total_perguntas_sessao'
+        ])
 
         stats = get_or_create_daily_stats(request.user)
         perguntas_respondidas_na_sessao = RespostasUsuarioPorSessao.objects.filter(
@@ -1009,14 +1071,19 @@ def end_quiz_session_view(request):
         stats.perguntas_respondidas_dia += perguntas_respondidas_na_sessao
         stats.acertos_dia += sessao_quiz.total_acertos
         stats.pontos_dia += sessao_quiz.pontuacao_final
+        stats.xp_ganho_dia += sessao_quiz.xp_total_sessao
         stats.tempo_estudo_segundos_dia += tempo_total_segundos_frontend
         stats.save()
+
+        gamification_service.apply_session_result(request.user, sessao_quiz, score_result)
 
         return JsonResponse({
             'status': 'success', 'message': 'Sessão finalizada com sucesso.',
             'pontuacao_final': sessao_quiz.pontuacao_final,
             'total_acertos': sessao_quiz.total_acertos,
-            'total_erros': sessao_quiz.total_erros
+            'total_erros': sessao_quiz.total_erros,
+            'xp_final': sessao_quiz.xp_total_sessao,
+            'sequencia_final': sessao_quiz.melhor_sequencia_acertos
         })
     except SessoesQuizUsuario.DoesNotExist:
         return JsonResponse({'status': 'error', 'message': 'Sessão de quiz inválida ou não pertence ao usuário.'}, status=403)


### PR DESCRIPTION
## Summary
- add difficulty-aware scoring configuration, streak bonuses, and gamification profile models with migrations
- implement scoring and gamification services and integrate them across API endpoints and Django views
- expose new XP metrics in statistics/admin interfaces and extend tests accordingly

## Testing
- `python manage.py test` *(fails: Django not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d041ed988483339406322d74353d8c