### PR TITLE
Add dynamic challenges, level rewards, and differentiated XP

### DIFF
--- a/quiz/admin.py
+++ b/quiz/admin.py
@@ -12,6 +12,7 @@ from .models import (
     QuizDefinicao, QuizDefinicaoPergunta, ConfiguracoesGeraisQuiz, # Novos modelos
     UserPreferences,
     NivelGamificacao, Conquista, PerfilGamificacaoUsuario, ConquistaUsuario,
+    DesafioDinamico, ProgressoDesafioUsuario, RecompensaNivelResgatada,
 )
 
 # Inline para OpcoesResposta dentro de PerguntaAdmin
@@ -403,6 +404,65 @@ class ConfiguracoesGeraisQuizAdmin(admin.ModelAdmin):
     @admin.display(description='Última Modificação', ordering='data_modificacao')
     def data_modificacao_formatada(self, obj):
         return obj.data_modificacao.strftime("%d/%m/%Y %H:%M") if obj.data_modificacao else "-"
+
+
+@admin.register(DesafioDinamico)
+class DesafioDinamicoAdmin(admin.ModelAdmin):
+    list_display = (
+        'nome', 'slug', 'tipo', 'ativo', 'data_inicio', 'data_fim', 'criterio_resumo', 'recompensa_resumo'
+    )
+    list_filter = ('tipo', 'ativo', 'data_inicio', 'data_fim')
+    search_fields = ('nome', 'slug', 'descricao')
+    readonly_fields = ('criado_em', 'atualizado_em')
+    fieldsets = (
+        (None, {'fields': ('nome', 'slug', 'descricao', 'tipo', 'ativo')}),
+        ('Regras', {'fields': ('criterio_json', 'recompensa_json')}),
+        ('Janela de Ativação', {'fields': ('data_inicio', 'data_fim')}),
+        ('Auditoria', {'fields': ('criado_em', 'atualizado_em'), 'classes': ('collapse',)}),
+    )
+
+    @admin.display(description='Critério')
+    def criterio_resumo(self, obj):
+        criterio = obj.criterio_json or {}
+        tipo = criterio.get('tipo')
+        valor = criterio.get('valor')
+        if tipo is None and not valor:
+            return '—'
+        return f"{tipo}: {valor}"
+
+    @admin.display(description='Recompensa')
+    def recompensa_resumo(self, obj):
+        recompensa = obj.recompensa_json or {}
+        if not recompensa:
+            return '—'
+        titulo = recompensa.get('titulo') or recompensa.get('nome') or recompensa.get('type')
+        if not titulo and isinstance(recompensa, dict):
+            titulo = ', '.join(recompensa.keys())[:40]
+        return titulo or 'Configuração'
+
+
+@admin.register(ProgressoDesafioUsuario)
+class ProgressoDesafioUsuarioAdmin(admin.ModelAdmin):
+    list_display = (
+        'perfil', 'desafio', 'valor_atual', 'concluido', 'data_conclusao', 'atualizado_em'
+    )
+    list_filter = ('concluido', 'desafio__tipo')
+    search_fields = (
+        'perfil__user__username', 'perfil__user__email', 'desafio__nome',
+    )
+    autocomplete_fields = ['perfil', 'desafio']
+    readonly_fields = ('criado_em', 'atualizado_em')
+
+
+@admin.register(RecompensaNivelResgatada)
+class RecompensaNivelResgatadaAdmin(admin.ModelAdmin):
+    list_display = ('perfil', 'nivel', 'recompensa_id', 'data_resgate')
+    list_filter = ('nivel',)
+    search_fields = (
+        'perfil__user__username', 'perfil__user__email', 'nivel__nome', 'recompensa_id'
+    )
+    autocomplete_fields = ['perfil', 'nivel']
+    readonly_fields = ('data_resgate',)
 
 
 @admin.register(UserPreferences)

--- a/quiz/api/serializers.py
+++ b/quiz/api/serializers.py
@@ -76,6 +76,11 @@ class StatisticsQuerySerializer(serializers.Serializer):
     period = serializers.CharField(required=False, allow_blank=True)
 
 
+class LevelRewardClaimSerializer(serializers.Serializer):
+    level_id = serializers.IntegerField(required=True)
+    reward_id = serializers.CharField(required=True, allow_blank=False)
+
+
 class UserQuestionHistoryQuerySerializer(serializers.Serializer):
     """Validates filters applied to the question history endpoint."""
 

--- a/quiz/api/viewsets.py
+++ b/quiz/api/viewsets.py
@@ -6,6 +6,7 @@ import json
 from collections import defaultdict
 from datetime import datetime, time
 
+from django.core.exceptions import ValidationError
 from django.db.models import Case, Count, Q, When
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -49,6 +50,7 @@ from .serializers import (
     StartQuizSessionSerializer,
     StatisticsQuerySerializer,
     UserQuestionHistoryQuerySerializer,
+    LevelRewardClaimSerializer,
 )
 
 
@@ -227,7 +229,7 @@ class QuizViewSet(viewsets.ViewSet):
         )
 
         scoring_service = ScoringService(quiz_config)
-        score_result = scoring_service.compute_session_result(responses)
+        score_result = scoring_service.compute_session_result(responses, session=sessao_quiz)
 
         if responses:
             for response_obj, response_score in zip(responses, score_result.response_scores):
@@ -533,6 +535,7 @@ class QuizViewSet(viewsets.ViewSet):
                 'sequencia_final': sessao_quiz.sequencia_acertos_atual,
                 'melhor_sequencia': sessao_quiz.melhor_sequencia_acertos,
                 'conquistas_desbloqueadas': gamification_result.conquistas_desbloqueadas,
+                'desafios_concluidos': gamification_result.desafios_concluidos,
                 'gamificacao': gamification_result.snapshot,
             })
         except SessoesQuizUsuario.DoesNotExist:
@@ -687,6 +690,61 @@ class QuizViewSet(viewsets.ViewSet):
                 {'status': 'error', 'message': 'Erro interno ao tentar retomar sessão.'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
+
+    @action(detail=False, methods=['post'], url_path='claim-level-reward')
+    def claim_level_reward(self, request):
+        if not request.user.is_authenticated:
+            return Response(
+                {'status': 'error', 'message': 'Autenticação necessária.'},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        try:
+            payload = self._parse_json_body(request)
+        except serializers.ValidationError as exc:
+            detail = exc.args[0] if exc.args else {}
+            message = detail.get('detail', 'Corpo da requisição JSON inválido.') if isinstance(detail, dict) else 'Corpo da requisição JSON inválido.'
+            return Response({'status': 'error', 'message': message}, status=status.HTTP_400_BAD_REQUEST)
+
+        serializer = LevelRewardClaimSerializer(data=payload)
+        try:
+            serializer.is_valid(raise_exception=True)
+        except serializers.ValidationError:
+            return Response({'status': 'error', 'errors': serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        data = serializer.validated_data
+        level_id = data.get('level_id')
+        reward_id = data.get('reward_id')
+
+        try:
+            claim_payload = self._gamification_service.claim_level_reward(
+                request.user,
+                level_id=level_id,
+                reward_id=reward_id,
+            )
+        except ValidationError as exc:
+            if hasattr(exc, 'message_dict'):
+                message = exc.message_dict
+            else:
+                messages = getattr(exc, 'messages', None) or [str(exc)]
+                message = messages[0]
+            return Response({'status': 'error', 'message': message}, status=status.HTTP_400_BAD_REQUEST)
+        except Exception:
+            return Response(
+                {'status': 'error', 'message': 'Não foi possível resgatar a recompensa.'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        snapshot = self._gamification_service.get_profile_snapshot(request.user)
+
+        return Response(
+            {
+                'status': 'success',
+                'reward': claim_payload['reward'],
+                'rewards_state': claim_payload['rewards_state'],
+                'gamificacao': snapshot,
+            }
+        )
 
 
 class UserQuestionHistoryPagination(PageNumberPagination):

--- a/quiz/migrations/0010_dynamic_challenges.py
+++ b/quiz/migrations/0010_dynamic_challenges.py
@@ -1,0 +1,81 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('quiz', '0009_gamification_and_scoring'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='DesafioDinamico',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('slug', models.SlugField(max_length=150, unique=True, verbose_name='Slug do Desafio')),
+                ('nome', models.CharField(max_length=200, verbose_name='Nome do Desafio')),
+                ('descricao', models.TextField(blank=True, verbose_name='Descrição')),
+                ('tipo', models.CharField(choices=[('daily', 'Diário'), ('weekly', 'Semanal'), ('event', 'Evento')], default='event', max_length=20, verbose_name='Tipo')),
+                ('criterio_json', models.JSONField(blank=True, default=dict, help_text="Estrutura {'tipo': 'xp_total', 'valor': 500} ou similar.", verbose_name='Critério')),
+                ('recompensa_json', models.JSONField(blank=True, default=dict, help_text='Metadados da recompensa entregue ao concluir o desafio.', verbose_name='Recompensa')),
+                ('data_inicio', models.DateTimeField(blank=True, null=True, verbose_name='Início')),
+                ('data_fim', models.DateTimeField(blank=True, null=True, verbose_name='Fim')),
+                ('ativo', models.BooleanField(default=True, verbose_name='Ativo')),
+                ('criado_em', models.DateTimeField(auto_now_add=True, verbose_name='Criado em')),
+                ('atualizado_em', models.DateTimeField(auto_now=True, verbose_name='Atualizado em')),
+            ],
+            options={
+                'ordering': ['-ativo', 'data_inicio', 'nome'],
+                'verbose_name': 'Desafio Dinâmico',
+                'verbose_name_plural': 'Desafios Dinâmicos',
+            },
+        ),
+        migrations.CreateModel(
+            name='RecompensaNivelResgatada',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('recompensa_id', models.CharField(max_length=150, verbose_name='Identificador da Recompensa')),
+                ('dados_recompensa', models.JSONField(blank=True, default=dict, verbose_name='Dados da Recompensa')),
+                ('data_resgate', models.DateTimeField(auto_now_add=True, verbose_name='Data de Resgate')),
+                ('nivel', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='recompensas_resgatadas', to='quiz.nivelgamificacao', verbose_name='Nível')),
+                ('perfil', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='recompensas_resgatadas', to='quiz.perfilgamificacaousuario', verbose_name='Perfil')),
+            ],
+            options={
+                'verbose_name': 'Recompensa de Nível Resgatada',
+                'verbose_name_plural': 'Recompensas de Nível Resgatadas',
+                'indexes': [
+                    models.Index(fields=['perfil', 'nivel'], name='idx_resgate_perfil_nivel'),
+                ],
+                'constraints': [
+                    models.UniqueConstraint(fields=('perfil', 'nivel', 'recompensa_id'), name='quiz_recompensa_nivel_resgatada_unq'),
+                ],
+            },
+        ),
+        migrations.CreateModel(
+            name='ProgressoDesafioUsuario',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('valor_atual', models.FloatField(default=0.0, verbose_name='Valor Atual')),
+                ('concluido', models.BooleanField(default=False, verbose_name='Concluído')),
+                ('data_conclusao', models.DateTimeField(blank=True, null=True, verbose_name='Concluído em')),
+                ('janela_inicio', models.DateTimeField(blank=True, null=True, verbose_name='Início do Ciclo')),
+                ('janela_fim', models.DateTimeField(blank=True, null=True, verbose_name='Fim do Ciclo')),
+                ('metadata', models.JSONField(blank=True, default=dict, verbose_name='Metadados')),
+                ('criado_em', models.DateTimeField(auto_now_add=True, verbose_name='Criado em')),
+                ('atualizado_em', models.DateTimeField(auto_now=True, verbose_name='Atualizado em')),
+                ('desafio', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='progresso_usuarios', to='quiz.desafiodinamico', verbose_name='Desafio')),
+                ('perfil', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='progresso_desafios', to='quiz.perfilgamificacaousuario', verbose_name='Perfil')),
+            ],
+            options={
+                'verbose_name': 'Progresso de Desafio do Usuário',
+                'verbose_name_plural': 'Progressos de Desafios dos Usuários',
+                'indexes': [
+                    models.Index(fields=['perfil', 'desafio'], name='idx_desafio_perfil'),
+                ],
+                'constraints': [
+                    models.UniqueConstraint(fields=('desafio', 'perfil'), name='quiz_progresso_desafio_usuario_desafio_perfil_uniq'),
+                ],
+            },
+        ),
+    ]

--- a/quiz/models.py
+++ b/quiz/models.py
@@ -4,8 +4,8 @@ from django.contrib.auth.models import User
 from django.utils import timezone
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
-from datetime import timedelta
-from typing import Dict, List
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
 
 
 def default_difficulty_rewards() -> Dict[str, Dict[str, int]]:
@@ -996,6 +996,70 @@ class NivelGamificacao(models.Model):
         if self.xp_maximo is not None and self.xp_maximo < self.xp_minimo:
             raise ValidationError({'xp_maximo': 'O XP máximo deve ser maior ou igual ao XP mínimo.'})
 
+    def get_reward_definitions(self) -> List[Dict[str, Any]]:
+        """Normaliza o JSON de recompensas em uma lista de itens estruturados."""
+
+        payload = self.recompensas_json or {}
+        items: List[Dict[str, Any]] = []
+
+        if isinstance(payload, dict):
+            raw_items = payload.get('items') or payload.get('recompensas') or payload
+        else:
+            raw_items = payload
+
+        if isinstance(raw_items, dict):
+            for key, value in raw_items.items():
+                if isinstance(value, dict):
+                    normalized = {
+                        'id': str(value.get('id') or key),
+                        'nome': value.get('nome') or str(key).replace('_', ' ').title(),
+                        'descricao': value.get('descricao') or value.get('description'),
+                        'tipo': value.get('tipo'),
+                        'valor': value.get('valor'),
+                        'metadata': value.get('metadata') or {},
+                    }
+                else:
+                    normalized = {
+                        'id': str(key),
+                        'nome': str(key).replace('_', ' ').title(),
+                        'descricao': str(value),
+                        'tipo': None,
+                        'valor': value,
+                        'metadata': {},
+                    }
+                items.append(normalized)
+        elif isinstance(raw_items, list):
+            for index, value in enumerate(raw_items):
+                if isinstance(value, dict):
+                    normalized = {
+                        'id': str(value.get('id') or value.get('slug') or f'item-{index}'),
+                        'nome': value.get('nome') or value.get('titulo') or value.get('title') or f'Recompensa {index + 1}',
+                        'descricao': value.get('descricao') or value.get('description'),
+                        'tipo': value.get('tipo'),
+                        'valor': value.get('valor'),
+                        'metadata': value.get('metadata') or {},
+                    }
+                else:
+                    normalized = {
+                        'id': f'item-{index}',
+                        'nome': f'Recompensa {index + 1}',
+                        'descricao': str(value),
+                        'tipo': None,
+                        'valor': value,
+                        'metadata': {},
+                    }
+                items.append(normalized)
+
+        deduped: Dict[str, Dict[str, Any]] = {}
+        for item in items:
+            identifier = item.get('id') or f"item-{len(deduped)}"
+            if identifier in deduped:
+                continue
+            item['id'] = identifier
+            deduped[identifier] = item
+
+        return list(deduped.values())
+
 
 class Conquista(models.Model):
     """Define conquistas/badges desbloqueáveis pelos usuários."""
@@ -1123,3 +1187,167 @@ class ConquistaUsuario(models.Model):
 
     def __str__(self):
         return f"{self.perfil.user.get_username()} -> {self.conquista.nome}"
+
+
+class DesafioDinamicoQuerySet(models.QuerySet):
+    def ativos(self, reference_time: Optional[datetime] = None):
+        reference = reference_time or timezone.now()
+        return self.filter(ativo=True).filter(
+            models.Q(data_inicio__isnull=True) | models.Q(data_inicio__lte=reference)
+        ).filter(
+            models.Q(data_fim__isnull=True) | models.Q(data_fim__gte=reference)
+        )
+
+
+class DesafioDinamico(models.Model):
+    """Desafios temporários para manter o engajamento."""
+
+    class TipoDesafio(models.TextChoices):
+        DIARIO = 'daily', 'Diário'
+        SEMANAL = 'weekly', 'Semanal'
+        ESPECIAL = 'event', 'Evento'
+
+    slug = models.SlugField(max_length=150, unique=True, verbose_name="Slug do Desafio")
+    nome = models.CharField(max_length=200, verbose_name="Nome do Desafio")
+    descricao = models.TextField(blank=True, verbose_name="Descrição")
+    tipo = models.CharField(
+        max_length=20,
+        choices=TipoDesafio.choices,
+        default=TipoDesafio.ESPECIAL,
+        verbose_name="Tipo",
+    )
+    criterio_json = models.JSONField(
+        default=dict,
+        blank=True,
+        verbose_name="Critério",
+        help_text="Estrutura {'tipo': 'xp_total', 'valor': 500} ou similar.",
+    )
+    recompensa_json = models.JSONField(
+        default=dict,
+        blank=True,
+        verbose_name="Recompensa",
+        help_text="Metadados da recompensa entregue ao concluir o desafio.",
+    )
+    data_inicio = models.DateTimeField(null=True, blank=True, verbose_name="Início")
+    data_fim = models.DateTimeField(null=True, blank=True, verbose_name="Fim")
+    ativo = models.BooleanField(default=True, verbose_name="Ativo")
+    criado_em = models.DateTimeField(auto_now_add=True, verbose_name="Criado em")
+    atualizado_em = models.DateTimeField(auto_now=True, verbose_name="Atualizado em")
+
+    objects = DesafioDinamicoQuerySet.as_manager()
+
+    class Meta:
+        verbose_name = "Desafio Dinâmico"
+        verbose_name_plural = "Desafios Dinâmicos"
+        ordering = ['-ativo', 'data_inicio', 'nome']
+
+    def __str__(self):
+        return self.nome
+
+    def clean(self):
+        super().clean()
+        if self.data_inicio and self.data_fim and self.data_fim < self.data_inicio:
+            raise ValidationError({'data_fim': 'A data de término deve ser posterior à data de início.'})
+
+    def is_active(self, reference_time: Optional[datetime] = None) -> bool:
+        reference = reference_time or timezone.now()
+        return DesafioDinamico.objects.ativos(reference).filter(pk=self.pk).exists()
+
+    def get_target_value(self) -> float:
+        criterio = self.criterio_json or {}
+        try:
+            return float(criterio.get('valor') or 0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    def get_metric_type(self) -> str:
+        criterio = self.criterio_json or {}
+        return str(criterio.get('tipo', '')).lower()
+
+
+class ProgressoDesafioUsuario(models.Model):
+    """Progresso do usuário dentro de um desafio dinâmico."""
+
+    desafio = models.ForeignKey(
+        DesafioDinamico,
+        on_delete=models.CASCADE,
+        related_name='progresso_usuarios',
+        verbose_name="Desafio",
+    )
+    perfil = models.ForeignKey(
+        PerfilGamificacaoUsuario,
+        on_delete=models.CASCADE,
+        related_name='progresso_desafios',
+        verbose_name="Perfil",
+    )
+    valor_atual = models.FloatField(default=0.0, verbose_name="Valor Atual")
+    concluido = models.BooleanField(default=False, verbose_name="Concluído")
+    data_conclusao = models.DateTimeField(null=True, blank=True, verbose_name="Concluído em")
+    janela_inicio = models.DateTimeField(null=True, blank=True, verbose_name="Início do Ciclo")
+    janela_fim = models.DateTimeField(null=True, blank=True, verbose_name="Fim do Ciclo")
+    metadata = models.JSONField(default=dict, blank=True, verbose_name="Metadados")
+    criado_em = models.DateTimeField(auto_now_add=True, verbose_name="Criado em")
+    atualizado_em = models.DateTimeField(auto_now=True, verbose_name="Atualizado em")
+
+    class Meta:
+        verbose_name = "Progresso de Desafio do Usuário"
+        verbose_name_plural = "Progressos de Desafios dos Usuários"
+        unique_together = ('desafio', 'perfil')
+        indexes = [
+            models.Index(fields=['perfil', 'desafio'], name='idx_desafio_perfil'),
+        ]
+
+    def __str__(self):
+        return f"{self.perfil.user.get_username()} em {self.desafio.nome}"
+
+    def reset_for_challenge_window(self, desafio: DesafioDinamico) -> bool:
+        """Reseta o progresso se o período do desafio foi alterado."""
+
+        new_start = desafio.data_inicio
+        new_end = desafio.data_fim
+        if self.janela_inicio == new_start and self.janela_fim == new_end:
+            return False
+
+        self.valor_atual = 0.0
+        self.concluido = False
+        self.data_conclusao = None
+        self.metadata = {}
+        self.janela_inicio = new_start
+        self.janela_fim = new_end
+        return True
+
+    def progress_percent(self, target: float) -> float:
+        if target <= 0:
+            return 0.0
+        return max(0.0, min((self.valor_atual / target) * 100.0, 100.0))
+
+
+class RecompensaNivelResgatada(models.Model):
+    """Recompensas de nível que já foram resgatadas."""
+
+    perfil = models.ForeignKey(
+        PerfilGamificacaoUsuario,
+        on_delete=models.CASCADE,
+        related_name='recompensas_resgatadas',
+        verbose_name="Perfil",
+    )
+    nivel = models.ForeignKey(
+        NivelGamificacao,
+        on_delete=models.CASCADE,
+        related_name='recompensas_resgatadas',
+        verbose_name="Nível",
+    )
+    recompensa_id = models.CharField(max_length=150, verbose_name="Identificador da Recompensa")
+    dados_recompensa = models.JSONField(default=dict, blank=True, verbose_name="Dados da Recompensa")
+    data_resgate = models.DateTimeField(auto_now_add=True, verbose_name="Data de Resgate")
+
+    class Meta:
+        verbose_name = "Recompensa de Nível Resgatada"
+        verbose_name_plural = "Recompensas de Nível Resgatadas"
+        unique_together = ('perfil', 'nivel', 'recompensa_id')
+        indexes = [
+            models.Index(fields=['perfil', 'nivel'], name='idx_resgate_perfil_nivel'),
+        ]
+
+    def __str__(self):
+        return f"{self.recompensa_id} - {self.perfil.user.get_username()}"

--- a/quiz/services/gamification_service.py
+++ b/quiz/services/gamification_service.py
@@ -3,17 +3,23 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
 
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import Count, Max
+from django.utils import timezone
 
 from quiz.models import (
     Conquista,
     ConquistaUsuario,
     EstatisticasDiariasUsuario,
+    DesafioDinamico,
     NivelGamificacao,
     PerfilGamificacaoUsuario,
+    ProgressoDesafioUsuario,
+    RecompensaNivelResgatada,
     SessoesQuizUsuario,
 )
 from quiz.services.scoring_service import SessionScoreResult
@@ -26,6 +32,19 @@ class GamificationUpdateResult:
     profile: PerfilGamificacaoUsuario
     conquistas_desbloqueadas: int
     snapshot: Dict[str, Any]
+    desafios_concluidos: int
+
+
+@dataclass
+class GamificationContext:
+    """Estado agregado reutilizado durante o processamento de gamificação."""
+
+    daily_stats: Optional[EstatisticasDiariasUsuario]
+    daily_questions: int
+    daily_xp: int
+    daily_streak: int
+    session_metrics: Dict[str, Any]
+    reference_time: datetime
 
 
 class GamificationService:
@@ -34,6 +53,51 @@ class GamificationService:
     def ensure_profile(self, user) -> PerfilGamificacaoUsuario:
         profile, _ = PerfilGamificacaoUsuario.objects.get_or_create(user=user)
         return profile
+
+    def _build_context(
+        self,
+        profile: PerfilGamificacaoUsuario,
+        *,
+        daily_stats: Optional[EstatisticasDiariasUsuario] = None,
+    ) -> GamificationContext:
+        reference_time = timezone.now()
+
+        daily_stat_reference = daily_stats
+        if not daily_stat_reference:
+            daily_stat_reference = (
+                EstatisticasDiariasUsuario.objects.filter(id_usuario=profile.user)
+                .order_by('-data_estatistica')
+                .first()
+            )
+
+        perguntas_dia = 0
+        xp_diario = 0
+        daily_streak = 0
+
+        if daily_stat_reference:
+            perguntas_dia = daily_stat_reference.perguntas_respondidas_dia or 0
+            xp_diario = daily_stat_reference.xp_ganho_dia or 0
+            if perguntas_dia > 0:
+                daily_streak = daily_stat_reference.sequencia_dias_quiz or 0
+
+        sessions_qs = SessoesQuizUsuario.objects.filter(
+            id_usuario=profile.user,
+            status_sessao=SessoesQuizUsuario.StatusSessao.COMPLETA,
+        )
+        session_metrics = sessions_qs.aggregate(
+            max_score=Max('pontuacao_final'),
+            max_correct=Max('total_acertos'),
+            total_sessions=Count('id'),
+        )
+
+        return GamificationContext(
+            daily_stats=daily_stat_reference,
+            daily_questions=perguntas_dia,
+            daily_xp=xp_diario,
+            daily_streak=daily_streak,
+            session_metrics=session_metrics,
+            reference_time=reference_time,
+        )
 
     @transaction.atomic
     def apply_session_result(
@@ -57,11 +121,20 @@ class GamificationService:
         profile.save(update_fields=fields_to_update)
         profile.atualizar_nivel()
 
+        context = self._build_context(profile, daily_stats=daily_stats)
+
         conquistas_novas = self._unlock_achievements(
             profile,
             sessao,
             score_result,
-            daily_stats=daily_stats,
+            context=context,
+        )
+
+        desafios_atualizados = self._update_dynamic_challenges(
+            profile,
+            sessao,
+            score_result,
+            context=context,
         )
 
         snapshot = self._serialize_profile(
@@ -69,13 +142,15 @@ class GamificationService:
             xp_ganho=score_result.total_xp,
             conquistas_novas=conquistas_novas,
             nivel_anterior=nivel_anterior,
-            daily_stats=daily_stats,
+            context=context,
+            challenges_updates=desafios_atualizados,
         )
 
         return GamificationUpdateResult(
             profile=profile,
             conquistas_desbloqueadas=len(conquistas_novas),
             snapshot=snapshot,
+            desafios_concluidos=sum(1 for _, concluido in desafios_atualizados if concluido),
         )
 
     def get_profile_snapshot(
@@ -93,13 +168,14 @@ class GamificationService:
             .order_by('-data_estatistica')
             .first()
         )
+        context = self._build_context(profile, daily_stats=daily_stats)
         return self._serialize_profile(
             profile=profile,
             xp_ganho=0,
             conquistas_novas=None,
             nivel_anterior=None,
             include_catalog=include_catalog,
-            daily_stats=daily_stats,
+            context=context,
         )
 
     def _unlock_achievements(
@@ -107,37 +183,17 @@ class GamificationService:
         profile: PerfilGamificacaoUsuario,
         sessao: SessoesQuizUsuario,
         score_result: SessionScoreResult,
-        daily_stats: Optional[EstatisticasDiariasUsuario] = None,
+        *,
+        context: GamificationContext,
     ) -> List[ConquistaUsuario]:
         conquistas_disponiveis = Conquista.objects.all()
         ja_desbloqueadas = set(profile.conquistas.values_list('id', flat=True))
         a_criar: List[Dict[str, Any]] = []
 
-        daily_stat_reference = daily_stats
-        if not daily_stat_reference:
-            daily_stat_reference = (
-                EstatisticasDiariasUsuario.objects.filter(id_usuario=profile.user)
-                .order_by('-data_estatistica')
-                .first()
-            )
-
-        perguntas_dia = daily_stat_reference.perguntas_respondidas_dia if daily_stat_reference else 0
-        xp_diario_val = daily_stat_reference.xp_ganho_dia if daily_stat_reference else 0
-
-        if daily_stat_reference and perguntas_dia > 0:
-            daily_streak = daily_stat_reference.sequencia_dias_quiz or 0
-        else:
-            daily_streak = 0
-
-        sessions_qs = SessoesQuizUsuario.objects.filter(
-            id_usuario=profile.user,
-            status_sessao=SessoesQuizUsuario.StatusSessao.COMPLETA,
-        )
-        session_metrics = sessions_qs.aggregate(
-            max_score=Max('pontuacao_final'),
-            max_correct=Max('total_acertos'),
-            total_sessions=Count('id'),
-        )
+        perguntas_dia = context.daily_questions
+        xp_diario_val = context.daily_xp
+        daily_streak = context.daily_streak
+        session_metrics = context.session_metrics or {}
         total_sessions_completed = session_metrics.get('total_sessions') or 0
 
         for conquista in conquistas_disponiveis:
@@ -185,6 +241,159 @@ class GamificationService:
 
         return criadas
 
+    def _resolve_challenge_metric(
+        self,
+        *,
+        challenge: DesafioDinamico,
+        sessao: SessoesQuizUsuario,
+        score_result: SessionScoreResult,
+        context: GamificationContext,
+    ) -> Optional[Tuple[str, float]]:
+        metric_type = challenge.get_metric_type()
+        if not metric_type:
+            return None
+
+        metric_type = metric_type.lower()
+        if metric_type == 'xp_total':
+            return 'accumulate', float(max(score_result.total_xp, 0))
+        if metric_type == 'xp_diario':
+            return 'accumulate', float(max(score_result.total_xp, 0))
+        if metric_type == 'perguntas_diarias':
+            return 'accumulate', float(max(score_result.total_answered, 0))
+        if metric_type == 'quizzes_completos':
+            return 'accumulate', 1.0 if sessao.status_sessao == SessoesQuizUsuario.StatusSessao.COMPLETA else 0.0
+        if metric_type == 'pontuacao_sessao':
+            value = sessao.pontuacao_final if sessao and sessao.pontuacao_final is not None else score_result.total_points
+            return 'max', float(max(value or 0, 0))
+        if metric_type == 'respostas_corretas_sessao':
+            return 'max', float(max(score_result.total_correct, 0))
+        if metric_type == 'melhor_sequencia':
+            return 'max', float(max(score_result.best_streak, 0))
+        if metric_type == 'dias_consecutivos':
+            return 'max', float(max(context.daily_streak, 0))
+        return None
+
+    def _update_dynamic_challenges(
+        self,
+        profile: PerfilGamificacaoUsuario,
+        sessao: SessoesQuizUsuario,
+        score_result: SessionScoreResult,
+        *,
+        context: GamificationContext,
+    ) -> List[Tuple[ProgressoDesafioUsuario, bool]]:
+        active_challenges = list(DesafioDinamico.objects.ativos(context.reference_time))
+        if not active_challenges:
+            return []
+
+        progress_map = {
+            progress.desafio_id: progress
+            for progress in ProgressoDesafioUsuario.objects.filter(
+                perfil=profile,
+                desafio__in=active_challenges,
+            )
+        }
+
+        updates: List[Tuple[ProgressoDesafioUsuario, bool]] = []
+        for challenge in active_challenges:
+            progress = progress_map.get(challenge.id)
+            if not progress:
+                progress = ProgressoDesafioUsuario.objects.create(
+                    desafio=challenge,
+                    perfil=profile,
+                    janela_inicio=challenge.data_inicio,
+                    janela_fim=challenge.data_fim,
+                )
+                progress_map[challenge.id] = progress
+
+            window_reset = progress.reset_for_challenge_window(challenge)
+
+            metric_payload = self._resolve_challenge_metric(
+                challenge=challenge,
+                sessao=sessao,
+                score_result=score_result,
+                context=context,
+            )
+
+            if metric_payload is None:
+                if window_reset:
+                    progress.save(
+                        update_fields=[
+                            'valor_atual',
+                            'concluido',
+                            'data_conclusao',
+                            'metadata',
+                            'janela_inicio',
+                            'janela_fim',
+                        ]
+                    )
+                    updates.append((progress, False))
+                continue
+
+            strategy, measurement = metric_payload
+            measurement = float(measurement or 0.0)
+
+            target_value = challenge.get_target_value()
+            previous_value = progress.valor_atual
+            previous_completed = progress.concluido
+            fields_to_update: List[str] = []
+
+            if window_reset:
+                fields_to_update.extend(
+                    ['valor_atual', 'concluido', 'data_conclusao', 'metadata', 'janela_inicio', 'janela_fim']
+                )
+
+            new_value = previous_value
+            changed = window_reset
+
+            if strategy == 'accumulate':
+                if measurement > 0:
+                    new_value = previous_value + measurement
+                    changed = True
+            elif strategy == 'max':
+                new_value = max(previous_value, measurement)
+                changed = changed or new_value != previous_value
+            else:
+                new_value = max(measurement, 0.0)
+                changed = changed or new_value != previous_value
+
+            if target_value > 0:
+                new_value = min(new_value, target_value)
+
+            if new_value != progress.valor_atual:
+                progress.valor_atual = new_value
+                if 'valor_atual' not in fields_to_update:
+                    fields_to_update.append('valor_atual')
+
+            metadata = progress.metadata or {}
+            metadata['ultima_contribuicao'] = measurement
+            metadata['atualizado_em'] = context.reference_time.isoformat()
+            progress.metadata = metadata
+            if 'metadata' not in fields_to_update:
+                fields_to_update.append('metadata')
+
+            newly_completed = False
+            if target_value > 0 and progress.valor_atual >= target_value:
+                if not progress.concluido:
+                    newly_completed = True
+                progress.concluido = True
+                progress.data_conclusao = context.reference_time
+                fields_to_update.extend(['concluido', 'data_conclusao'])
+            elif progress.concluido and progress.valor_atual < target_value:
+                progress.concluido = False
+                progress.data_conclusao = None
+                fields_to_update.extend(['concluido', 'data_conclusao'])
+
+            if fields_to_update:
+                if 'atualizado_em' not in fields_to_update:
+                    fields_to_update.append('atualizado_em')
+                progress.save(update_fields=list(dict.fromkeys(fields_to_update)))
+                changed = True
+
+            if changed or newly_completed or previous_completed != progress.concluido:
+                updates.append((progress, newly_completed))
+
+        return updates
+
     def _serialize_profile(
         self,
         *,
@@ -193,19 +402,15 @@ class GamificationService:
         conquistas_novas: Optional[List[ConquistaUsuario]] = None,
         nivel_anterior: Optional[NivelGamificacao] = None,
         include_catalog: bool = False,
-        daily_stats: Optional[EstatisticasDiariasUsuario] = None,
+        context: Optional[GamificationContext] = None,
+        challenges_updates: Optional[List[Tuple[ProgressoDesafioUsuario, bool]]] = None,
     ) -> Dict[str, Any]:
         """Transforma o perfil em um payload amigável para o frontend."""
 
         xp_ganho_int = int(max(xp_ganho or 0, 0))
 
-        daily_stats_obj = daily_stats
-        if daily_stats_obj is None:
-            daily_stats_obj = (
-                EstatisticasDiariasUsuario.objects.filter(id_usuario=profile.user)
-                .order_by('-data_estatistica')
-                .first()
-            )
+        context_obj = context or self._build_context(profile)
+        daily_stats_obj = context_obj.daily_stats
 
         daily_engagement_payload = None
         if daily_stats_obj:
@@ -222,16 +427,10 @@ class GamificationService:
         daily_streak_value = 0
         if daily_engagement_payload:
             daily_streak_value = daily_engagement_payload.get('streak_days') or 0
+        elif context_obj:
+            daily_streak_value = context_obj.daily_streak
 
-        sessions_qs = SessoesQuizUsuario.objects.filter(
-            id_usuario=profile.user,
-            status_sessao=SessoesQuizUsuario.StatusSessao.COMPLETA,
-        )
-        session_metrics = sessions_qs.aggregate(
-            max_score=Max('pontuacao_final'),
-            max_correct=Max('total_acertos'),
-            total_sessions=Count('id'),
-        )
+        session_metrics = context_obj.session_metrics or {}
 
         conquistas_relacoes = list(
             profile.conquistas_usuarios.select_related('conquista').order_by('-data_conquista')
@@ -294,9 +493,7 @@ class GamificationService:
             progress_payload = self._build_achievement_progress(
                 conquista=conquista,
                 profile=profile,
-                daily_stats=daily_stats_obj,
-                daily_streak=daily_streak_value,
-                session_metrics=session_metrics,
+                context=context_obj,
             )
 
             if rel is None and progress_payload:
@@ -391,6 +588,12 @@ class GamificationService:
                 'catalog': catalogo_conquistas,
                 'upcoming': upcoming_highlights,
             },
+            'challenges': self._serialize_challenges(
+                profile=profile,
+                context=context_obj,
+                recently_updated=challenges_updates,
+            ),
+            'rewards': self._serialize_rewards(profile=profile, current_level=current_level),
         }
 
     def _build_achievement_progress(
@@ -398,9 +601,7 @@ class GamificationService:
         *,
         conquista: Conquista,
         profile: PerfilGamificacaoUsuario,
-        daily_stats: Optional[EstatisticasDiariasUsuario],
-        daily_streak: int,
-        session_metrics: Dict[str, Any],
+        context: GamificationContext,
     ) -> Optional[Dict[str, Any]]:
         criterio = conquista.criterio_json or {}
         tipo = str(criterio.get('tipo', '')).lower()
@@ -415,6 +616,10 @@ class GamificationService:
 
         if target_value <= 0:
             return None
+
+        daily_stats = context.daily_stats
+        daily_streak = context.daily_streak
+        session_metrics = context.session_metrics or {}
 
         unit_label = 'progresso'
         if tipo == 'xp_total':
@@ -469,3 +674,243 @@ class GamificationService:
             'remaining_label': remaining_label,
             'unit': unit_label,
         }
+
+    def _serialize_challenges(
+        self,
+        *,
+        profile: PerfilGamificacaoUsuario,
+        context: GamificationContext,
+        recently_updated: Optional[List[Tuple[ProgressoDesafioUsuario, bool]]],
+    ) -> Dict[str, Any]:
+        active_challenges = list(DesafioDinamico.objects.ativos(context.reference_time))
+        if not active_challenges:
+            return {'active': [], 'completed_now': [], 'total_active': 0}
+
+        progress_map = {
+            progress.desafio_id: progress
+            for progress in ProgressoDesafioUsuario.objects.filter(
+                perfil=profile,
+                desafio__in=active_challenges,
+            )
+        }
+
+        active_payload: List[Dict[str, Any]] = []
+        for challenge in active_challenges:
+            progress = progress_map.get(challenge.id)
+            if not progress:
+                progress = ProgressoDesafioUsuario(
+                    desafio=challenge,
+                    perfil=profile,
+                    janela_inicio=challenge.data_inicio,
+                    janela_fim=challenge.data_fim,
+                )
+            active_payload.append(
+                self._serialize_single_challenge(
+                    challenge=challenge,
+                    progress=progress,
+                    reference_time=context.reference_time,
+                )
+            )
+
+        completed_payload: List[Dict[str, Any]] = []
+        if recently_updated:
+            seen_ids = set()
+            for progress, completed_now in recently_updated:
+                if completed_now and progress.desafio_id not in seen_ids:
+                    completed_payload.append(
+                        self._serialize_single_challenge(
+                            challenge=progress.desafio,
+                            progress=progress,
+                            reference_time=context.reference_time,
+                        )
+                    )
+                    seen_ids.add(progress.desafio_id)
+
+        return {
+            'active': active_payload,
+            'completed_now': completed_payload,
+            'total_active': len(active_payload),
+        }
+
+    def _serialize_single_challenge(
+        self,
+        *,
+        challenge: DesafioDinamico,
+        progress: ProgressoDesafioUsuario,
+        reference_time: datetime,
+    ) -> Dict[str, Any]:
+        target_value = challenge.get_target_value()
+        current_value = float(progress.valor_atual or 0.0)
+        percent = progress.progress_percent(target_value) if target_value else 0.0
+        remaining = None
+        if target_value:
+            remaining = max(int(round(target_value - current_value)), 0)
+
+        label = f"{int(round(current_value))}"
+        if target_value:
+            label = f"{int(round(current_value))} / {int(round(target_value))}"
+
+        time_remaining_seconds = None
+        if challenge.data_fim:
+            delta = challenge.data_fim - reference_time
+            seconds = int(delta.total_seconds())
+            time_remaining_seconds = max(seconds, 0)
+
+        return {
+            'slug': challenge.slug,
+            'nome': challenge.nome,
+            'descricao': challenge.descricao,
+            'tipo': challenge.tipo,
+            'start': challenge.data_inicio.isoformat() if challenge.data_inicio else None,
+            'end': challenge.data_fim.isoformat() if challenge.data_fim else None,
+            'target': int(round(target_value)) if target_value else None,
+            'progress': {
+                'current': int(round(current_value)),
+                'percent': round(percent, 1) if target_value else 0.0,
+                'label': label,
+                'remaining': remaining,
+            },
+            'reward': challenge.recompensa_json or {},
+            'is_completed': bool(progress.concluido),
+            'completed_at': progress.data_conclusao.isoformat() if progress.data_conclusao else None,
+            'time_remaining_seconds': time_remaining_seconds,
+            'metadata': progress.metadata or {},
+        }
+
+    def _serialize_rewards(
+        self,
+        *,
+        profile: PerfilGamificacaoUsuario,
+        current_level: Optional[NivelGamificacao],
+    ) -> Dict[str, Any]:
+        claimed_qs = RecompensaNivelResgatada.objects.filter(perfil=profile)
+        claimed_map = {
+            (claim.nivel_id, claim.recompensa_id): claim
+            for claim in claimed_qs
+        }
+
+        eligible_levels = NivelGamificacao.objects.filter(
+            xp_minimo__lte=profile.xp_total,
+        ).order_by('ordem', 'xp_minimo')
+
+        all_rewards: List[Dict[str, Any]] = []
+        available_to_claim: List[Dict[str, Any]] = []
+        claimed_list: List[Dict[str, Any]] = []
+
+        for level in eligible_levels:
+            for reward in level.get_reward_definitions():
+                reward_id = str(reward.get('id'))
+                payload = {
+                    'level_id': level.id,
+                    'level_name': level.nome,
+                    'level_identifier': level.identificador,
+                    'reward_id': reward_id,
+                    'name': reward.get('nome'),
+                    'description': reward.get('descricao'),
+                    'type': reward.get('tipo'),
+                    'value': reward.get('valor'),
+                    'metadata': reward.get('metadata') or {},
+                    'is_claimed': False,
+                    'claimed_at': None,
+                }
+                claim = claimed_map.get((level.id, reward_id))
+                if claim:
+                    payload['is_claimed'] = True
+                    payload['claimed_at'] = claim.data_resgate.isoformat()
+                    payload['claimed_metadata'] = claim.dados_recompensa or {}
+                    claimed_list.append(payload)
+                else:
+                    available_to_claim.append(payload)
+                all_rewards.append(payload)
+
+        next_level = None
+        if current_level:
+            next_level = (
+                NivelGamificacao.objects.filter(xp_minimo__gt=current_level.xp_minimo)
+                .order_by('ordem', 'xp_minimo')
+                .first()
+            )
+        if not next_level:
+            next_level = (
+                NivelGamificacao.objects.filter(xp_minimo__gt=profile.xp_total)
+                .order_by('ordem', 'xp_minimo')
+                .first()
+            )
+
+        upcoming_rewards: List[Dict[str, Any]] = []
+        if next_level:
+            for reward in next_level.get_reward_definitions():
+                upcoming_rewards.append(
+                    {
+                        'level_id': next_level.id,
+                        'level_name': next_level.nome,
+                        'level_identifier': next_level.identificador,
+                        'reward_id': str(reward.get('id')),
+                        'name': reward.get('nome'),
+                        'description': reward.get('descricao'),
+                        'type': reward.get('tipo'),
+                        'value': reward.get('valor'),
+                        'metadata': reward.get('metadata') or {},
+                    }
+                )
+
+        return {
+            'available_to_claim': available_to_claim,
+            'claimed': claimed_list,
+            'all': all_rewards,
+            'upcoming': upcoming_rewards,
+        }
+
+    def claim_level_reward(
+        self,
+        user,
+        *,
+        level_id: int,
+        reward_id: str,
+    ) -> Dict[str, Any]:
+        profile = self.ensure_profile(user)
+        profile.atualizar_nivel()
+
+        try:
+            level = NivelGamificacao.objects.get(pk=level_id)
+        except NivelGamificacao.DoesNotExist as exc:
+            raise ValidationError({'level_id': 'Nível informado é inválido.'}) from exc
+
+        if profile.xp_total < level.xp_minimo:
+            raise ValidationError('O usuário ainda não alcançou este nível.')
+
+        reward_identifier = str(reward_id)
+        reward_definition = None
+        for reward in level.get_reward_definitions():
+            if str(reward.get('id')) == reward_identifier:
+                reward_definition = reward
+                break
+
+        if not reward_definition:
+            raise ValidationError({'reward_id': 'Recompensa não encontrada para este nível.'})
+
+        claim, created = RecompensaNivelResgatada.objects.get_or_create(
+            perfil=profile,
+            nivel=level,
+            recompensa_id=reward_identifier,
+            defaults={'dados_recompensa': reward_definition},
+        )
+
+        if not created:
+            raise ValidationError('Esta recompensa já foi resgatada anteriormente.')
+
+        reward_payload = {
+            'level_id': level.id,
+            'level_name': level.nome,
+            'reward_id': reward_identifier,
+            'name': reward_definition.get('nome'),
+            'description': reward_definition.get('descricao'),
+            'type': reward_definition.get('tipo'),
+            'value': reward_definition.get('valor'),
+            'metadata': reward_definition.get('metadata') or {},
+            'claimed_at': claim.data_resgate.isoformat(),
+        }
+
+        rewards_state = self._serialize_rewards(profile=profile, current_level=profile.nivel_atual)
+
+        return {'reward': reward_payload, 'rewards_state': rewards_state}

--- a/quiz/services/scoring_service.py
+++ b/quiz/services/scoring_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, List, Optional
+from typing import Any, Iterable, List, Optional
 
 from django.utils import timezone
 
@@ -34,6 +34,7 @@ class SessionScoreResult:
     current_streak: int
     best_streak: int
     response_scores: List[ResponseScore]
+    secondary_xp_bonus: int = 0
 
     @property
     def last_multiplier(self) -> float:
@@ -48,14 +49,70 @@ class ScoringService:
     def __init__(self, config: ConfiguracoesGeraisQuiz):
         self.config = config
 
+    @staticmethod
+    def _normalize_difficulty_label(difficulty: Optional[str]) -> str:
+        if not difficulty:
+            return ''
+        return str(difficulty).strip().lower()
+
+    def _get_difficulty_xp_bonus(self, difficulty: Optional[str]) -> float:
+        label = self._normalize_difficulty_label(difficulty)
+        if label in {'difícil', 'dificil'}:
+            return 0.5
+        if label in {'médio', 'medio'}:
+            return 0.25
+        if label in {'fácil', 'facil'}:
+            return 0.1
+        return 0.0
+
+    def _calculate_secondary_xp_bonus(
+        self,
+        *,
+        total_correct: int,
+        total_answered: int,
+        best_streak: int,
+        duration_seconds: Optional[int],
+    ) -> float:
+        bonus = 0.0
+        if total_answered > 0:
+            accuracy = total_correct / total_answered
+            if accuracy >= 0.95:
+                bonus += 15.0
+            elif accuracy >= 0.8:
+                bonus += 8.0
+
+        if best_streak >= 10:
+            bonus += 10.0
+        elif best_streak >= 5:
+            bonus += 5.0
+
+        if duration_seconds and total_answered > 0:
+            avg_time = duration_seconds / total_answered
+            if avg_time < 20:
+                bonus += 5.0
+            elif avg_time < 40:
+                bonus += 2.0
+
+        return bonus
+
     def compute_session_result(
         self,
         responses: Iterable[RespostasUsuarioPorSessao],
+        *,
+        session: Optional[Any] = None,
+        duration_seconds: Optional[int] = None,
     ) -> SessionScoreResult:
         """Calcula a pontuação consolidada de uma sessão."""
 
         responses_list = list(responses)
         responses_list.sort(key=lambda r: (r.data_resposta or timezone.now(), r.pk))
+
+        session_duration = duration_seconds
+        if session_duration is None and session is not None:
+            session_duration = getattr(session, 'tempo_total_segundos', None)
+            if session_duration in (None, 0) and getattr(session, 'data_inicio', None) and getattr(session, 'data_fim', None):
+                delta = session.data_fim - session.data_inicio
+                session_duration = int(max(delta.total_seconds(), 0))
 
         total_points_raw = 0.0
         total_xp = 0.0
@@ -70,6 +127,7 @@ class ScoringService:
             pergunta = getattr(response, "id_pergunta", None)
             dificuldade = getattr(pergunta, "nivel_dificuldade", None)
             rule = self.config.get_difficulty_rule(dificuldade or "")
+            difficulty_bonus_factor = self._get_difficulty_xp_bonus(dificuldade)
 
             base_points = float(rule.get("points", self.config.pontuacao_por_acerto))
             base_xp = float(rule.get("xp", self.config.pontuacao_por_acerto))
@@ -89,6 +147,7 @@ class ScoringService:
                 multiplicador = min(multiplicador, self.config.get_max_bonus_multiplier())
                 pontos_resposta = base_points * multiplicador
                 xp_resposta = base_xp * multiplicador
+                xp_resposta += base_xp * difficulty_bonus_factor
             elif response.foi_correta is False and response.id_opcao_resposta_selecionada_id is not None:
                 total_incorrect += 1
                 current_streak = 0
@@ -117,6 +176,15 @@ class ScoringService:
         total_points = int(round(max(total_points_raw, 0)))
         total_xp_int = int(round(max(total_xp, 0)))
 
+        secondary_bonus = self._calculate_secondary_xp_bonus(
+            total_correct=total_correct,
+            total_answered=total_answered,
+            best_streak=best_streak,
+            duration_seconds=session_duration,
+        )
+        secondary_bonus_int = int(round(max(secondary_bonus, 0)))
+        total_xp_int += secondary_bonus_int
+
         return SessionScoreResult(
             total_points=total_points,
             total_xp=total_xp_int,
@@ -126,4 +194,5 @@ class ScoringService:
             current_streak=current_streak,
             best_streak=best_streak,
             response_scores=response_scores,
+            secondary_xp_bonus=secondary_bonus_int,
         )

--- a/quiz/tests/test_services.py
+++ b/quiz/tests/test_services.py
@@ -1,4 +1,7 @@
 from datetime import timedelta
+from types import SimpleNamespace
+
+from datetime import timedelta
 
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -14,10 +17,12 @@ from quiz.models import (
     Pergunta,
     QuestaoFavorita,
     SessoesQuizUsuario,
+    DesafioDinamico,
+    RecompensaNivelResgatada,
 )
 from quiz.services.gamification_service import GamificationService
 from quiz.services.quiz_service import QuizDataService
-from quiz.services.scoring_service import SessionScoreResult
+from quiz.services.scoring_service import ScoringService, SessionScoreResult
 from quiz.services.statistics_service import StatisticsService
 from quiz.views import get_quiz_config, invalidate_quiz_config_cache
 
@@ -215,6 +220,16 @@ class GamificationServiceTests(TestCase):
             xp_minimo=0,
             xp_maximo=150,
         )
+        self.level.recompensas_json = {
+            'items': [
+                {
+                    'id': 'ebook',
+                    'nome': 'Guia de Estudos',
+                    'descricao': 'Material complementar exclusivo.',
+                }
+            ]
+        }
+        self.level.save()
 
         Conquista.objects.create(
             slug='xp-50',
@@ -250,6 +265,16 @@ class GamificationServiceTests(TestCase):
             pontos_dia=180,
             xp_ganho_dia=75,
             sequencia_dias_quiz=3,
+        )
+
+        self.dynamic_challenge = DesafioDinamico.objects.create(
+            slug='desafio-responda-15',
+            nome='Responder 15 perguntas',
+            tipo=DesafioDinamico.TipoDesafio.SEMANAL,
+            criterio_json={'tipo': 'perguntas_diarias', 'valor': 15},
+            recompensa_json={'xp_bonus': 20},
+            data_inicio=timezone.now() - timedelta(days=1),
+            data_fim=timezone.now() + timedelta(days=5),
         )
 
         self.previous_session = SessoesQuizUsuario.objects.create(
@@ -302,3 +327,108 @@ class GamificationServiceTests(TestCase):
         self.assertIsInstance(upcoming, list)
         self.assertTrue(any(item.get('progress') for item in upcoming))
         self.assertTrue(any(item['progress']['metric'] == 'xp_total' for item in upcoming if item.get('progress')))
+
+    def test_dynamic_challenge_progress_and_completion(self):
+        first_result = self.service.apply_session_result(
+            self.user,
+            self.session,
+            self.score_result,
+            daily_stats=self.daily_stat,
+        )
+
+        challenges_snapshot = first_result.snapshot['challenges']
+        self.assertGreater(challenges_snapshot['total_active'], 0)
+        active_challenge = challenges_snapshot['active'][0]
+        self.assertEqual(active_challenge['progress']['current'], 12)
+        self.assertFalse(active_challenge['is_completed'])
+
+        extra_session = SessoesQuizUsuario.objects.create(
+            id_usuario=self.user,
+            modo_quiz=SessoesQuizUsuario.ModoQuiz.RAPIDO,
+            status_sessao=SessoesQuizUsuario.StatusSessao.COMPLETA,
+            total_perguntas_sessao=5,
+            total_acertos=4,
+            total_erros=1,
+            pontuacao_final=95,
+            xp_total_sessao=45,
+        )
+        extra_score = SessionScoreResult(
+            total_points=95,
+            total_xp=45,
+            total_correct=4,
+            total_incorrect=1,
+            total_answered=5,
+            current_streak=3,
+            best_streak=4,
+            response_scores=[],
+        )
+
+        second_result = self.service.apply_session_result(
+            self.user,
+            extra_session,
+            extra_score,
+            daily_stats=self.daily_stat,
+        )
+
+        self.assertGreaterEqual(second_result.desafios_concluidos, 1)
+        challenges_after = second_result.snapshot['challenges']
+        self.assertTrue(any(item['is_completed'] for item in challenges_after['active']))
+        self.assertTrue(len(challenges_after['completed_now']) >= 1)
+
+    def test_rewards_available_and_claim_flow(self):
+        result = self.service.apply_session_result(
+            self.user,
+            self.session,
+            self.score_result,
+            daily_stats=self.daily_stat,
+        )
+
+        rewards_snapshot = result.snapshot['rewards']
+        self.assertTrue(rewards_snapshot['available_to_claim'])
+        reward_payload = rewards_snapshot['available_to_claim'][0]
+
+        claim_payload = self.service.claim_level_reward(
+            self.user,
+            level_id=self.level.id,
+            reward_id=reward_payload['reward_id'],
+        )
+
+        self.assertEqual(RecompensaNivelResgatada.objects.filter(perfil__user=self.user).count(), 1)
+        self.assertEqual(claim_payload['reward']['reward_id'], reward_payload['reward_id'])
+
+        refreshed_snapshot = self.service.get_profile_snapshot(self.user)
+        self.assertFalse(refreshed_snapshot['rewards']['available_to_claim'])
+        self.assertTrue(refreshed_snapshot['rewards']['claimed'])
+
+
+class ScoringServiceTests(TestCase):
+    def setUp(self):
+        invalidate_quiz_config_cache()
+        ConfiguracoesGeraisQuiz.objects.all().delete()
+        self.config = ConfiguracoesGeraisQuiz.objects.create()
+        self.service = ScoringService(self.config)
+        self.user = User.objects.create_user('scorer', 'scorer@example.com', 'secret')
+        self.question = Pergunta.objects.create(
+            texto_pergunta='Pergunta difícil?',
+            nivel_dificuldade=Pergunta.NivelDificuldade.DIFICIL,
+        )
+        self.option = OpcaoResposta.objects.create(
+            pergunta=self.question,
+            texto_opcao='Resposta correta',
+            eh_correta=True,
+        )
+
+    def test_scoring_service_awards_distinct_xp(self):
+        response = SimpleNamespace(
+            pk=1,
+            data_resposta=timezone.now(),
+            id_pergunta=SimpleNamespace(nivel_dificuldade=self.question.nivel_dificuldade),
+            id_opcao_resposta_selecionada_id=self.option.pk,
+            foi_correta=True,
+        )
+        session = SimpleNamespace(tempo_total_segundos=90)
+
+        result = self.service.compute_session_result([response], session=session)
+
+        self.assertNotEqual(result.total_points, result.total_xp)
+        self.assertGreater(result.secondary_xp_bonus, 0)

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -950,7 +950,7 @@ def register_answer_view(request):
             .select_related('id_pergunta')
             .order_by('data_resposta', 'pk')
         )
-        score_result = scoring_service.compute_session_result(respostas_da_sessao)
+        score_result = scoring_service.compute_session_result(respostas_da_sessao, session=sessao_quiz)
         if respostas_da_sessao:
             for resp_obj, resp_score in zip(respostas_da_sessao, score_result.response_scores):
                 resp_obj.pontos_obtidos = resp_score.pontos
@@ -1039,7 +1039,7 @@ def end_quiz_session_view(request):
             .select_related('id_pergunta')
             .order_by('data_resposta', 'pk')
         )
-        score_result = scoring_service.compute_session_result(respostas_da_sessao)
+        score_result = scoring_service.compute_session_result(respostas_da_sessao, session=sessao_quiz)
         if respostas_da_sessao:
             for resp_obj, resp_score in zip(respostas_da_sessao, score_result.response_scores):
                 resp_obj.pontos_obtidos = resp_score.pontos


### PR DESCRIPTION
## Summary
- add models and admin support for dynamic challenges and level reward redemption, including a migration
- enhance the gamification service to serialize challenges/rewards, update progress, and expose a reward-claim API endpoint
- differentiate XP scoring with difficulty/secondary bonuses and expand tests to cover new behavior

## Testing
- `python manage.py test quiz.tests.test_services` *(fails: Django not installed in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1552ec9908333a2fcfe8edb18e88e