### PR TITLE
Add seed data and command for gamification features

### DIFF
--- a/docs/dados.md
+++ b/docs/dados.md
@@ -44,3 +44,21 @@ Os modelos `Categoria`, `Pergunta` e `OpcaoResposta` possuem o campo `codigo_imp
 - Populado automaticamente em registros antigos através das migrations, usando o `pk` como valor inicial.
 
 Graças a esse campo, o comando `load_quiz_data` se torna idempotente: rodadas subsequentes da importação atualizam os registros existentes sem criar duplicatas, desde que o identificador externo seja preservado.
+
+## Populando dados de gamificação
+
+Para facilitar os testes dos recursos de gamificação, o projeto inclui uma migration (`0011_seed_gamification_data`) e um comando de management que inserem níveis com recompensas, conquistas e desafios dinâmicos de demonstração.
+
+Após aplicar as migrations execute:
+
+```bash
+python manage.py seed_gamification_data
+```
+
+O comando cria ou atualiza os registros sem gerar duplicatas e apresenta um resumo com o que foi inserido, atualizado ou mantido. Caso deseje reiniciar completamente os dados de gamificação, utilize a opção `--purge`:
+
+```bash
+python manage.py seed_gamification_data --purge
+```
+
+Esse utilitário é útil para restaurar o banco de dados para um estado conhecido durante testes locais ou demonstrações.

--- a/quiz/management/commands/seed_gamification_data.py
+++ b/quiz/management/commands/seed_gamification_data.py
@@ -1,0 +1,131 @@
+"""Comando utilitário para semear dados de gamificação de demonstração."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, Sequence
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.utils import timezone
+
+from quiz.models import Conquista, DesafioDinamico, NivelGamificacao
+from quiz.seeders.gamification import (
+    get_achievement_seeds,
+    get_challenge_seeds,
+    get_level_seeds,
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Cria ou atualiza níveis, conquistas e desafios dinâmicos com dados de exemplo. "
+        "Use para ter conteúdo pronto ao explorar a área de gamificação."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--purge',
+            action='store_true',
+            help='Remove registros existentes antes de semear os dados de exemplo.',
+        )
+
+    def handle(self, *args, **options):
+        purge = bool(options.get('purge'))
+
+        with transaction.atomic():
+            if purge:
+                self._purge_existing()
+
+            level_summary = self._seed_levels()
+            achievement_summary = self._seed_achievements()
+            challenge_summary = self._seed_challenges()
+
+        self.stdout.write(self.style.SUCCESS('Dados de gamificação sincronizados com sucesso.'))
+        self._print_summary('Níveis', level_summary)
+        self._print_summary('Conquistas', achievement_summary)
+        self._print_summary('Desafios dinâmicos', challenge_summary)
+
+    def _purge_existing(self) -> None:
+        NivelGamificacao.objects.all().delete()
+        Conquista.objects.all().delete()
+        DesafioDinamico.objects.all().delete()
+        self.stdout.write(self.style.WARNING('Registros existentes removidos.'))
+
+    def _seed_levels(self) -> Dict[str, int]:
+        payloads = get_level_seeds()
+        return self._sync_model(
+            model=NivelGamificacao,
+            unique_field='identificador',
+            payloads=payloads,
+            defaults_keys=['nome', 'descricao', 'ordem', 'xp_minimo', 'xp_maximo', 'recompensas_json'],
+        )
+
+    def _seed_achievements(self) -> Dict[str, int]:
+        payloads = get_achievement_seeds()
+        return self._sync_model(
+            model=Conquista,
+            unique_field='slug',
+            payloads=payloads,
+            defaults_keys=['nome', 'descricao', 'criterio_json', 'icone', 'ordem_exibicao'],
+        )
+
+    def _seed_challenges(self) -> Dict[str, int]:
+        reference = timezone.now()
+        payloads = get_challenge_seeds(reference)
+        return self._sync_model(
+            model=DesafioDinamico,
+            unique_field='slug',
+            payloads=payloads,
+            defaults_keys=[
+                'nome',
+                'descricao',
+                'tipo',
+                'criterio_json',
+                'recompensa_json',
+                'data_inicio',
+                'data_fim',
+                'ativo',
+            ],
+        )
+
+    def _sync_model(
+        self,
+        *,
+        model,
+        unique_field: str,
+        payloads: Iterable[Dict[str, object]],
+        defaults_keys: Sequence[str],
+    ) -> Dict[str, int]:
+        summary = {'created': 0, 'updated': 0, 'unchanged': 0}
+
+        for data in payloads:
+            lookup_value = data[unique_field]
+            defaults = {key: data.get(key) for key in defaults_keys}
+
+            existing = model.objects.filter(**{unique_field: lookup_value}).first()
+            changed = False
+            if existing:
+                for field, value in defaults.items():
+                    if getattr(existing, field) != value:
+                        changed = True
+                        break
+
+            _, created = model.objects.update_or_create(
+                defaults=defaults,
+                **{unique_field: lookup_value},
+            )
+
+            if created:
+                summary['created'] += 1
+            elif changed:
+                summary['updated'] += 1
+            else:
+                summary['unchanged'] += 1
+
+        return summary
+
+    def _print_summary(self, label: str, summary: Dict[str, int]) -> None:
+        message = (
+            f"{label}: {summary['created']} criados, "
+            f"{summary['updated']} atualizados, {summary['unchanged']} inalterados."
+        )
+        self.stdout.write(message)

--- a/quiz/migrations/0011_seed_gamification_data.py
+++ b/quiz/migrations/0011_seed_gamification_data.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from django.db import migrations
+
+from quiz.seeders.gamification import (
+    get_achievement_seeds,
+    get_challenge_seeds,
+    get_level_seeds,
+)
+
+
+LEVEL_IDENTIFIERS = ['iniciante', 'aprendiz', 'especialista', 'mentor']
+ACHIEVEMENT_SLUGS = [
+    'primeiro-quiz',
+    'xp-100',
+    'streak-3-dias',
+    'acertos-25',
+    'pontuacao-500',
+    'maratonista-diario',
+]
+CHALLENGE_SLUGS = [
+    'desafio-diario-xp',
+    'desafio-semanal-quizzes',
+    'desafio-evento-streak',
+]
+
+
+def seed_gamification(apps, _):
+    Level = apps.get_model('quiz', 'NivelGamificacao')
+    Achievement = apps.get_model('quiz', 'Conquista')
+    Challenge = apps.get_model('quiz', 'DesafioDinamico')
+
+    for payload in get_level_seeds():
+        Level.objects.update_or_create(
+            identificador=payload['identificador'],
+            defaults={
+                'nome': payload['nome'],
+                'descricao': payload['descricao'],
+                'ordem': payload['ordem'],
+                'xp_minimo': payload['xp_minimo'],
+                'xp_maximo': payload['xp_maximo'],
+                'recompensas_json': payload['recompensas_json'],
+            },
+        )
+
+    for payload in get_achievement_seeds():
+        Achievement.objects.update_or_create(
+            slug=payload['slug'],
+            defaults={
+                'nome': payload['nome'],
+                'descricao': payload['descricao'],
+                'criterio_json': payload['criterio_json'],
+                'icone': payload['icone'],
+                'ordem_exibicao': payload['ordem_exibicao'],
+            },
+        )
+
+    for payload in get_challenge_seeds():
+        Challenge.objects.update_or_create(
+            slug=payload['slug'],
+            defaults={
+                'nome': payload['nome'],
+                'descricao': payload['descricao'],
+                'tipo': payload['tipo'],
+                'criterio_json': payload['criterio_json'],
+                'recompensa_json': payload['recompensa_json'],
+                'data_inicio': payload['data_inicio'],
+                'data_fim': payload['data_fim'],
+                'ativo': payload['ativo'],
+            },
+        )
+
+
+def unseed_gamification(apps, _):
+    Level = apps.get_model('quiz', 'NivelGamificacao')
+    Achievement = apps.get_model('quiz', 'Conquista')
+    Challenge = apps.get_model('quiz', 'DesafioDinamico')
+
+    Level.objects.filter(identificador__in=LEVEL_IDENTIFIERS).delete()
+    Achievement.objects.filter(slug__in=ACHIEVEMENT_SLUGS).delete()
+    Challenge.objects.filter(slug__in=CHALLENGE_SLUGS).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('quiz', '0010_dynamic_challenges'),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_gamification, unseed_gamification),
+    ]

--- a/quiz/seeders/__init__.py
+++ b/quiz/seeders/__init__.py
@@ -1,0 +1,1 @@
+"""Utilitários para semear dados de apoio durante o desenvolvimento."""

--- a/quiz/seeders/gamification.py
+++ b/quiz/seeders/gamification.py
@@ -1,0 +1,303 @@
+"""Coleções de dados de exemplo para recursos de gamificação."""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+from django.utils import timezone
+
+
+@dataclass(frozen=True)
+class LevelRewardSeed:
+    identificador: str
+    nome: str
+    descricao: str
+    ordem: int
+    xp_minimo: int
+    xp_maximo: Optional[int]
+    recompensas_json: Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class AchievementSeed:
+    slug: str
+    nome: str
+    descricao: str
+    criterio_json: Dict[str, Any]
+    icone: str
+    ordem_exibicao: int
+
+
+@dataclass(frozen=True)
+class ChallengeSeed:
+    slug: str
+    nome: str
+    descricao: str
+    tipo: str
+    criterio_json: Dict[str, Any]
+    recompensa_json: Dict[str, Any]
+    delta_inicio: Optional[timedelta]
+    delta_fim: Optional[timedelta]
+
+
+_BASE_LEVELS: List[LevelRewardSeed] = [
+    LevelRewardSeed(
+        identificador='iniciante',
+        nome='Iniciante',
+        descricao='Primeiros passos na jornada de estudos com desafios acessíveis.',
+        ordem=1,
+        xp_minimo=0,
+        xp_maximo=149,
+        recompensas_json={
+            'items': [
+                {
+                    'id': 'badge_iniciante',
+                    'nome': 'Emblema Iniciante',
+                    'descricao': 'Emblema digital para celebrar sua primeira etapa.',
+                    'tipo': 'badge',
+                },
+                {
+                    'id': 'dica-extra',
+                    'nome': 'Dica Extra',
+                    'descricao': 'Receba uma dica exclusiva para aprimorar seus estudos.',
+                    'tipo': 'content_unlock',
+                    'valor': 1,
+                },
+            ]
+        },
+    ),
+    LevelRewardSeed(
+        identificador='aprendiz',
+        nome='Aprendiz Dedicado',
+        descricao='Você já domina o básico e segue firme em novas missões.',
+        ordem=2,
+        xp_minimo=150,
+        xp_maximo=399,
+        recompensas_json={
+            'items': [
+                {
+                    'id': 'bonus-xp-5',
+                    'nome': 'Impulso de XP',
+                    'descricao': 'Ganhe 5% a mais de XP nas próximas sessões concluídas hoje.',
+                    'tipo': 'xp_boost',
+                    'valor': 5,
+                    'metadata': {'duracao_horas': 24},
+                },
+                {
+                    'id': 'wallpaper-estudos',
+                    'nome': 'Wallpaper Exclusivo',
+                    'descricao': 'Material visual para deixar sua área de estudos inspiradora.',
+                    'tipo': 'download',
+                },
+            ]
+        },
+    ),
+    LevelRewardSeed(
+        identificador='especialista',
+        nome='Especialista',
+        descricao='Constância e foco estão levando seus resultados a outro nível.',
+        ordem=3,
+        xp_minimo=400,
+        xp_maximo=799,
+        recompensas_json={
+            'items': [
+                {
+                    'id': 'desconto-curso',
+                    'nome': 'Desconto em Curso Parceiro',
+                    'descricao': 'Desconto de 10% em um curso parceiro selecionado.',
+                    'tipo': 'coupon',
+                    'valor': 10,
+                },
+                {
+                    'id': 'tema-especial',
+                    'nome': 'Tema Especial do App',
+                    'descricao': 'Tema visual alternativo liberado no painel.',
+                    'tipo': 'theme',
+                },
+            ]
+        },
+    ),
+    LevelRewardSeed(
+        identificador='mentor',
+        nome='Mentor da Comunidade',
+        descricao='Seu empenho inspira outros estudantes. Continue liderando!',
+        ordem=4,
+        xp_minimo=800,
+        xp_maximo=None,
+        recompensas_json={
+            'items': [
+                {
+                    'id': 'badge-mentor',
+                    'nome': 'Emblema Mentor',
+                    'descricao': 'Um emblema lendário visível para toda a comunidade.',
+                    'tipo': 'badge',
+                },
+                {
+                    'id': 'sessao-consultoria',
+                    'nome': 'Sessão de Consultoria',
+                    'descricao': 'Agende uma conversa rápida com um especialista convidado.',
+                    'tipo': 'mentoring',
+                },
+            ]
+        },
+    ),
+]
+
+
+_BASE_ACHIEVEMENTS: List[AchievementSeed] = [
+    AchievementSeed(
+        slug='primeiro-quiz',
+        nome='Primeiro Quiz Concluído',
+        descricao='Finalize o seu primeiro quiz completo.',
+        criterio_json={'tipo': 'quizzes_completos', 'valor': 1},
+        icone='flag',
+        ordem_exibicao=10,
+    ),
+    AchievementSeed(
+        slug='xp-100',
+        nome='Cem Pontos de Conhecimento',
+        descricao='Acumule 100 pontos de XP totais.',
+        criterio_json={'tipo': 'xp_total', 'valor': 100},
+        icone='military_tech',
+        ordem_exibicao=20,
+    ),
+    AchievementSeed(
+        slug='streak-3-dias',
+        nome='Três Dias Seguidos',
+        descricao='Estude por 3 dias consecutivos.',
+        criterio_json={'tipo': 'dias_consecutivos', 'valor': 3},
+        icone='calendar_month',
+        ordem_exibicao=30,
+    ),
+    AchievementSeed(
+        slug='acertos-25',
+        nome='Mestre dos Acertos',
+        descricao='Acerte 25 questões corretas em uma única sessão.',
+        criterio_json={'tipo': 'respostas_corretas_sessao', 'valor': 25},
+        icone='check_circle',
+        ordem_exibicao=40,
+    ),
+    AchievementSeed(
+        slug='pontuacao-500',
+        nome='Pontuação Imbatível',
+        descricao='Alcance 500 pontos de pontuação em uma sessão.',
+        criterio_json={'tipo': 'pontuacao_sessao', 'valor': 500},
+        icone='stars',
+        ordem_exibicao=50,
+    ),
+    AchievementSeed(
+        slug='maratonista-diario',
+        nome='Maratonista Diário',
+        descricao='Responda 30 perguntas em um mesmo dia.',
+        criterio_json={'tipo': 'perguntas_diarias', 'valor': 30},
+        icone='directions_run',
+        ordem_exibicao=60,
+    ),
+]
+
+
+_BASE_CHALLENGES: List[ChallengeSeed] = [
+    ChallengeSeed(
+        slug='desafio-diario-xp',
+        nome='XP em Dobro Hoje',
+        descricao='Some 120 pontos de XP ao longo do dia para liberar um bônus.',
+        tipo='daily',
+        criterio_json={'tipo': 'xp_diario', 'valor': 120},
+        recompensa_json={
+            'nome': 'Pacote de Energia',
+            'descricao': 'Bônus de 50 XP aplicado automaticamente ao concluir.',
+            'tipo': 'xp_bonus',
+            'valor': 50,
+        },
+        delta_inicio=timedelta(minutes=0),
+        delta_fim=timedelta(days=1),
+    ),
+    ChallengeSeed(
+        slug='desafio-semanal-quizzes',
+        nome='Semana de Foco',
+        descricao='Complete 5 quizzes completos durante a semana.',
+        tipo='weekly',
+        criterio_json={'tipo': 'quizzes_completos', 'valor': 5},
+        recompensa_json={
+            'nome': 'Título de Foco Total',
+            'descricao': 'Título temporário exibido no seu perfil.',
+            'tipo': 'title',
+        },
+        delta_inicio=timedelta(minutes=0),
+        delta_fim=timedelta(days=7),
+    ),
+    ChallengeSeed(
+        slug='desafio-evento-streak',
+        nome='Evento Maratona de Estudos',
+        descricao='Mantenha uma sequência de 5 dias seguidos respondendo quizzes.',
+        tipo='event',
+        criterio_json={'tipo': 'dias_consecutivos', 'valor': 5},
+        recompensa_json={
+            'nome': 'Skin Especial do Avatar',
+            'descricao': 'Visual comemorativo disponível por tempo limitado.',
+            'tipo': 'cosmetic',
+        },
+        delta_inicio=timedelta(minutes=0),
+        delta_fim=timedelta(days=14),
+    ),
+]
+
+
+def get_level_seeds() -> List[Dict[str, Any]]:
+    """Retorna uma cópia independente das definições de níveis."""
+    return [
+        {
+            'identificador': seed.identificador,
+            'nome': seed.nome,
+            'descricao': seed.descricao,
+            'ordem': seed.ordem,
+            'xp_minimo': seed.xp_minimo,
+            'xp_maximo': seed.xp_maximo,
+            'recompensas_json': deepcopy(seed.recompensas_json),
+        }
+        for seed in _BASE_LEVELS
+    ]
+
+
+def get_achievement_seeds() -> List[Dict[str, Any]]:
+    """Retorna conquistas padrão usadas para demonstração."""
+    return [
+        {
+            'slug': seed.slug,
+            'nome': seed.nome,
+            'descricao': seed.descricao,
+            'criterio_json': deepcopy(seed.criterio_json),
+            'icone': seed.icone,
+            'ordem_exibicao': seed.ordem_exibicao,
+        }
+        for seed in _BASE_ACHIEVEMENTS
+    ]
+
+
+def get_challenge_seeds(reference: Optional[datetime] = None) -> List[Dict[str, Any]]:
+    """Gera desafios com datas relativas à referência fornecida."""
+    start_time = reference or timezone.now()
+
+    items: List[Dict[str, Any]] = []
+    for seed in _BASE_CHALLENGES:
+        inicio = start_time + (seed.delta_inicio or timedelta()) if seed.delta_inicio else start_time
+        fim = start_time + (seed.delta_fim or timedelta()) if seed.delta_fim else None
+        items.append(
+            {
+                'slug': seed.slug,
+                'nome': seed.nome,
+                'descricao': seed.descricao,
+                'tipo': seed.tipo,
+                'criterio_json': deepcopy(seed.criterio_json),
+                'recompensa_json': deepcopy(seed.recompensa_json),
+                'data_inicio': inicio,
+                'data_fim': fim,
+                'ativo': True,
+            }
+        )
+    return items
+
+
+

--- a/quiz/tests/test_seed_commands.py
+++ b/quiz/tests/test_seed_commands.py
@@ -1,0 +1,48 @@
+from django.core.management import call_command
+from django.test import TestCase
+
+from quiz.models import Conquista, DesafioDinamico, NivelGamificacao
+from quiz.seeders.gamification import (
+    get_achievement_seeds,
+    get_challenge_seeds,
+    get_level_seeds,
+)
+
+
+class SeedGamificationDataCommandTests(TestCase):
+    def test_command_populates_expected_records(self):
+        call_command('seed_gamification_data', purge=True)
+
+        expected_levels = {item['identificador'] for item in get_level_seeds()}
+        expected_achievements = {item['slug'] for item in get_achievement_seeds()}
+        expected_challenges = {item['slug'] for item in get_challenge_seeds()}
+
+        self.assertSetEqual(
+            set(NivelGamificacao.objects.values_list('identificador', flat=True)),
+            expected_levels,
+        )
+        self.assertSetEqual(
+            set(Conquista.objects.values_list('slug', flat=True)),
+            expected_achievements,
+        )
+        self.assertSetEqual(
+            set(DesafioDinamico.objects.values_list('slug', flat=True)),
+            expected_challenges,
+        )
+
+    def test_command_is_idempotent(self):
+        call_command('seed_gamification_data', purge=True)
+        first_counts = (
+            NivelGamificacao.objects.count(),
+            Conquista.objects.count(),
+            DesafioDinamico.objects.count(),
+        )
+
+        call_command('seed_gamification_data')
+        second_counts = (
+            NivelGamificacao.objects.count(),
+            Conquista.objects.count(),
+            DesafioDinamico.objects.count(),
+        )
+
+        self.assertEqual(first_counts, second_counts)


### PR DESCRIPTION
## Summary
- add reusable seed definitions for levels, achievements, and dynamic challenges
- introduce a data migration and `seed_gamification_data` management command to populate gamification content
- document the seeding workflow and cover the command with regression tests

## Testing
- `python manage.py test quiz.tests.test_seed_commands.SeedGamificationDataCommandTests --verbosity 2` *(fails: ModuleNotFoundError: No module named 'django' because dependencies are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c9e559d88333808161d966e67482