### PR TITLE
Rename gamification seed migration to 0012

### DIFF
--- a/docs/dados.md
+++ b/docs/dados.md
@@ -47,7 +47,7 @@ Graças a esse campo, o comando `load_quiz_data` se torna idempotente: rodadas s
 
 ## Populando dados de gamificação
 
-Para facilitar os testes dos recursos de gamificação, o projeto inclui uma migration (`0011_seed_gamification_data`) e um comando de management que inserem níveis com recompensas, conquistas e desafios dinâmicos de demonstração.
+Para facilitar os testes dos recursos de gamificação, o projeto inclui uma migration (`0012_seed_gamification_data`) e um comando de management que inserem níveis com recompensas, conquistas e desafios dinâmicos de demonstração.
 
 Após aplicar as migrations execute:
 

--- a/quiz/migrations/0011_remove_progressodesafiousuario_quiz_progresso_desafio_usuario_desafio_perfil_uniq_and_more.py
+++ b/quiz/migrations/0011_remove_progressodesafiousuario_quiz_progresso_desafio_usuario_desafio_perfil_uniq_and_more.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('quiz', '0010_dynamic_challenges'),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name='progressodesafiousuario',
+            name='quiz_progresso_desafio_usuario_desafio_perfil_uniq',
+        ),
+        migrations.AlterUniqueTogether(
+            name='progressodesafiousuario',
+            unique_together={('desafio', 'perfil')},
+        ),
+        migrations.RemoveConstraint(
+            model_name='recompensanivelresgatada',
+            name='quiz_recompensa_nivel_resgatada_unq',
+        ),
+        migrations.AlterUniqueTogether(
+            name='recompensanivelresgatada',
+            unique_together={('perfil', 'nivel', 'recompensa_id')},
+        ),
+    ]

--- a/quiz/migrations/0012_seed_gamification_data.py
+++ b/quiz/migrations/0012_seed_gamification_data.py
@@ -84,7 +84,14 @@ def unseed_gamification(apps, _):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('quiz', '0010_dynamic_challenges'),
+        (
+            'quiz',
+            '0011_remove_progressodesafiousuario_quiz_progresso_desafio_usuario_desafio_perfil_uniq_and_more',
+        ),
+    ]
+
+    replaces = [
+        ('quiz', '0011_seed_gamification_data'),
     ]
 
     operations = [


### PR DESCRIPTION
## Summary
- rename the gamification seed migration to 0012 and depend on the new ordering
- add migration 0011 that removes the legacy unique constraints in favor of unique_together definitions
- update the gamification data documentation to reference the new migration number
- mark the renamed seed migration as replacing the historical 0011 name so Django treats the graph as linear

## Testing
- python manage.py makemigrations --check *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68d1cccf7ab88333b1bc876d42e01a52