### PR TITLE
Refine score panel responsiveness for mobile

### DIFF
--- a/assets/css/components/score-panel.css
+++ b/assets/css/components/score-panel.css
@@ -231,6 +231,18 @@
   transition: background-color var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast), box-shadow var(--transition-fast);
 }
 
+.score-panel__action-button-icon {
+  font-size: 1.1rem;
+  margin-right: 8px;
+  line-height: 1;
+}
+
+.score-panel__action-button-label {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1;
+}
+
 .score-panel__action-button:hover,
 .score-panel__action-button:focus-visible {
   background-color: var(--color-primary-dark);
@@ -278,26 +290,25 @@
         min-width: 0;
         height: auto;
         max-height: none;
-        padding: 14px 18px;
-        border-radius: 20px;
+        padding: 12px 18px;
+        border-radius: 18px;
         background-color: rgba(var(--color-white-rgb, 255, 255, 255), 0.92);
-        backdrop-filter: blur(18px);
-        -webkit-backdrop-filter: blur(18px);
+        backdrop-filter: blur(16px);
+        -webkit-backdrop-filter: blur(16px);
         border: 1px solid rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.08);
-        box-shadow: 0 24px 45px -28px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.65);
-        display: grid;
-        grid-template-columns: auto minmax(0, 1fr) auto auto;
-        grid-template-areas: "timer stats pause action";
+        box-shadow: 0 20px 40px -28px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.55);
+        display: flex;
         align-items: center;
         gap: var(--spacing-sm, 12px);
-        overflow: visible;
+        overflow: hidden;
         z-index: var(--z-index-sticky, 10);
     }
 
     .score-panel__timer {
-        grid-area: timer;
-        flex-direction: row;
-        align-items: baseline;
+        order: 1;
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
         gap: var(--spacing-xxs, 6px);
         padding-bottom: 0;
         border-bottom: none;
@@ -306,27 +317,28 @@
     }
 
     .score-panel__timer-value {
-        font-size: 1.32rem;
+        font-size: 1.22rem;
         margin-bottom: 0;
     }
 
     .score-panel__timer-label {
-        font-size: 0.68rem;
+        font-size: 0.7rem;
         letter-spacing: 0.08em;
         font-weight: var(--font-weight-medium);
         color: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.7);
     }
 
     .score-panel__stats-group {
-        grid-area: stats;
+        order: 2;
+        flex: 1 1 auto;
         display: flex;
-        align-items: stretch;
+        align-items: center;
         gap: var(--spacing-xs, 10px);
         overflow-x: auto;
-        padding: 4px 2px;
+        padding: 4px 0;
         margin: 0;
         scrollbar-width: none;
-        scroll-snap-type: x mandatory;
+        scroll-snap-type: x proximity;
     }
 
     .score-panel__stats-group::-webkit-scrollbar {
@@ -334,129 +346,48 @@
     }
 
     .score-panel__stat {
+        flex: 0 0 auto;
         display: inline-flex;
         align-items: center;
-        justify-content: center;
-        flex: 0 0 auto;
-        min-width: 110px;
-        padding: 8px 12px;
-        border-radius: 14px;
-        background: linear-gradient(
-            135deg,
-            rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.16),
-            rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.08)
-        );
-        box-shadow: inset 0 1px 0 rgba(var(--color-white-rgb, 255, 255, 255), 0.3);
         gap: var(--spacing-xxs, 4px);
-        scroll-snap-align: start;
+        min-width: 92px;
+        padding: 7px 10px;
+        border-radius: 12px;
+        background-color: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.08);
+        box-shadow: inset 0 1px 0 rgba(var(--color-white-rgb, 255, 255, 255), 0.35);
+        scroll-snap-align: center;
     }
 
     .score-panel__stat-icon {
-        font-size: 1.05rem;
+        font-size: 1rem;
         width: 18px;
         height: 18px;
     }
 
     .score-panel__stat-content {
-        align-items: center;
-        text-align: center;
+        display: inline-flex;
+        flex-direction: row;
+        align-items: baseline;
+        gap: 4px;
         line-height: 1.1;
     }
 
-    .score-panel__stat-label {
+    .score-panel__stat-label,
+    .score-panel__stat-extra {
         display: none;
     }
 
     .score-panel__stat-value {
-        font-size: 0.98rem;
+        font-size: 0.96rem;
         font-weight: var(--font-weight-semibold);
         color: var(--color-primary-dark);
     }
 
-    .score-panel__stat-extra {
-        font-size: 0.72rem;
-        color: var(--color-text-secondary);
-    }
-
     .score-panel__pause-control {
-        grid-area: pause;
-        justify-content: flex-end;
-    }
-
-    .score-panel__pause-button {
-        width: 34px;
-        height: 34px;
-    }
-
-    .score-panel__pause-button .material-symbols-outlined {
-        font-size: 1.15rem;
-    }
-
-    .score-panel__action-button {
-        grid-area: action;
-        width: auto;
-        margin: 0;
-        padding: 8px 14px;
-        border-radius: 999px;
-        font-size: 0.78rem;
-        line-height: 1;
-        white-space: nowrap;
-        box-shadow: none;
-        background-color: transparent;
-    }
-
-    .score-panel__action-button:hover,
-    .score-panel__action-button:focus-visible {
-        transform: translateY(-1px);
-        box-shadow: 0 18px 30px -18px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.4);
-    }
-}
-
-@media (max-width: 600px) {
-    .score-panel {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        justify-content: space-between;
-        gap: var(--spacing-xxs, 8px);
-        padding: 12px 14px;
-        border-radius: 18px;
-        box-shadow: 0 18px 38px -24px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.6);
-    }
-
-    .score-panel__timer {
-        order: 1;
-        flex: 1 1 auto;
-        display: flex;
-        align-items: center;
-        gap: var(--spacing-xxs, 6px);
-        margin-right: auto;
-    }
-
-    .score-panel__timer-value {
-        font-size: 1.18rem;
-    }
-
-    .score-panel__stats-group {
-        order: 4;
-        flex: 1 1 100%;
-        padding: 2px 0;
-        gap: var(--spacing-xxs, 6px);
-    }
-
-    .score-panel__stat {
-        min-width: 96px;
-        padding: 6px 10px;
-        border-radius: 12px;
-    }
-
-    .score-panel__stat-value {
-        font-size: 0.92rem;
-    }
-
-    .score-panel__pause-control {
-        order: 2;
+        order: 3;
         flex: 0 0 auto;
+        display: flex;
+        justify-content: center;
         margin-left: auto;
     }
 
@@ -466,44 +397,53 @@
     }
 
     .score-panel__pause-button .material-symbols-outlined {
-        font-size: 1.05rem;
+        font-size: 1.1rem;
     }
 
     .score-panel__action-button {
-        order: 3;
+        order: 4;
         flex: 0 0 auto;
-        font-size: 0.74rem;
-        padding: 6px 12px;
+        width: auto;
+        margin: 0;
+        padding: 7px 14px;
+        border-radius: 999px;
+        font-size: 0.76rem;
+        line-height: 1;
+        white-space: nowrap;
+        box-shadow: none;
+        background-color: transparent;
+    }
+
+    .score-panel__action-button-icon {
+        margin-right: 6px;
+        font-size: 1rem;
+    }
+
+    .score-panel__action-button:hover,
+    .score-panel__action-button:focus-visible {
+        transform: translateY(-1px);
+        box-shadow: 0 16px 28px -20px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.38);
     }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 600px) {
     .score-panel {
-        padding: 10px 12px;
-        gap: var(--spacing-xxs, 6px);
-    }
-
-    .score-panel__timer {
-        width: 100%;
-        justify-content: space-between;
-        gap: var(--spacing-xxs, 4px);
+        padding: 10px 14px;
+        gap: var(--spacing-xxs, 8px);
+        border-radius: 16px;
     }
 
     .score-panel__timer-value {
-        font-size: 1.06rem;
-    }
-
-    .score-panel__timer-label {
-        display: none;
+        font-size: 1.12rem;
     }
 
     .score-panel__stats-group {
-        gap: var(--spacing-xxs, 4px);
+        gap: var(--spacing-xxs, 6px);
     }
 
     .score-panel__stat {
         min-width: 82px;
-        padding: 5px 9px;
+        padding: 6px 8px;
     }
 
     .score-panel__stat-icon {
@@ -511,7 +451,7 @@
     }
 
     .score-panel__stat-value {
-        font-size: 0.86rem;
+        font-size: 0.9rem;
     }
 
     .score-panel__pause-button {
@@ -519,29 +459,86 @@
         height: 30px;
     }
 
+    .score-panel__pause-button .material-symbols-outlined {
+        font-size: 1.05rem;
+    }
+
     .score-panel__action-button {
-        font-size: 0.7rem;
-        padding: 5px 10px;
+        padding: 6px 12px;
+        font-size: 0.72rem;
     }
 }
 
-@media (max-width: 380px) {
+@media (max-width: 480px) {
+    .score-panel {
+        padding: 9px 12px;
+        gap: var(--spacing-xxs, 6px);
+    }
+
+    .score-panel__timer-label {
+        display: none;
+    }
+
     .score-panel__timer-value {
         font-size: 1.02rem;
     }
 
     .score-panel__stats-group {
-        gap: var(--spacing-xxs, 3px);
+        gap: var(--spacing-xxs, 4px);
     }
 
     .score-panel__stat {
         min-width: 72px;
-        padding: 4px 8px;
+        padding: 5px 7px;
+    }
+
+    .score-panel__stat-icon {
+        font-size: 0.9rem;
+    }
+
+    .score-panel__stat-value {
+        font-size: 0.84rem;
+    }
+
+    .score-panel__pause-button {
+        width: 28px;
+        height: 28px;
+    }
+
+    .score-panel__pause-button .material-symbols-outlined {
+        font-size: 1rem;
     }
 
     .score-panel__action-button {
-        order: 5;
-        flex: 1 1 100%;
-        justify-content: center;
+        padding: 5px 10px;
+        font-size: 0.7rem;
+    }
+
+    .score-panel__action-button-icon {
+        margin-right: 0;
+        font-size: 0.95rem;
+    }
+
+    .score-panel__action-button-label {
+        display: none;
+    }
+}
+
+@media (max-width: 380px) {
+    .score-panel {
+        padding: 8px 10px;
+    }
+
+    .score-panel__stat {
+        min-width: 64px;
+    }
+
+    .score-panel__action-button {
+        padding: 4px 8px;
+        border-radius: 999px;
+    }
+
+    .score-panel__action-button-icon {
+        font-size: 0.88rem;
     }
 }

--- a/quiz/templates/quiz/questions_page.html
+++ b/quiz/templates/quiz/questions_page.html
@@ -51,7 +51,13 @@
                     </div>
                 </div>
             </div>
-            <button id="btn-encerrar-sessao" class="button button--outline button--small score-panel__action-button u-is-hidden">Encerrar</button>
+            <button id="btn-encerrar-sessao"
+                    class="button button--outline button--small score-panel__action-button u-is-hidden"
+                    aria-label="Encerrar sessão"
+                    title="Encerrar sessão">
+                <span class="material-symbols-outlined score-panel__action-button-icon" aria-hidden="true">logout</span>
+                <span class="score-panel__action-button-label">Encerrar</span>
+            </button>
         </aside>
 
         <div class="question-section__main-content">


### PR DESCRIPTION
## Summary
- compacted the score panel layout on mobile with a flex-based row and subtle glassmorphism styling
- reduced label noise, tightened timer/stat sizing, and enabled horizontal scrolling chips for stats in small spaces
- added an icon + accessible label to the end session button so it stays usable when the text label is hidden on narrow screens

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d3eb35b20483339c5f6b5de1589567