### PR TITLE
Refine score panel mobile experience

### DIFF
--- a/assets/css/components/score-panel.css
+++ b/assets/css/components/score-panel.css
@@ -59,18 +59,24 @@
 .score-panel__timer-value {
   font-family: var(--font-family-sans);
   font-size: var(--timer-font-size, 2.5rem);
-  font-weight: var(--font-weight-semibold); 
-  color: var(--timer-color, var(--color-primary-dark)); 
+  font-weight: var(--font-weight-semibold);
+  color: var(--timer-color, var(--color-primary-dark));
   line-height: 1.1;
   margin-bottom: var(--spacing-xxs, 4px);
+  font-variant-numeric: tabular-nums;
 }
 
 .score-panel__timer-label {
-  font-size: var(--timer-label-font-size, 0.75rem); 
-  font-weight: var(--font-weight-medium); 
+  font-size: var(--timer-label-font-size, 0.75rem);
+  font-weight: var(--font-weight-medium);
   color: var(--timer-label-color, var(--color-text-secondary)); 
   letter-spacing: 0.5px;
   text-transform: uppercase;
+}
+
+.score-panel__timer-icon {
+  display: none;
+  line-height: 1;
 }
 
 /* Element: .score-panel__stats-group */
@@ -133,6 +139,7 @@
   font-weight: var(--font-weight-bold);
   color: var(--stat-value-color, var(--color-primary-dark));
   line-height: 1;
+  font-variant-numeric: tabular-nums;
 }
 
 .score-panel__stat-extra {
@@ -285,60 +292,103 @@
 @media (max-width: 768px) {
     .score-panel {
         position: sticky;
-        top: var(--score-panel-sticky-top, 0);
+        top: var(--score-panel-sticky-top, clamp(0px, 2vw, 12px));
         width: 100%;
         min-width: 0;
         height: auto;
         max-height: none;
-        padding: 12px 18px;
-        border-radius: 18px;
-        background-color: rgba(var(--color-white-rgb, 255, 255, 255), 0.92);
-        backdrop-filter: blur(16px);
-        -webkit-backdrop-filter: blur(16px);
-        border: 1px solid rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.08);
-        box-shadow: 0 20px 40px -28px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.55);
-        display: flex;
+        margin-inline: auto;
+        padding: clamp(12px, 3vw, 18px) clamp(14px, 4vw, 22px);
+        border-radius: 20px;
+        background: linear-gradient(135deg,
+            rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.12),
+            rgba(var(--color-white-rgb, 255, 255, 255), 0.9)
+        );
+        backdrop-filter: blur(18px);
+        -webkit-backdrop-filter: blur(18px);
+        border: 1px solid rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.12);
+        box-shadow: 0 26px 50px -35px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.65);
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
         align-items: center;
-        gap: var(--spacing-sm, 12px);
+        gap: clamp(12px, 3vw, 20px);
         overflow: hidden;
         z-index: var(--z-index-sticky, 10);
     }
 
     .score-panel__timer {
-        order: 1;
-        flex: 0 0 auto;
-        display: flex;
+        display: inline-flex;
         align-items: center;
-        gap: var(--spacing-xxs, 6px);
-        padding-bottom: 0;
-        border-bottom: none;
+        gap: clamp(8px, 2.5vw, 14px);
+        padding: 6px clamp(12px, 3vw, 18px);
+        background: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.12);
+        border-radius: 999px;
+        border: 1px solid rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.1);
         margin-bottom: 0;
+        border-bottom: none;
         text-align: left;
+        justify-self: flex-start;
+        box-shadow: 0 18px 32px -28px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.45);
+    }
+
+    .score-panel__timer-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: clamp(30px, 9vw, 36px);
+        height: clamp(30px, 9vw, 36px);
+        border-radius: 999px;
+        background: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.16);
+        color: var(--color-primary-dark);
+        font-size: 1.2rem;
     }
 
     .score-panel__timer-value {
-        font-size: 1.22rem;
+        font-size: clamp(1.05rem, 3.4vw, 1.28rem);
         margin-bottom: 0;
+        letter-spacing: 0.04em;
     }
 
     .score-panel__timer-label {
-        font-size: 0.7rem;
-        letter-spacing: 0.08em;
-        font-weight: var(--font-weight-medium);
-        color: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.7);
+        display: none;
+    }
+
+    .score-panel__pause-control {
+        width: auto;
+        margin: 0 0 0 clamp(8px, 2vw, 12px);
+        display: inline-flex;
+        align-items: center;
+    }
+
+    .score-panel__pause-button {
+        width: clamp(36px, 10vw, 42px);
+        height: clamp(36px, 10vw, 42px);
+        border-radius: 14px;
+        background: var(--color-white);
+        color: var(--color-primary-dark);
+        border: 1px solid rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.14);
+        box-shadow: 0 18px 24px -24px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.7);
+    }
+
+    .score-panel__pause-button .material-symbols-outlined {
+        font-size: 1.15rem;
     }
 
     .score-panel__stats-group {
-        order: 2;
-        flex: 1 1 auto;
-        display: flex;
+        display: grid;
+        grid-auto-flow: column;
+        grid-auto-columns: minmax(62px, 1fr);
+        gap: clamp(10px, 3vw, 18px);
         align-items: center;
-        gap: var(--spacing-xs, 10px);
-        overflow-x: auto;
-        padding: 4px 0;
+        justify-items: center;
+        justify-self: stretch;
+        padding: 0 clamp(4px, 1vw, 8px);
         margin: 0;
+        overflow-x: auto;
         scrollbar-width: none;
         scroll-snap-type: x proximity;
+        -webkit-overflow-scrolling: touch;
+        touch-action: pan-x;
     }
 
     .score-panel__stats-group::-webkit-scrollbar {
@@ -346,30 +396,51 @@
     }
 
     .score-panel__stat {
-        flex: 0 0 auto;
-        display: inline-flex;
+        min-width: 0;
+        padding: 0;
+        border-radius: 0;
+        background: transparent;
+        box-shadow: none;
+        display: flex;
+        flex-direction: column;
         align-items: center;
-        gap: var(--spacing-xxs, 4px);
-        min-width: 92px;
-        padding: 7px 10px;
-        border-radius: 12px;
-        background-color: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.08);
-        box-shadow: inset 0 1px 0 rgba(var(--color-white-rgb, 255, 255, 255), 0.35);
+        gap: clamp(4px, 1.8vw, 8px);
         scroll-snap-align: center;
     }
 
     .score-panel__stat-icon {
-        font-size: 1rem;
-        width: 18px;
-        height: 18px;
+        width: clamp(34px, 9vw, 40px);
+        height: clamp(34px, 9vw, 40px);
+        border-radius: 14px;
+        font-size: 1.18rem;
+        background: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.1);
+    }
+
+    .score-panel__stat--points .score-panel__stat-icon {
+        background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
+        box-shadow: 0 12px 22px -18px rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.55);
+    }
+
+    .score-panel__stat--correct .score-panel__stat-icon {
+        background: rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.16);
+        box-shadow: 0 12px 22px -18px rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.55);
+    }
+
+    .score-panel__stat--incorrect .score-panel__stat-icon {
+        background: rgba(var(--color-accent-red-rgb, 230, 57, 70), 0.16);
+        box-shadow: 0 12px 22px -18px rgba(var(--color-accent-red-rgb, 230, 57, 70), 0.55);
+    }
+
+    .score-panel__stat--streak .score-panel__stat-icon {
+        background: rgba(var(--color-accent-yellow-rgb, 255, 215, 0), 0.2);
+        box-shadow: 0 12px 22px -18px rgba(var(--color-accent-yellow-rgb, 255, 215, 0), 0.4);
     }
 
     .score-panel__stat-content {
-        display: inline-flex;
-        flex-direction: row;
-        align-items: baseline;
-        gap: 4px;
-        line-height: 1.1;
+        flex-direction: column;
+        align-items: center;
+        gap: 2px;
+        line-height: 1.05;
     }
 
     .score-panel__stat-label,
@@ -378,80 +449,188 @@
     }
 
     .score-panel__stat-value {
-        font-size: 0.96rem;
+        font-size: clamp(0.82rem, 2.8vw, 0.98rem);
         font-weight: var(--font-weight-semibold);
-        color: var(--color-primary-dark);
+        letter-spacing: 0.04em;
     }
 
-    .score-panel__pause-control {
-        order: 3;
-        flex: 0 0 auto;
-        display: flex;
+    .score-panel__action-button {
+        width: clamp(44px, 12vw, 50px);
+        height: clamp(44px, 12vw, 50px);
+        margin: 0;
+        padding: 0;
+        border-radius: 16px;
+        background: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.14);
+        border: 1px solid rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.16);
+        color: var(--color-primary-dark);
+        display: inline-flex;
+        align-items: center;
         justify-content: center;
-        margin-left: auto;
+        box-shadow: none;
+        justify-self: flex-end;
+    }
+
+    .score-panel__action-button-icon {
+        margin-right: 0;
+        font-size: 1.22rem;
+    }
+
+    .score-panel__action-button-label {
+        display: none;
+    }
+
+    .score-panel__action-button:hover,
+    .score-panel__action-button:focus-visible {
+        transform: translateY(-1px);
+        box-shadow: 0 20px 34px -26px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.4);
+        background: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.2);
+    }
+
+    .score-panel__action-button:active {
+        transform: scale(0.96);
+        background: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.28);
+        color: var(--color-primary-dark);
+        border-color: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.28);
+        box-shadow: none;
+    }
+}
+
+@media (max-width: 600px) {
+    .score-panel {
+        padding: clamp(10px, 3vw, 14px) clamp(12px, 5vw, 18px);
+        gap: clamp(10px, 3vw, 16px);
+        border-radius: 18px;
+    }
+
+    .score-panel__timer {
+        padding: 6px clamp(10px, 4vw, 14px);
+        gap: clamp(6px, 3vw, 12px);
+    }
+
+    .score-panel__timer-icon {
+        width: clamp(28px, 10vw, 32px);
+        height: clamp(28px, 10vw, 32px);
+        font-size: 1.1rem;
+    }
+
+    .score-panel__timer-value {
+        font-size: clamp(1rem, 3.8vw, 1.18rem);
     }
 
     .score-panel__pause-button {
-        width: 32px;
-        height: 32px;
+        width: clamp(34px, 11vw, 40px);
+        height: clamp(34px, 11vw, 40px);
     }
 
     .score-panel__pause-button .material-symbols-outlined {
         font-size: 1.1rem;
     }
 
-    .score-panel__action-button {
-        order: 4;
-        flex: 0 0 auto;
-        width: auto;
-        margin: 0;
-        padding: 7px 14px;
-        border-radius: 999px;
-        font-size: 0.76rem;
-        line-height: 1;
-        white-space: nowrap;
-        box-shadow: none;
-        background-color: transparent;
-    }
-
-    .score-panel__action-button-icon {
-        margin-right: 6px;
-        font-size: 1rem;
-    }
-
-    .score-panel__action-button:hover,
-    .score-panel__action-button:focus-visible {
-        transform: translateY(-1px);
-        box-shadow: 0 16px 28px -20px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.38);
-    }
-}
-
-@media (max-width: 600px) {
-    .score-panel {
-        padding: 10px 14px;
-        gap: var(--spacing-xxs, 8px);
-        border-radius: 16px;
-    }
-
-    .score-panel__timer-value {
-        font-size: 1.12rem;
-    }
-
     .score-panel__stats-group {
-        gap: var(--spacing-xxs, 6px);
+        gap: clamp(8px, 3vw, 14px);
+        grid-auto-columns: minmax(58px, 1fr);
+        padding: 0 clamp(2px, 1.6vw, 6px);
     }
 
     .score-panel__stat {
-        min-width: 82px;
-        padding: 6px 8px;
+        gap: clamp(3px, 2.4vw, 6px);
     }
 
     .score-panel__stat-icon {
-        font-size: 0.95rem;
+        width: clamp(30px, 11vw, 34px);
+        height: clamp(30px, 11vw, 34px);
+        font-size: 1.08rem;
     }
 
     .score-panel__stat-value {
-        font-size: 0.9rem;
+        font-size: clamp(0.78rem, 3.2vw, 0.92rem);
+    }
+
+    .score-panel__action-button {
+        width: clamp(40px, 14vw, 46px);
+        height: clamp(40px, 14vw, 46px);
+    }
+
+    .score-panel__action-button-icon {
+        font-size: 1.16rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .score-panel {
+        padding: 10px clamp(10px, 5vw, 16px);
+        gap: clamp(8px, 3vw, 12px);
+        border-radius: 16px;
+    }
+
+    .score-panel__timer {
+        padding: 5px clamp(8px, 4vw, 12px);
+    }
+
+    .score-panel__timer-value {
+        font-size: clamp(0.96rem, 4vw, 1.1rem);
+    }
+
+    .score-panel__stats-group {
+        gap: clamp(6px, 3vw, 10px);
+        grid-auto-columns: minmax(52px, 1fr);
+    }
+
+    .score-panel__stat-icon {
+        width: clamp(28px, 12vw, 32px);
+        height: clamp(28px, 12vw, 32px);
+        font-size: 1.02rem;
+    }
+
+    .score-panel__stat-value {
+        font-size: clamp(0.74rem, 3.6vw, 0.88rem);
+    }
+
+    .score-panel__pause-button {
+        width: clamp(32px, 12vw, 38px);
+        height: clamp(32px, 12vw, 38px);
+    }
+
+    .score-panel__action-button {
+        width: clamp(38px, 14vw, 44px);
+        height: clamp(38px, 14vw, 44px);
+    }
+
+    .score-panel__action-button-icon {
+        font-size: 1.08rem;
+    }
+}
+
+@media (max-width: 380px) {
+    .score-panel {
+        padding: 9px clamp(8px, 5vw, 12px);
+        gap: clamp(6px, 4vw, 10px);
+        border-radius: 15px;
+    }
+
+    .score-panel__timer {
+        padding: 4px clamp(6px, 5vw, 10px);
+        gap: clamp(5px, 4vw, 8px);
+    }
+
+    .score-panel__timer-icon {
+        width: 26px;
+        height: 26px;
+        font-size: 1rem;
+    }
+
+    .score-panel__stats-group {
+        grid-auto-columns: minmax(48px, 1fr);
+    }
+
+    .score-panel__stat-icon {
+        width: 26px;
+        height: 26px;
+        font-size: 0.98rem;
+    }
+
+    .score-panel__stat-value {
+        font-size: 0.78rem;
     }
 
     .score-panel__pause-button {
@@ -459,86 +638,9 @@
         height: 30px;
     }
 
-    .score-panel__pause-button .material-symbols-outlined {
-        font-size: 1.05rem;
-    }
-
     .score-panel__action-button {
-        padding: 6px 12px;
-        font-size: 0.72rem;
-    }
-}
-
-@media (max-width: 480px) {
-    .score-panel {
-        padding: 9px 12px;
-        gap: var(--spacing-xxs, 6px);
-    }
-
-    .score-panel__timer-label {
-        display: none;
-    }
-
-    .score-panel__timer-value {
-        font-size: 1.02rem;
-    }
-
-    .score-panel__stats-group {
-        gap: var(--spacing-xxs, 4px);
-    }
-
-    .score-panel__stat {
-        min-width: 72px;
-        padding: 5px 7px;
-    }
-
-    .score-panel__stat-icon {
-        font-size: 0.9rem;
-    }
-
-    .score-panel__stat-value {
-        font-size: 0.84rem;
-    }
-
-    .score-panel__pause-button {
-        width: 28px;
-        height: 28px;
-    }
-
-    .score-panel__pause-button .material-symbols-outlined {
-        font-size: 1rem;
-    }
-
-    .score-panel__action-button {
-        padding: 5px 10px;
-        font-size: 0.7rem;
-    }
-
-    .score-panel__action-button-icon {
-        margin-right: 0;
-        font-size: 0.95rem;
-    }
-
-    .score-panel__action-button-label {
-        display: none;
-    }
-}
-
-@media (max-width: 380px) {
-    .score-panel {
-        padding: 8px 10px;
-    }
-
-    .score-panel__stat {
-        min-width: 64px;
-    }
-
-    .score-panel__action-button {
-        padding: 4px 8px;
-        border-radius: 999px;
-    }
-
-    .score-panel__action-button-icon {
-        font-size: 0.88rem;
+        width: 34px;
+        height: 34px;
+        border-radius: 14px;
     }
 }

--- a/quiz/templates/quiz/questions_page.html
+++ b/quiz/templates/quiz/questions_page.html
@@ -6,7 +6,8 @@
 {% block content %}
     <section id="question-section" class="main-section">
         <aside class="score-panel u-is-hidden">
-            <div class="score-panel__timer">
+            <div class="score-panel__timer" aria-live="polite" role="status">
+                <span class="material-symbols-outlined score-panel__timer-icon" aria-hidden="true">schedule</span>
                 <span id="timer-display" class="score-panel__timer-value">00:00</span>
                 <span class="score-panel__timer-label">TEMPO DECORRIDO</span>
                 <div id="score-panel-controls" class="score-panel__pause-control">


### PR DESCRIPTION
## Summary
- redesenhei o painel de score em telas menores para virar uma cápsula compacta com estatísticas em formato de chips e ações reduzidas
- adicionei ícone e aria-live no timer para manter o componente acessível enquanto o texto é removido em mobile

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d3ed967bcc8333a1bc5aa3920ead81