### PR TITLE
Stop filter apply button flashing during count fetch

### DIFF
--- a/assets/js/ui/FilterPanel.js
+++ b/assets/js/ui/FilterPanel.js
@@ -413,14 +413,25 @@ export default class FilterPanel {
         
         feedbackTextEl.className = 'form-text-feedback form-text-feedback--filter-panel';
         const enableAplicarFiltros = (enable) => { aplicarFiltrosBtn.disabled = !enable; };
+        const setAplicarFiltrosBusyState = (isBusy) => {
+            if (isBusy) {
+                aplicarFiltrosBtn.setAttribute('aria-busy', 'true');
+                aplicarFiltrosBtn.classList.add('is-loading');
+            } else {
+                aplicarFiltrosBtn.removeAttribute('aria-busy');
+                aplicarFiltrosBtn.classList.remove('is-loading');
+            }
+        };
 
         if (isLoadingCount) {
             feedbackTextEl.textContent = "Verificando...";
             feedbackTextEl.classList.add('is-loading');
-            enableAplicarFiltros(false);
+            setAplicarFiltrosBusyState(true);
             return;
         }
-        
+
+        setAplicarFiltrosBusyState(false);
+
         if (countError) {
             input.removeAttribute('max');
             feedbackTextEl.textContent = countError;


### PR DESCRIPTION
## Summary
- add a busy-state helper for the filter panel apply button instead of toggling disabled during count fetches
- keep the button enabled while counts are loading to avoid the visible blinking effect and expose aria-busy feedback

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d40941ae488333b42b6e44c3998526