### PR TITLE
Prevent mobile account content flash

### DIFF
--- a/assets/css/sections/conta-section.css
+++ b/assets/css/sections/conta-section.css
@@ -5095,6 +5095,14 @@
         border-radius: 0; border: none; box-shadow: none;
     }
 
+    .account-content:not(.is-mobile-content-visible) {
+        display: none;
+    }
+
+    .account-content.is-mobile-content-visible {
+        display: block;
+    }
+
     .account-content .card__title { font-size: 1.3rem; margin-bottom: var(--spacing-md, 20px); }
     .profile-info-table { display: block; overflow-x: auto; margin-bottom: var(--spacing-md, 20px); }
     .profile-info-table th, .profile-info-table td { font-size: 0.875rem; white-space: nowrap; }

--- a/assets/js/ui/AccountPageManager.js
+++ b/assets/js/ui/AccountPageManager.js
@@ -61,6 +61,7 @@ export default class AccountPageManager {
             },
         };
         this.bodyElement = document.body;
+        this.mobileContentVisibleClass = 'is-mobile-content-visible';
         // --- INÍCIO DA CORREÇÃO ---
         // A referência ao bottomNavElement foi removida daqui.
         // --- FIM DA CORREÇÃO ---
@@ -1166,6 +1167,14 @@ export default class AccountPageManager {
 
     _updateUIVisibility(isContentActive) {
         const isMobile = this._isMobileView();
+        const contentArea = this.elements.contentArea;
+
+        if (isMobile && contentArea) {
+            contentArea.classList.toggle(this.mobileContentVisibleClass, Boolean(isContentActive));
+        } else {
+            contentArea?.classList.remove(this.mobileContentVisibleClass);
+        }
+
         if (isMobile) {
             this.quizUI.showElement(isContentActive ? this.elements.backToMenuButton : this.elements.sidebar);
             this.quizUI.hideElement(isContentActive ? this.elements.sidebar : this.elements.backToMenuButton);


### PR DESCRIPTION
## Summary
- add a dedicated CSS hook that keeps the account content hidden on mobile viewports until the tab content is intentionally displayed
- toggle the new helper class from AccountPageManager so the correct section is shown without flashing the profile information on load

## Testing
- python manage.py test *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68d413dd5c988333af07a658e309b629