### PR TITLE
Fix gamification conditional in account page template

### DIFF
--- a/quiz/templates/quiz/account_page.html
+++ b/quiz/templates/quiz/account_page.html
@@ -471,7 +471,8 @@
                             </div>
                             {% endif %}
 
-                            {% if gamification and (gamification.achievements or gamification.rewards) %}
+                            {% if gamification %}
+                                {% if gamification.achievements or gamification.rewards %}
                             <div class="account-progress__insights-grid">
                                 {% if gamification.achievements %}
                                 <section class="account-progress__insight-card">
@@ -547,6 +548,7 @@
                                 </section>
                                 {% endif %}
                             </div>
+                                {% endif %}
                             {% endif %}
 
                             {% if gamification and gamification.daily_engagement %}


### PR DESCRIPTION
## Summary
- split the gamification insights conditional to avoid unsupported parentheses in Django templates

## Testing
- python manage.py check *(fails: Missing dependency: django)*

------
https://chatgpt.com/codex/tasks/task_e_68d486093a8083338c98f61c51a4129c