### PR TITLE
Revamp Challenge Hub landing experience

### DIFF
--- a/assets/css/components/hero-block.css
+++ b/assets/css/components/hero-block.css
@@ -1,142 +1,411 @@
 /* assets/css/components/hero-block.css */
 
 /*
-==========================================================================
-  Component: Hero Block (.hero-block)
-==========================================================================
+===============================================================================
+  Component: Hub Hero (Challenge Hub landing area)
+===============================================================================
 */
 
-/* Block: .hero-block */
-.hero-block {
+.hub-hero {
+    position: relative;
     width: 100%;
-    padding: var(--hero-padding-y-top, clamp(50px, 9vh, 70px))
-             var(--hero-padding-x, clamp(20px, 3vw, 40px))
-             var(--hero-padding-y-bottom, clamp(40px, 8vh, 60px));
-    background: var(--hero-bg-gradient, linear-gradient(135deg, var(--color-primary-dark) 0%, var(--color-primary-medium) 60%, var(--color-secondary-green) 100%));
-    color: var(--hero-text-color, var(--color-white)); /* Cor padrão do texto dentro do hero */
-    text-align: center;
+    margin: clamp(20px, 4vw, 40px) auto;
+    padding: clamp(32px, 5vw, 56px);
+    border-radius: var(--border-radius-xxl, 32px);
+    background: radial-gradient(circle at 10% -10%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 55%),
+                radial-gradient(circle at 85% 10%, rgba(35, 209, 160, 0.15) 0%, rgba(35, 209, 160, 0) 55%),
+                linear-gradient(140deg, rgba(var(--color-primary-dark-rgb), 0.98) 0%, rgba(15, 52, 96, 0.93) 60%, rgba(var(--color-secondary-green-rgb), 0.85) 100%);
+    color: var(--color-white);
+    overflow: hidden;
+    box-shadow: 0 25px 60px rgba(9, 17, 36, 0.35);
+}
+
+.hub-hero__content {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+    gap: clamp(28px, 5vw, 56px);
+    align-items: stretch;
+}
+
+.hub-hero__orb {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(0px);
+    opacity: 0.65;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.hub-hero__orb--primary {
+    width: clamp(220px, 32vw, 420px);
+    height: clamp(220px, 32vw, 420px);
+    top: -18%;
+    left: -8%;
+    background: radial-gradient(circle, rgba(var(--color-secondary-green-rgb), 0.55) 0%, rgba(21, 208, 160, 0) 70%);
+}
+
+.hub-hero__orb--secondary {
+    width: clamp(200px, 30vw, 360px);
+    height: clamp(200px, 30vw, 360px);
+    bottom: -22%;
+    right: -10%;
+    background: radial-gradient(circle, rgba(72, 118, 255, 0.45) 0%, rgba(72, 118, 255, 0) 70%);
+}
+
+.hub-hero__main {
     display: flex;
     flex-direction: column;
+    gap: clamp(18px, 3.5vh, 28px);
+}
+
+.hub-hero__eyebrow {
+    display: inline-flex;
     align-items: center;
-    gap: var(--hero-internal-gap, clamp(30px, 5vh, 40px));
-    box-shadow: var(--hero-shadow, 0 6px 20px rgba(0,0,0,0.1));
-  }
-  
-  /* Element: .hero-block__welcome */
-  .hero-block__welcome {
-    max-width: var(--hero-welcome-max-width, 700px);
-    margin-bottom: 0;
-  }
-  
-  /* Element: .hero-block__title */
-  .hero-block__title {
+    gap: 8px;
+    padding: 6px 14px;
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 999px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.4em;
+}
+
+.hub-hero__title {
     font-family: var(--font-family-heading);
-    font-size: var(--hero-title-size, clamp(1.9rem, 5vw, 2.8rem));
     font-weight: var(--font-weight-bold);
-    margin: 0 0 var(--spacing-sm, 10px) 0;
-    text-shadow: 0 2px 4px rgba(0,0,0,0.25);
-    line-height: var(--line-height-tight, 1.2);
-    color: var(--hero-text-color, var(--color-white)); /* << GARANTE a cor branca */
-  }
-  
-  /* Element: .hero-block__subtitle */
-  .hero-block__subtitle {
-    font-size: var(--hero-subtitle-size, clamp(0.95rem, 2.2vw, 1.15rem));
-    opacity: 0.9;
-    font-weight: var(--font-weight-light);
-    line-height: var(--line-height-base, 1.6);
+    font-size: clamp(2rem, 4.6vw, 2.9rem);
+    line-height: 1.15;
     margin: 0;
-  }
-  
-  /* O .stats-deck é estilizado em stats-deck.css */
-  
-  /* Element: .hero-block__cta */
-  .hero-block__cta {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
-  
-  /* Element: .hero-block__cta-text */
-  .hero-block__cta-text {
-    font-size: var(--hero-cta-text-size, clamp(1rem, 2.5vw, 1.1rem));
-    margin: 0 0 var(--spacing-md, 20px) 0;
-    font-weight: var(--font-weight-normal);
-    opacity: 0.95;
-  }
-  
-  /* Element: .hero-block__cta-actions */
-  .hero-block__cta-actions {
+}
+
+.hub-hero__subtitle {
+    margin: 0;
+    font-size: clamp(1.05rem, 2.6vw, 1.25rem);
+    line-height: 1.7;
+    max-width: 720px;
+    color: rgba(255, 255, 255, 0.92);
+}
+
+.hub-hero__chips {
     display: flex;
     flex-wrap: wrap;
-    justify-content: center; /* Isto manterá o botão centralizado */
-    gap: var(--hero-cta-actions-gap, var(--spacing-md, 15px));
+    gap: 10px 14px;
+}
+
+.hub-hero__chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.13);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+}
+
+.hub-hero__chip-icon {
+    font-size: 1.1rem;
+}
+
+.hub-hero__stats {
+    display: flex;
+    flex-direction: column;
+}
+
+.hub-hero__stats .stats-deck {
+    --stats-deck-columns: 2;
+    --stats-deck-gap: clamp(16px, 3.5vw, 24px);
+    --stats-deck-max-width: 100%;
+    --stat-card-bg: rgba(8, 19, 35, 0.35);
+    --stat-card-border-color: rgba(255, 255, 255, 0.2);
+    --stat-card-shadow: 0 18px 30px rgba(4, 12, 27, 0.35);
+    --stat-card-hover-bg: rgba(15, 32, 54, 0.55);
+    --stat-card-hover-shadow: 0 22px 40px rgba(4, 12, 27, 0.4);
+    --stat-card-min-height: 140px;
     width: 100%;
-    max-width: var(--hero-cta-actions-max-width, 550px); 
-  }
+}
 
-  /* Ajuste para o botão único dentro do CTA do hero */
-  .hero-block__cta-actions .button--fancy {
-    flex-grow: 0; 
-    flex-shrink: 1; 
-    flex-basis: auto; 
+.stats-deck--compact .stat-card__label {
+    font-size: clamp(0.75rem, 1.6vw, 0.85rem);
+}
 
-    /* Ajuste a largura do botão aqui */
-    min-width: 280px; /* Ex: Mínimo de 280px */
-    max-width: 350px; /* Ex: Máximo de 350px */
-    width: 100%;     /* Tenta ocupar a largura do container, respeitando min/max */
-  }
-  
-  
-  /*
-  --------------------------------------------------------------------------
-    Responsive Styles for .hero-block
-  --------------------------------------------------------------------------
-  */
-  @media (max-width: 992px) {
-      /* ... (sem grandes mudanças necessárias aqui geralmente) ... */
-  }
-  @media (max-width: 768px) {
-    .hero-block {
-      --hero-padding-y-top: clamp(55px, 9.5vh, 70px);
-      --hero-padding-x: clamp(25px, 4vw, 35px);
-      --hero-padding-y-bottom: clamp(45px, 8.5vh, 60px);
-      --hero-internal-gap: clamp(35px, 5.5vh, 45px);
+.stats-deck--compact .stat-card__value {
+    font-size: clamp(1.6rem, 3.2vw, 2.2rem);
+}
+
+.hub-hero__cta {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.hub-hero__cta-text {
+    margin: 0;
+    font-size: clamp(0.95rem, 2.4vw, 1.05rem);
+    max-width: 640px;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.hub-hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+}
+
+.hub-hero__actions .button--fancy {
+    flex: 1 1 220px;
+    min-width: 230px;
+}
+
+.hub-hero__aside {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(18px, 3vh, 26px);
+    padding: clamp(26px, 4vw, 36px);
+    background: rgba(9, 20, 36, 0.55);
+    border-radius: var(--border-radius-xxl, 28px);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+    box-shadow: 0 22px 45px rgba(4, 12, 27, 0.45);
+}
+
+.hub-hero__aside-header {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.hub-hero__aside-pill {
+    align-self: flex-start;
+    padding: 6px 14px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    font-size: 0.75rem;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.hub-hero__aside-title {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: clamp(1.4rem, 3.2vw, 1.8rem);
+    line-height: 1.3;
+}
+
+.hub-hero__aside-subtitle {
+    margin: 0;
+    font-size: clamp(0.95rem, 2.2vw, 1.05rem);
+    color: rgba(255, 255, 255, 0.78);
+    line-height: 1.6;
+}
+
+.game-modes-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: clamp(16px, 3.5vw, 24px);
+}
+
+.game-mode-card {
+    position: relative;
+    display: flex;
+    gap: 18px;
+    align-items: flex-start;
+    text-decoration: none;
+    color: inherit;
+    padding: clamp(18px, 3.5vw, 24px);
+    border-radius: var(--border-radius-xl, 22px);
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0.05) 100%);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+    min-height: 170px;
+    overflow: hidden;
+}
+
+.game-mode-card:hover,
+.game-mode-card:focus-visible {
+    transform: translateY(-6px);
+    box-shadow: 0 24px 40px rgba(4, 12, 27, 0.4);
+    border-color: rgba(255, 255, 255, 0.35);
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0.08) 100%);
+}
+
+.game-mode-card:focus-visible {
+    outline: 3px solid rgba(255, 255, 255, 0.45);
+    outline-offset: 3px;
+}
+
+.game-mode-card__icon {
+    flex-shrink: 0;
+    font-size: clamp(1.6rem, 3.8vw, 2rem);
+    padding: 14px;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    color: var(--color-white);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.game-mode-card__body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    min-width: 0;
+}
+
+.game-mode-card__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+.game-mode-card__title {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: clamp(1.05rem, 2.4vw, 1.2rem);
+}
+
+.game-mode-card__chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 5px 12px;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background: rgba(255, 255, 255, 0.15);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+}
+
+.game-mode-card__chip--accent {
+    background: rgba(var(--color-secondary-green-rgb), 0.22);
+    border-color: rgba(var(--color-secondary-green-rgb), 0.45);
+    color: var(--color-white);
+}
+
+.game-mode-card__description {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    color: rgba(255, 255, 255, 0.82);
+}
+
+.game-mode-card__meta {
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 6px;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.8);
+    list-style: none;
+}
+
+.game-mode-card__meta li {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.game-mode-card__meta .material-symbols-outlined {
+    font-size: 1.1rem;
+}
+
+.game-mode-card--ghost {
+    background: rgba(255, 255, 255, 0.08);
+    border-style: dashed;
+    border-color: rgba(255, 255, 255, 0.28);
+}
+
+.game-mode-card--ghost:hover,
+.game-mode-card--ghost:focus-visible {
+    background: rgba(255, 255, 255, 0.14);
+    border-color: rgba(255, 255, 255, 0.45);
+}
+
+@media (max-width: 1100px) {
+    .hub-hero__content {
+        grid-template-columns: 1fr;
     }
-  }
-  @media (max-width: 480px) {
-    .hero-block {
-      --hero-padding-y-top: clamp(45px, 10vh, 60px);
-      --hero-padding-x: clamp(20px, 5vw, 30px);
-      --hero-padding-y-bottom: clamp(35px, 8vh, 50px);
-      --hero-internal-gap: clamp(35px, 6vh, 45px);
+
+    .hub-hero__aside {
+        order: -1;
     }
-    .hero-block__title {
-      margin-bottom: var(--spacing-md, 15px);
+}
+
+@media (max-width: 820px) {
+    .hub-hero {
+        padding: clamp(28px, 6vw, 40px);
     }
-    .hero-block__subtitle {
-      line-height: 1.7;
+
+    .hub-hero__chips {
+        gap: 8px 10px;
     }
-    .hero-block__cta-text {
-      margin-bottom: var(--spacing-lg, 25px);
+
+    .hub-hero__actions {
+        gap: 12px;
     }
-    .hero-block__cta-actions {
-      gap: var(--spacing-lg, 20px);
+}
+
+@media (max-width: 640px) {
+    .hub-hero__eyebrow {
+        letter-spacing: 0.25em;
     }
-    .hero-block__cta-actions .button--fancy {
-      min-width: 240px; /* Ajuste para telas menores */
-      max-width: 90%;   /* Pode usar porcentagem para ser mais fluido */
+
+    .hub-hero__content {
+        gap: clamp(22px, 5vw, 32px);
     }
-  }
-  @media (max-width: 360px) {
-    .hero-block {
-      --hero-padding-y-top: clamp(40px, 8vh, 50px);
-      --hero-padding-x: clamp(15px, 4vw, 25px);
-      --hero-padding-y-bottom: clamp(30px, 7vh, 40px);
-      --hero-internal-gap: clamp(30px, 5vh, 40px);
+
+    .hub-hero__chips {
+        flex-direction: column;
+        align-items: stretch;
     }
-    .hero-block__cta-actions .button--fancy {
-      min-width: 200px; 
+
+    .hub-hero__chip {
+        justify-content: center;
     }
-  }
+
+    .hub-hero__actions .button--fancy {
+        min-width: 100%;
+    }
+
+    .hub-hero__stats .stats-deck {
+        --stats-deck-columns: 1;
+    }
+}
+
+@media (max-width: 480px) {
+    .hub-hero {
+        padding: clamp(24px, 8vw, 32px);
+        border-radius: var(--border-radius-xl, 24px);
+    }
+
+    .hub-hero__aside {
+        padding: clamp(22px, 7vw, 30px);
+    }
+
+    .game-mode-card {
+        flex-direction: column;
+        min-height: 0;
+    }
+
+    .game-mode-card__icon {
+        align-self: flex-start;
+    }
+
+    .game-mode-card__header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .game-mode-card__chip {
+        margin-top: 6px;
+    }
+}

--- a/quiz/templates/quiz/home.html
+++ b/quiz/templates/quiz/home.html
@@ -1,169 +1,238 @@
-{# Arquivo: templates/quiz/home.html #} 
-{% extends "quiz/base.html" %} 
-{% load static %} 
-{% block title %}{{ page_title|default:"MedQuiz - Início" }}{%endblock title %} 
+{# Arquivo: templates/quiz/home.html #}
+{% extends "quiz/base.html" %}
+{% load static %}
+{% block title %}{{ page_title|default:"MedQuiz - Início" }}{%endblock title %}
 {% block content %}
-<section id="home-section" class="main-section">
-	<div class="hero-block">
-		<div class="hero-block__welcome">
-			{% if user.is_authenticated %}
-			<h1 class="hero-block__title">
-				Olá, {{ user.first_name|default:user.username }}!
-			</h1>
-			{% else %}
-			<h1 class="hero-block__title">Bem-vindo ao MedQuiz!</h1>
-			{% endif %}
-			<p class="hero-block__subtitle">
-				Pronto para expandir seus conhecimentos hoje?
-			</p>
-		</div>
+<section id="home-section" class="hub-hero">
+        <span class="hub-hero__orb hub-hero__orb--primary" aria-hidden="true"></span>
+        <span class="hub-hero__orb hub-hero__orb--secondary" aria-hidden="true"></span>
 
-		{% if user.is_authenticated and daily_stats %}
-		<div class="stats-deck">
-			<div class="stat-card">
-				<span class="material-symbols-outlined stat-card__icon"
-					>checklist</span
-				>
-				<span class="stat-card__label">Respondidas Hoje</span>
-				<span class="stat-card__value" id="daily-questions"
-					>{{ daily_stats.perguntas_respondidas_dia }}</span
-				>
-			</div>
-			<div class="stat-card">
-				<span class="material-symbols-outlined stat-card__icon"
-					>target</span
-				>
-				<span class="stat-card__label">Acertos Hoje</span>
-				<span class="stat-card__value" id="daily-accuracy"
-					>{{ accuracy_percentage }}</span
-				>
-			</div>
-			<div class="stat-card">
-				<span class="material-symbols-outlined stat-card__icon"
-					>military_tech</span
-				>
-				<span class="stat-card__label">Pontos Hoje</span>
-				<span class="stat-card__value" id="daily-points"
-					>{{ daily_stats.pontos_dia }}</span
-				>
-			</div>
-			<div class="stat-card">
-				<span class="material-symbols-outlined stat-card__icon"
-					>local_fire_department</span
-				>
-				<span class="stat-card__label">Sequência Dias</span>
-				<span class="stat-card__value" id="streak-value"
-					>{{ daily_stats.sequencia_dias_quiz }}</span
-				>
-			</div>
-		</div>
-		{% else %}
-		<div class="stats-deck">
-			<div class="stat-card">
-				<span class="material-symbols-outlined stat-card__icon"
-					>quiz</span
-				>
-				<span class="stat-card__label">Muitas Questões</span>
-				{# Este span será preenchido pelo script.js após carregar os
-				dados da API #}
-				<span class="stat-card__value" id="hub-total-questions-count"
-					>...</span
-				>
-			</div>
-			<div class="stat-card">
-				<span class="material-symbols-outlined stat-card__icon"
-					>school</span
-				>
-				<span class="stat-card__label">Aprenda Mais</span>
-				<span class="stat-card__value">Sempre!</span>
-			</div>
-			<div class="stat-card">
-				<span class="material-symbols-outlined stat-card__icon"
-					>military_tech</span
-				>
-				<span class="stat-card__label">Ganhe Pontos</span>
-				<span class="stat-card__value">Jogue!</span>
-			</div>
-			<div class="stat-card">
-				<span class="material-symbols-outlined stat-card__icon"
-					>person_add</span
-				>
-				<span class="stat-card__label">Crie Conta</span>
-				<span class="stat-card__value">Grátis!</span>
-			</div>
-		</div>
-		{% endif %}
+        <div class="hub-hero__content">
+                <div class="hub-hero__main">
+                        <span class="hub-hero__eyebrow">Challenge Hub</span>
+                        {% if user.is_authenticated %}
+                        <h1 class="hub-hero__title">
+                                Hora de evoluir, {{ user.first_name|default:user.username }}!
+                        </h1>
+                        <p class="hub-hero__subtitle">
+                                Combine modos de jogo, acompanhe seus indicadores em tempo real e mantenha sua sequência de vitórias.
+                        </p>
+                        {% else %}
+                        <h1 class="hub-hero__title">Bem-vindo ao Challenge Hub do MedQuiz</h1>
+                        <p class="hub-hero__subtitle">
+                                Escolha como quer jogar, conheça desafios especiais e salve seu progresso com experiências personalizadas.
+                        </p>
+                        {% endif %}
 
-		<div class="hero-block__cta">
-			{% if user.is_authenticated %}
-			<p class="hero-block__cta-text">
-				Pronto para testar seus conhecimentos?
-			</p>
-			<div class="hero-block__cta-actions">
-				<a
-					href="{% url 'quiz:questions' %}"
-					class="button button--fancy button--fancy-primary"
-					id="go-to-challenges-hub-link"
-				>
-					<span class="material-symbols-outlined button__icon"
-						>rocket_launch</span
-					>
-					<span class="button__label">Iniciar Desafio</span>
-				</a>
-			</div>
-			{% else %}
-			<p class="hero-block__cta-text">
-				Crie sua conta ou faça login para salvar seu progresso e
-				competir!
-			</p>
-			<div
-				class="hero-block__cta-actions"
-				style="
-					display: flex;
-					gap: 15px;
-					flex-wrap: wrap;
-					justify-content: center;
-				"
-			>
-				<a
-					href="{% url 'quiz:register' %}"
-					class="button button--fancy button--fancy-primary"
-				>
-					<span class="material-symbols-outlined button__icon"
-						>person_add</span
-					>
-					Cadastre-se Gratuitamente
-				</a>
-				<a
-					href="{% url 'login' %}"
-					class="button button--fancy button--fancy-secondary"
-				>
-					<span class="material-symbols-outlined button__icon"
-						>login</span
-					>
-					Fazer Login
-				</a>
-			</div>
-			{% endif %}
-		</div>
-	</div>
-	<div class="home-section__additional-content">
-		<div class="card card--additional-content card--centered-content">
-			<h2 class="card__title">Explore Mais</h2>
-			<div class="card__body">
-				<p>
-					Ainda desenvolvendo esta área, mas aqui você poderá
-					encontrar artigos, dicas de estudo e outros recursos para
-					complementar seu aprendizado.
-				</p>
-				<a
-					href="{% url 'quiz:questions' %}"
-					class="button button--outline button--small"
-					id="view-all-questions-alt-link"
-					>Ver Banco de Questões</a
-				>
-			</div>
-		</div>
-	</div>
+                        <div class="hub-hero__chips" aria-label="Destaques do Challenge Hub">
+                                <span class="hub-hero__chip">
+                                        <span class="material-symbols-outlined hub-hero__chip-icon">leaderboard</span>
+                                        Rankings dinâmicos
+                                </span>
+                                <span class="hub-hero__chip">
+                                        <span class="material-symbols-outlined hub-hero__chip-icon">emoji_events</span>
+                                        Conquistas temáticas
+                                </span>
+                                <span class="hub-hero__chip">
+                                        <span class="material-symbols-outlined hub-hero__chip-icon">group</span>
+                                        Desafios colaborativos
+                                </span>
+                                <span class="hub-hero__chip">
+                                        <span class="material-symbols-outlined hub-hero__chip-icon">trending_up</span>
+                                        Insights inteligentes
+                                </span>
+                        </div>
+
+                        <div class="hub-hero__stats">
+                                {% if user.is_authenticated and daily_stats %}
+                                <div class="stats-deck stats-deck--compact" role="list">
+                                        <div class="stat-card" role="listitem">
+                                                <span class="material-symbols-outlined stat-card__icon">checklist</span>
+                                                <span class="stat-card__label">Respondidas hoje</span>
+                                                <span class="stat-card__value" id="daily-questions">{{ daily_stats.perguntas_respondidas_dia }}</span>
+                                        </div>
+                                        <div class="stat-card" role="listitem">
+                                                <span class="material-symbols-outlined stat-card__icon">target</span>
+                                                <span class="stat-card__label">Precisão diária</span>
+                                                <span class="stat-card__value" id="daily-accuracy">{{ accuracy_percentage }}</span>
+                                        </div>
+                                        <div class="stat-card" role="listitem">
+                                                <span class="material-symbols-outlined stat-card__icon">military_tech</span>
+                                                <span class="stat-card__label">Pontos do dia</span>
+                                                <span class="stat-card__value" id="daily-points">{{ daily_stats.pontos_dia }}</span>
+                                        </div>
+                                        <div class="stat-card" role="listitem">
+                                                <span class="material-symbols-outlined stat-card__icon">local_fire_department</span>
+                                                <span class="stat-card__label">Sequência ativa</span>
+                                                <span class="stat-card__value" id="streak-value">{{ daily_stats.sequencia_dias_quiz }}</span>
+                                        </div>
+                                </div>
+                                {% else %}
+                                <div class="stats-deck stats-deck--compact" role="list">
+                                        <div class="stat-card" role="listitem">
+                                                <span class="material-symbols-outlined stat-card__icon">quiz</span>
+                                                <span class="stat-card__label">Banco disponível</span>
+                                                <span class="stat-card__value" id="hub-total-questions-count">...</span>
+                                        </div>
+                                        <div class="stat-card" role="listitem">
+                                                <span class="material-symbols-outlined stat-card__icon">school</span>
+                                                <span class="stat-card__label">Trilhas personalizadas</span>
+                                                <span class="stat-card__value">Liberadas</span>
+                                        </div>
+                                        <div class="stat-card" role="listitem">
+                                                <span class="material-symbols-outlined stat-card__icon">military_tech</span>
+                                                <span class="stat-card__label">Recompensas</span>
+                                                <span class="stat-card__value">Diárias</span>
+                                        </div>
+                                        <div class="stat-card" role="listitem">
+                                                <span class="material-symbols-outlined stat-card__icon">person_add</span>
+                                                <span class="stat-card__label">Conta gratuita</span>
+                                                <span class="stat-card__value">1 min</span>
+                                        </div>
+                                </div>
+                                {% endif %}
+                        </div>
+
+                        <div class="hub-hero__cta">
+                                {% if user.is_authenticated %}
+                                <p class="hub-hero__cta-text">
+                                        Combine um modo rápido com suas preferências salvas ou mergulhe direto em um novo desafio.
+                                </p>
+                                <div class="hub-hero__actions">
+                                        <a
+                                                href="{% url 'quiz:questions' %}"
+                                                class="button button--fancy button--fancy-primary"
+                                                id="go-to-challenges-hub-link"
+                                        >
+                                                <span class="material-symbols-outlined button__icon">rocket_launch</span>
+                                                <span class="button__label">Iniciar sessão rápida</span>
+                                        </a>
+                                        <a
+                                                href="{% url 'quiz:account' %}"
+                                                class="button button--fancy button--fancy-secondary"
+                                        >
+                                                <span class="material-symbols-outlined button__icon">tune</span>
+                                                <span class="button__label">Abrir painel pessoal</span>
+                                        </a>
+                                </div>
+                                {% else %}
+                                <p class="hub-hero__cta-text">
+                                        Crie sua conta gratuita para desbloquear progresso salvo, rankings ao vivo e modos personalizados.
+                                </p>
+                                <div class="hub-hero__actions">
+                                        <a
+                                                href="{% url 'quiz:register' %}"
+                                                class="button button--fancy button--fancy-primary"
+                                        >
+                                                <span class="material-symbols-outlined button__icon">person_add</span>
+                                                Cadastre-se gratuitamente
+                                        </a>
+                                        <a
+                                                href="{% url 'login' %}"
+                                                class="button button--fancy button--fancy-secondary"
+                                        >
+                                                <span class="material-symbols-outlined button__icon">login</span>
+                                                Fazer login
+                                        </a>
+                                </div>
+                                {% endif %}
+                        </div>
+                </div>
+
+                <aside class="hub-hero__aside" aria-labelledby="game-modes-heading">
+                        <header class="hub-hero__aside-header">
+                                <span class="hub-hero__aside-pill">Modos de jogo</span>
+                                <h2 class="hub-hero__aside-title" id="game-modes-heading">
+                                        Escolha como quer jogar hoje
+                                </h2>
+                                <p class="hub-hero__aside-subtitle">
+                                        Combine regras, limite de tempo e objetivos especiais para transformar seus estudos em missões épicas.
+                                </p>
+                        </header>
+                        <div class="game-modes-grid">
+                                <a
+                                        href="{% url 'quiz:questions' %}?modo=classico"
+                                        class="game-mode-card"
+                                        data-mode="classico"
+                                >
+                                        <span class="material-symbols-outlined game-mode-card__icon">auto_stories</span>
+                                        <div class="game-mode-card__body">
+                                                <div class="game-mode-card__header">
+                                                        <h3 class="game-mode-card__title">Clássico</h3>
+                                                        <span class="game-mode-card__chip">Recomendado</span>
+                                                </div>
+                                                <p class="game-mode-card__description">
+                                                        Responda no seu ritmo, com feedback completo e curadoria inteligente de questões.
+                                                </p>
+                                                <ul class="game-mode-card__meta">
+                                                        <li><span class="material-symbols-outlined">schedule</span>15 questões</li>
+                                                        <li><span class="material-symbols-outlined">workspace_premium</span>Multiplica pontos</li>
+                                                </ul>
+                                        </div>
+                                </a>
+                                <a
+                                        href="{% url 'quiz:questions' %}?modo=sprint"
+                                        class="game-mode-card"
+                                        data-mode="sprint"
+                                >
+                                        <span class="material-symbols-outlined game-mode-card__icon">speed</span>
+                                        <div class="game-mode-card__body">
+                                                <div class="game-mode-card__header">
+                                                        <h3 class="game-mode-card__title">Sprint</h3>
+                                                        <span class="game-mode-card__chip game-mode-card__chip--accent">Novo</span>
+                                                </div>
+                                                <p class="game-mode-card__description">
+                                                        Corridas contra o tempo com boosters de combo e checkpoints estratégicos.
+                                                </p>
+                                                <ul class="game-mode-card__meta">
+                                                        <li><span class="material-symbols-outlined">timer</span>2 min por questão</li>
+                                                        <li><span class="material-symbols-outlined">bolt</span>Power-ups em cadeia</li>
+                                                </ul>
+                                        </div>
+                                </a>
+                                <a
+                                        href="{% url 'quiz:questions' %}?modo=maratona"
+                                        class="game-mode-card"
+                                        data-mode="maratona"
+                                >
+                                        <span class="material-symbols-outlined game-mode-card__icon">track_changes</span>
+                                        <div class="game-mode-card__body">
+                                                <div class="game-mode-card__header">
+                                                        <h3 class="game-mode-card__title">Maratona</h3>
+                                                        <span class="game-mode-card__chip">Alta resistência</span>
+                                                </div>
+                                                <p class="game-mode-card__description">
+                                                        Sessões longas com checkpoints, metas intermediárias e resumo estratégico.
+                                                </p>
+                                                <ul class="game-mode-card__meta">
+                                                        <li><span class="material-symbols-outlined">flag</span>Objetivos personalizáveis</li>
+                                                        <li><span class="material-symbols-outlined">insights</span>Relatório avançado</li>
+                                                </ul>
+                                        </div>
+                                </a>
+                                <a
+                                        href="{% url 'quiz:questions' %}?modo=estudo"
+                                        class="game-mode-card game-mode-card--ghost"
+                                        data-mode="estudo"
+                                        id="view-all-questions-alt-link"
+                                >
+                                        <span class="material-symbols-outlined game-mode-card__icon">menu_book</span>
+                                        <div class="game-mode-card__body">
+                                                <div class="game-mode-card__header">
+                                                        <h3 class="game-mode-card__title">Estudo livre</h3>
+                                                        <span class="game-mode-card__chip">Catálogo completo</span>
+                                                </div>
+                                                <p class="game-mode-card__description">
+                                                        Explore todo o banco de questões, filtre por temas e acompanhe seus favoritos.
+                                                </p>
+                                                <ul class="game-mode-card__meta">
+                                                        <li><span class="material-symbols-outlined">filter_alt</span>Filtros avançados</li>
+                                                        <li><span class="material-symbols-outlined">bookmarks</span>Salvar coleções</li>
+                                                </ul>
+                                        </div>
+                                </a>
+                        </div>
+                </aside>
+        </div>
 </section>
-{% endblock content %} 
+{% endblock content %}


### PR DESCRIPTION
## Summary
- redesign the Challenge Hub hero area with a modern split layout and animated accents
- surface personalized stats, dynamic highlights, and refreshed calls to action for authenticated and guest users
- introduce a grid of game mode cards so players can choose between clássico, sprint, maratona and estudo livre flows

## Testing
- python manage.py check *(fails: Django not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7373ea600833399a6ce13a0579437