### PR TITLE
Revamp Challenge Hub layout

### DIFF
--- a/assets/css/components/hero-block.css
+++ b/assets/css/components/hero-block.css
@@ -10,61 +10,71 @@
     position: relative;
     width: 100%;
     margin: clamp(20px, 4vw, 40px) auto;
-    padding: clamp(32px, 5vw, 56px);
+    padding: clamp(34px, 5vw, 64px);
     border-radius: var(--border-radius-xxl, 32px);
-    background: radial-gradient(circle at 10% -10%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 55%),
-                radial-gradient(circle at 85% 10%, rgba(35, 209, 160, 0.15) 0%, rgba(35, 209, 160, 0) 55%),
-                linear-gradient(140deg, rgba(var(--color-primary-dark-rgb), 0.98) 0%, rgba(15, 52, 96, 0.93) 60%, rgba(var(--color-secondary-green-rgb), 0.85) 100%);
+    background: radial-gradient(circle at 5% -10%, rgba(255, 255, 255, 0.16) 0%, rgba(255, 255, 255, 0) 55%),
+        radial-gradient(circle at 90% 0%, rgba(54, 209, 176, 0.25) 0%, rgba(54, 209, 176, 0) 55%),
+        linear-gradient(140deg, rgba(var(--color-primary-dark-rgb), 0.98) 0%, rgba(10, 36, 72, 0.94) 52%, rgba(var(--color-secondary-green-rgb), 0.88) 100%);
     color: var(--color-white);
     overflow: hidden;
-    box-shadow: 0 25px 60px rgba(9, 17, 36, 0.35);
+    box-shadow: 0 26px 64px rgba(9, 17, 36, 0.38);
 }
 
-.hub-hero__content {
+.hub-hero--revamped {
+    isolation: isolate;
+}
+
+.hub-hero__layout {
     position: relative;
     z-index: 1;
     display: grid;
     grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
-    gap: clamp(28px, 5vw, 56px);
-    align-items: stretch;
+    gap: clamp(32px, 5vw, 60px);
+    align-items: start;
 }
 
 .hub-hero__orb {
     position: absolute;
     border-radius: 50%;
     filter: blur(0px);
-    opacity: 0.65;
+    opacity: 0.6;
     pointer-events: none;
     z-index: 0;
 }
 
 .hub-hero__orb--primary {
-    width: clamp(220px, 32vw, 420px);
-    height: clamp(220px, 32vw, 420px);
-    top: -18%;
-    left: -8%;
+    width: clamp(240px, 33vw, 440px);
+    height: clamp(240px, 33vw, 440px);
+    top: -22%;
+    left: -10%;
     background: radial-gradient(circle, rgba(var(--color-secondary-green-rgb), 0.55) 0%, rgba(21, 208, 160, 0) 70%);
 }
 
 .hub-hero__orb--secondary {
-    width: clamp(200px, 30vw, 360px);
-    height: clamp(200px, 30vw, 360px);
-    bottom: -22%;
-    right: -10%;
+    width: clamp(200px, 30vw, 380px);
+    height: clamp(200px, 30vw, 380px);
+    bottom: -28%;
+    right: -12%;
     background: radial-gradient(circle, rgba(72, 118, 255, 0.45) 0%, rgba(72, 118, 255, 0) 70%);
 }
 
-.hub-hero__main {
+.hub-hero__primary {
     display: flex;
     flex-direction: column;
-    gap: clamp(18px, 3.5vh, 28px);
+    gap: clamp(22px, 4vw, 32px);
+}
+
+.hub-hero__header {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(12px, 2.8vw, 18px);
 }
 
 .hub-hero__eyebrow {
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    padding: 6px 14px;
+    padding: 6px 16px;
     background: rgba(255, 255, 255, 0.12);
     border: 1px solid rgba(255, 255, 255, 0.18);
     border-radius: 999px;
@@ -76,41 +86,42 @@
 .hub-hero__title {
     font-family: var(--font-family-heading);
     font-weight: var(--font-weight-bold);
-    font-size: clamp(2rem, 4.6vw, 2.9rem);
+    font-size: clamp(2.1rem, 4.8vw, 3rem);
     line-height: 1.15;
     margin: 0;
 }
 
 .hub-hero__subtitle {
     margin: 0;
-    font-size: clamp(1.05rem, 2.6vw, 1.25rem);
+    font-size: clamp(1.05rem, 2.6vw, 1.3rem);
     line-height: 1.7;
     max-width: 720px;
-    color: rgba(255, 255, 255, 0.92);
+    color: rgba(255, 255, 255, 0.9);
 }
 
-.hub-hero__chips {
+.hub-hero__badge-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+    gap: clamp(12px, 3vw, 18px);
+}
+
+.feature-pill {
     display: flex;
-    flex-wrap: wrap;
-    gap: 10px 14px;
-}
-
-.hub-hero__chip {
-    display: inline-flex;
     align-items: center;
-    gap: 8px;
-    padding: 8px 14px;
-    border-radius: 999px;
-    background: rgba(255, 255, 255, 0.13);
+    gap: 12px;
+    padding: 12px 18px;
+    border-radius: var(--border-radius-xl, 20px);
+    background: rgba(12, 28, 52, 0.45);
     border: 1px solid rgba(255, 255, 255, 0.18);
-    font-size: 0.85rem;
     color: rgba(255, 255, 255, 0.92);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
+    font-size: 0.9rem;
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
 }
 
-.hub-hero__chip-icon {
-    font-size: 1.1rem;
+.feature-pill__icon {
+    font-size: 1.35rem;
+    color: rgba(255, 255, 255, 0.85);
 }
 
 .hub-hero__stats {
@@ -120,14 +131,14 @@
 
 .hub-hero__stats .stats-deck {
     --stats-deck-columns: 2;
-    --stats-deck-gap: clamp(16px, 3.5vw, 24px);
+    --stats-deck-gap: clamp(16px, 3.5vw, 26px);
     --stats-deck-max-width: 100%;
-    --stat-card-bg: rgba(8, 19, 35, 0.35);
-    --stat-card-border-color: rgba(255, 255, 255, 0.2);
-    --stat-card-shadow: 0 18px 30px rgba(4, 12, 27, 0.35);
+    --stat-card-bg: rgba(8, 19, 35, 0.38);
+    --stat-card-border-color: rgba(255, 255, 255, 0.22);
+    --stat-card-shadow: 0 18px 36px rgba(4, 12, 27, 0.38);
     --stat-card-hover-bg: rgba(15, 32, 54, 0.55);
-    --stat-card-hover-shadow: 0 22px 40px rgba(4, 12, 27, 0.4);
-    --stat-card-min-height: 140px;
+    --stat-card-hover-shadow: 0 22px 40px rgba(4, 12, 27, 0.42);
+    --stat-card-min-height: 150px;
     width: 100%;
 }
 
@@ -136,20 +147,24 @@
 }
 
 .stats-deck--compact .stat-card__value {
-    font-size: clamp(1.6rem, 3.2vw, 2.2rem);
+    font-size: clamp(1.6rem, 3.2vw, 2.25rem);
 }
 
 .hub-hero__cta {
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: clamp(14px, 3vw, 18px);
 }
 
 .hub-hero__cta-text {
     margin: 0;
-    font-size: clamp(0.95rem, 2.4vw, 1.05rem);
+    font-size: clamp(0.95rem, 2.4vw, 1.08rem);
     max-width: 640px;
     color: rgba(255, 255, 255, 0.85);
+}
+
+.hub-hero__cta-text p {
+    margin: 0;
 }
 
 .hub-hero__actions {
@@ -163,28 +178,82 @@
     min-width: 230px;
 }
 
-.hub-hero__aside {
-    display: flex;
-    flex-direction: column;
-    gap: clamp(18px, 3vh, 26px);
-    padding: clamp(26px, 4vw, 36px);
-    background: rgba(9, 20, 36, 0.55);
-    border-radius: var(--border-radius-xxl, 28px);
-    border: 1px solid rgba(255, 255, 255, 0.14);
-    backdrop-filter: blur(24px);
-    -webkit-backdrop-filter: blur(24px);
-    box-shadow: 0 22px 45px rgba(4, 12, 27, 0.45);
+.hub-hero__quicklinks {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: clamp(14px, 3vw, 20px);
 }
 
-.hub-hero__aside-header {
+.quicklink {
+    display: flex;
+    gap: 14px;
+    align-items: center;
+    padding: 16px 18px;
+    text-decoration: none;
+    color: inherit;
+    background: rgba(8, 21, 38, 0.52);
+    border-radius: var(--border-radius-xl, 22px);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.quicklink:hover,
+.quicklink:focus-visible {
+    transform: translateY(-4px);
+    box-shadow: 0 20px 34px rgba(4, 12, 27, 0.38);
+    border-color: rgba(255, 255, 255, 0.32);
+}
+
+.quicklink:focus-visible {
+    outline: 3px solid rgba(255, 255, 255, 0.4);
+    outline-offset: 3px;
+}
+
+.quicklink__icon {
+    flex-shrink: 0;
+    font-size: 1.6rem;
+    padding: 12px;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    color: var(--color-white);
+}
+
+.quicklink__content {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 4px;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.82);
+}
+
+.quicklink__content strong {
+    font-size: 1rem;
+    color: rgba(255, 255, 255, 0.96);
+}
+
+.hub-hero__modes {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(20px, 3.6vw, 28px);
+    padding: clamp(26px, 4vw, 36px);
+    background: rgba(9, 20, 36, 0.6);
+    border-radius: var(--border-radius-xxl, 28px);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    backdrop-filter: blur(26px);
+    -webkit-backdrop-filter: blur(26px);
+    box-shadow: 0 24px 48px rgba(4, 12, 27, 0.44);
+}
+
+.hub-hero__modes-header {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
 }
 
 .hub-hero__aside-pill {
     align-self: flex-start;
-    padding: 6px 14px;
+    padding: 6px 16px;
     border-radius: 999px;
     border: 1px solid rgba(255, 255, 255, 0.22);
     font-size: 0.75rem;
@@ -196,157 +265,199 @@
 .hub-hero__aside-title {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(1.4rem, 3.2vw, 1.8rem);
+    font-size: clamp(1.5rem, 3.4vw, 1.9rem);
     line-height: 1.3;
 }
 
 .hub-hero__aside-subtitle {
     margin: 0;
-    font-size: clamp(0.95rem, 2.2vw, 1.05rem);
+    font-size: clamp(0.95rem, 2.2vw, 1.08rem);
     color: rgba(255, 255, 255, 0.78);
     line-height: 1.6;
 }
 
-.game-modes-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: clamp(16px, 3.5vw, 24px);
-}
-
-.game-mode-card {
-    position: relative;
+.mode-pills {
     display: flex;
-    gap: 18px;
-    align-items: flex-start;
-    text-decoration: none;
-    color: inherit;
-    padding: clamp(18px, 3.5vw, 24px);
-    border-radius: var(--border-radius-xl, 22px);
-    background: linear-gradient(160deg, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0.05) 100%);
-    border: 1px solid rgba(255, 255, 255, 0.16);
-    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease, background 0.25s ease;
-    min-height: 170px;
-    overflow: hidden;
-}
-
-.game-mode-card:hover,
-.game-mode-card:focus-visible {
-    transform: translateY(-6px);
-    box-shadow: 0 24px 40px rgba(4, 12, 27, 0.4);
-    border-color: rgba(255, 255, 255, 0.35);
-    background: linear-gradient(160deg, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0.08) 100%);
-}
-
-.game-mode-card:focus-visible {
-    outline: 3px solid rgba(255, 255, 255, 0.45);
-    outline-offset: 3px;
-}
-
-.game-mode-card__icon {
-    flex-shrink: 0;
-    font-size: clamp(1.6rem, 3.8vw, 2rem);
-    padding: 14px;
-    border-radius: 18px;
-    background: rgba(255, 255, 255, 0.12);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    color: var(--color-white);
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
-}
-
-.game-mode-card__body {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    min-width: 0;
-}
-
-.game-mode-card__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+    flex-wrap: wrap;
     gap: 10px;
 }
 
-.game-mode-card__title {
-    margin: 0;
-    font-family: var(--font-family-heading);
-    font-size: clamp(1.05rem, 2.4vw, 1.2rem);
-}
-
-.game-mode-card__chip {
+.mode-pill {
     display: inline-flex;
     align-items: center;
-    padding: 5px 12px;
+    gap: 6px;
+    padding: 6px 14px;
     border-radius: 999px;
-    font-size: 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    background: rgba(255, 255, 255, 0.12);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.mode-area {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(14px, 2.6vw, 20px);
+    padding: clamp(16px, 3vw, 24px);
+    background: rgba(7, 16, 30, 0.45);
+    border-radius: var(--border-radius-xl, 22px);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.mode-area__header {
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+}
+
+.mode-area__icon {
+    flex-shrink: 0;
+    font-size: 2rem;
+    padding: 14px;
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.mode-area__title {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: clamp(1.15rem, 2.6vw, 1.35rem);
+}
+
+.mode-area__description {
+    margin: 6px 0 0;
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.78);
+    line-height: 1.55;
+}
+
+.mode-area__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: clamp(14px, 3vw, 20px);
+}
+
+.mode-area__grid--stretch {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.mode-card {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 20px;
+    text-decoration: none;
+    color: inherit;
+    border-radius: var(--border-radius-xl, 22px);
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0.04) 100%);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+    min-height: 200px;
+}
+
+.mode-card:hover,
+.mode-card:focus-visible {
+    transform: translateY(-6px);
+    box-shadow: 0 24px 42px rgba(4, 12, 27, 0.42);
+    border-color: rgba(255, 255, 255, 0.32);
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0.06) 100%);
+}
+
+.mode-card:focus-visible {
+    outline: 3px solid rgba(255, 255, 255, 0.42);
+    outline-offset: 3px;
+}
+
+.mode-card__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.mode-card__icon {
+    font-size: 1.8rem;
+    padding: 12px;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.mode-card__meta {
+    font-size: 0.78rem;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    background: rgba(255, 255, 255, 0.15);
-    border: 1px solid rgba(255, 255, 255, 0.25);
+    color: rgba(255, 255, 255, 0.7);
 }
 
-.game-mode-card__chip--accent {
-    background: rgba(var(--color-secondary-green-rgb), 0.22);
-    border-color: rgba(var(--color-secondary-green-rgb), 0.45);
-    color: var(--color-white);
-}
-
-.game-mode-card__description {
+.mode-card__title {
     margin: 0;
-    font-size: 0.95rem;
-    line-height: 1.5;
+    font-family: var(--font-family-heading);
+    font-size: clamp(1.05rem, 2.4vw, 1.25rem);
+}
+
+.mode-card__description {
+    margin: 0;
+    font-size: 0.94rem;
+    line-height: 1.55;
     color: rgba(255, 255, 255, 0.82);
 }
 
-.game-mode-card__meta {
+.mode-card__tags {
     margin: 0;
     padding: 0;
-    display: grid;
-    gap: 6px;
-    font-size: 0.85rem;
-    color: rgba(255, 255, 255, 0.8);
     list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 10px;
+    font-size: 0.8rem;
+    color: rgba(255, 255, 255, 0.78);
 }
 
-.game-mode-card__meta li {
+.mode-card__tags li {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
-}
-
-.game-mode-card__meta .material-symbols-outlined {
-    font-size: 1.1rem;
-}
-
-.game-mode-card--ghost {
+    padding: 4px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
     background: rgba(255, 255, 255, 0.08);
+}
+
+.mode-card--accent {
+    background: linear-gradient(150deg, rgba(var(--color-secondary-green-rgb), 0.42) 0%, rgba(255, 255, 255, 0.1) 100%);
+    border-color: rgba(var(--color-secondary-green-rgb), 0.45);
+}
+
+.mode-card--ghost {
     border-style: dashed;
-    border-color: rgba(255, 255, 255, 0.28);
+    background: rgba(255, 255, 255, 0.08);
 }
 
-.game-mode-card--ghost:hover,
-.game-mode-card--ghost:focus-visible {
-    background: rgba(255, 255, 255, 0.14);
-    border-color: rgba(255, 255, 255, 0.45);
+.mode-card--ghost:hover,
+.mode-card--ghost:focus-visible {
+    border-style: solid;
 }
 
-@media (max-width: 1100px) {
-    .hub-hero__content {
+@media (max-width: 1200px) {
+    .hub-hero__layout {
         grid-template-columns: 1fr;
     }
 
-    .hub-hero__aside {
+    .hub-hero__modes {
         order: -1;
     }
 }
 
 @media (max-width: 820px) {
     .hub-hero {
-        padding: clamp(28px, 6vw, 40px);
+        padding: clamp(28px, 6vw, 42px);
     }
 
-    .hub-hero__chips {
-        gap: 8px 10px;
+    .hub-hero__badge-row {
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     }
 
     .hub-hero__actions {
@@ -359,17 +470,16 @@
         letter-spacing: 0.25em;
     }
 
-    .hub-hero__content {
-        gap: clamp(22px, 5vw, 32px);
+    .hub-hero__layout {
+        gap: clamp(24px, 6vw, 32px);
     }
 
-    .hub-hero__chips {
-        flex-direction: column;
-        align-items: stretch;
+    .hub-hero__badge-row {
+        grid-template-columns: 1fr;
     }
 
-    .hub-hero__chip {
-        justify-content: center;
+    .hub-hero__quicklinks {
+        grid-template-columns: 1fr;
     }
 
     .hub-hero__actions .button--fancy {
@@ -387,25 +497,20 @@
         border-radius: var(--border-radius-xl, 24px);
     }
 
-    .hub-hero__aside {
+    .hub-hero__modes {
         padding: clamp(22px, 7vw, 30px);
     }
 
-    .game-mode-card {
-        flex-direction: column;
-        min-height: 0;
+    .mode-area__grid {
+        grid-template-columns: 1fr;
     }
 
-    .game-mode-card__icon {
-        align-self: flex-start;
-    }
-
-    .game-mode-card__header {
+    .quicklink {
         flex-direction: column;
         align-items: flex-start;
     }
 
-    .game-mode-card__chip {
-        margin-top: 6px;
+    .quicklink__icon {
+        align-self: flex-start;
     }
 }

--- a/quiz/templates/quiz/home.html
+++ b/quiz/templates/quiz/home.html
@@ -3,44 +3,46 @@
 {% load static %}
 {% block title %}{{ page_title|default:"MedQuiz - Início" }}{%endblock title %}
 {% block content %}
-<section id="home-section" class="hub-hero">
+<section id="home-section" class="hub-hero hub-hero--revamped" aria-labelledby="challenge-hub-heading">
         <span class="hub-hero__orb hub-hero__orb--primary" aria-hidden="true"></span>
         <span class="hub-hero__orb hub-hero__orb--secondary" aria-hidden="true"></span>
 
-        <div class="hub-hero__content">
-                <div class="hub-hero__main">
-                        <span class="hub-hero__eyebrow">Challenge Hub</span>
-                        {% if user.is_authenticated %}
-                        <h1 class="hub-hero__title">
-                                Hora de evoluir, {{ user.first_name|default:user.username }}!
-                        </h1>
-                        <p class="hub-hero__subtitle">
-                                Combine modos de jogo, acompanhe seus indicadores em tempo real e mantenha sua sequência de vitórias.
-                        </p>
-                        {% else %}
-                        <h1 class="hub-hero__title">Bem-vindo ao Challenge Hub do MedQuiz</h1>
-                        <p class="hub-hero__subtitle">
-                                Escolha como quer jogar, conheça desafios especiais e salve seu progresso com experiências personalizadas.
-                        </p>
-                        {% endif %}
+        <div class="hub-hero__layout">
+                <div class="hub-hero__primary">
+                        <header class="hub-hero__header">
+                                <span class="hub-hero__eyebrow">Challenge Hub</span>
+                                {% if user.is_authenticated %}
+                                <h1 class="hub-hero__title" id="challenge-hub-heading">
+                                        Hora de evoluir, {{ user.first_name|default:user.username }}!
+                                </h1>
+                                <p class="hub-hero__subtitle">
+                                        Personalize a dificuldade, monitore seus indicadores ao vivo e escolha experiências que se adaptam ao seu ritmo.
+                                </p>
+                                {% else %}
+                                <h1 class="hub-hero__title" id="challenge-hub-heading">Bem-vindo ao Challenge Hub do MedQuiz</h1>
+                                <p class="hub-hero__subtitle">
+                                        Descubra uma central de modos inteligentes, jornadas guiadas e desafios colaborativos para acelerar sua evolução.
+                                </p>
+                                {% endif %}
+                        </header>
 
-                        <div class="hub-hero__chips" aria-label="Destaques do Challenge Hub">
-                                <span class="hub-hero__chip">
-                                        <span class="material-symbols-outlined hub-hero__chip-icon">leaderboard</span>
-                                        Rankings dinâmicos
-                                </span>
-                                <span class="hub-hero__chip">
-                                        <span class="material-symbols-outlined hub-hero__chip-icon">emoji_events</span>
-                                        Conquistas temáticas
-                                </span>
-                                <span class="hub-hero__chip">
-                                        <span class="material-symbols-outlined hub-hero__chip-icon">group</span>
-                                        Desafios colaborativos
-                                </span>
-                                <span class="hub-hero__chip">
-                                        <span class="material-symbols-outlined hub-hero__chip-icon">trending_up</span>
-                                        Insights inteligentes
-                                </span>
+                        <div class="hub-hero__badge-row" role="list" aria-label="Destaques da central de desafios">
+                                <div class="feature-pill" role="listitem">
+                                        <span class="material-symbols-outlined feature-pill__icon">dynamic_form</span>
+                                        Combinações de regras instantâneas
+                                </div>
+                                <div class="feature-pill" role="listitem">
+                                        <span class="material-symbols-outlined feature-pill__icon">query_stats</span>
+                                        Insights em tempo real
+                                </div>
+                                <div class="feature-pill" role="listitem">
+                                        <span class="material-symbols-outlined feature-pill__icon">stadium</span>
+                                        Temporadas temáticas mensais
+                                </div>
+                                <div class="feature-pill" role="listitem">
+                                        <span class="material-symbols-outlined feature-pill__icon">diversity_3</span>
+                                        Sessões solo, duo e squad
+                                </div>
                         </div>
 
                         <div class="hub-hero__stats">
@@ -95,9 +97,11 @@
 
                         <div class="hub-hero__cta">
                                 {% if user.is_authenticated %}
-                                <p class="hub-hero__cta-text">
-                                        Combine um modo rápido com suas preferências salvas ou mergulhe direto em um novo desafio.
-                                </p>
+                                <div class="hub-hero__cta-text">
+                                        <p>
+                                                Acesse um setup sugerido ou abra o painel pessoal para montar sua própria combinação de regras.
+                                        </p>
+                                </div>
                                 <div class="hub-hero__actions">
                                         <a
                                                 href="{% url 'quiz:questions' %}"
@@ -105,7 +109,7 @@
                                                 id="go-to-challenges-hub-link"
                                         >
                                                 <span class="material-symbols-outlined button__icon">rocket_launch</span>
-                                                <span class="button__label">Iniciar sessão rápida</span>
+                                                <span class="button__label">Iniciar sessão instantânea</span>
                                         </a>
                                         <a
                                                 href="{% url 'quiz:account' %}"
@@ -116,9 +120,11 @@
                                         </a>
                                 </div>
                                 {% else %}
-                                <p class="hub-hero__cta-text">
-                                        Crie sua conta gratuita para desbloquear progresso salvo, rankings ao vivo e modos personalizados.
-                                </p>
+                                <div class="hub-hero__cta-text">
+                                        <p>
+                                                Crie sua conta gratuita para desbloquear progresso salvo, rankings ao vivo e modos cooperativos exclusivos.
+                                        </p>
+                                </div>
                                 <div class="hub-hero__actions">
                                         <a
                                                 href="{% url 'quiz:register' %}"
@@ -137,100 +143,175 @@
                                 </div>
                                 {% endif %}
                         </div>
+
+                        <div class="hub-hero__quicklinks" role="list" aria-label="Atalhos rápidos de treino">
+                                <a class="quicklink" role="listitem" href="{% url 'quiz:questions' %}?modo=classico&foco=flashcards" data-mode="flash">
+                                        <span class="material-symbols-outlined quicklink__icon">bolt</span>
+                                        <span class="quicklink__content">
+                                                <strong>Flash rounds</strong>
+                                                <span>15 questões curtas para aquecer antes da prova.</span>
+                                        </span>
+                                </a>
+                                <a class="quicklink" role="listitem" href="{% url 'quiz:questions' %}?modo=estudo&playlist=revision" data-mode="revision">
+                                        <span class="material-symbols-outlined quicklink__icon">sync_saved_locally</span>
+                                        <span class="quicklink__content">
+                                                <strong>Revisão inteligente</strong>
+                                                <span>Retome automaticamente conteúdos pendentes.</span>
+                                        </span>
+                                </a>
+                                <a class="quicklink" role="listitem" href="{% url 'quiz:questions' %}?modo=maratona&evento=simulado" data-mode="simulado">
+                                        <span class="material-symbols-outlined quicklink__icon">assignment_turned_in</span>
+                                        <span class="quicklink__content">
+                                                <strong>Simulado guiado</strong>
+                                                <span>Estruture sessões longas com checkpoints.</span>
+                                        </span>
+                                </a>
+                        </div>
                 </div>
 
-                <aside class="hub-hero__aside" aria-labelledby="game-modes-heading">
-                        <header class="hub-hero__aside-header">
-                                <span class="hub-hero__aside-pill">Modos de jogo</span>
+                <aside class="hub-hero__modes" aria-labelledby="game-modes-heading">
+                        <header class="hub-hero__modes-header">
+                                <span class="hub-hero__aside-pill">Experiências de jogo</span>
                                 <h2 class="hub-hero__aside-title" id="game-modes-heading">
-                                        Escolha como quer jogar hoje
+                                        Escolha o formato ideal para hoje
                                 </h2>
                                 <p class="hub-hero__aside-subtitle">
-                                        Combine regras, limite de tempo e objetivos especiais para transformar seus estudos em missões épicas.
+                                        Combine ritmo, objetivos e interação para transformar seu estudo em missões épicas.
                                 </p>
+                                <div class="mode-pills" role="list" aria-label="Categorias de modo">
+                                        <span class="mode-pill" role="listitem">
+                                                <span class="material-symbols-outlined">auto_awesome</span>
+                                                Solo estratégico
+                                        </span>
+                                        <span class="mode-pill" role="listitem">
+                                                <span class="material-symbols-outlined">groups</span>
+                                                Colaborativo
+                                        </span>
+                                        <span class="mode-pill" role="listitem">
+                                                <span class="material-symbols-outlined">emoji_events</span>
+                                                Competitivo
+                                        </span>
+                                </div>
                         </header>
-                        <div class="game-modes-grid">
-                                <a
-                                        href="{% url 'quiz:questions' %}?modo=classico"
-                                        class="game-mode-card"
-                                        data-mode="classico"
-                                >
-                                        <span class="material-symbols-outlined game-mode-card__icon">auto_stories</span>
-                                        <div class="game-mode-card__body">
-                                                <div class="game-mode-card__header">
-                                                        <h3 class="game-mode-card__title">Clássico</h3>
-                                                        <span class="game-mode-card__chip">Recomendado</span>
-                                                </div>
-                                                <p class="game-mode-card__description">
-                                                        Responda no seu ritmo, com feedback completo e curadoria inteligente de questões.
-                                                </p>
-                                                <ul class="game-mode-card__meta">
-                                                        <li><span class="material-symbols-outlined">schedule</span>15 questões</li>
-                                                        <li><span class="material-symbols-outlined">workspace_premium</span>Multiplica pontos</li>
-                                                </ul>
+
+                        <div class="mode-area" aria-labelledby="solo-modes-heading">
+                                <div class="mode-area__header">
+                                        <span class="material-symbols-outlined mode-area__icon">person_play</span>
+                                        <div>
+                                                <h3 class="mode-area__title" id="solo-modes-heading">Sessões solo otimizadas</h3>
+                                                <p class="mode-area__description">Escolha o foco da sessão e deixe o algoritmo calibrar a curva de dificuldade.</p>
                                         </div>
-                                </a>
-                                <a
-                                        href="{% url 'quiz:questions' %}?modo=sprint"
-                                        class="game-mode-card"
-                                        data-mode="sprint"
-                                >
-                                        <span class="material-symbols-outlined game-mode-card__icon">speed</span>
-                                        <div class="game-mode-card__body">
-                                                <div class="game-mode-card__header">
-                                                        <h3 class="game-mode-card__title">Sprint</h3>
-                                                        <span class="game-mode-card__chip game-mode-card__chip--accent">Novo</span>
-                                                </div>
-                                                <p class="game-mode-card__description">
-                                                        Corridas contra o tempo com boosters de combo e checkpoints estratégicos.
-                                                </p>
-                                                <ul class="game-mode-card__meta">
-                                                        <li><span class="material-symbols-outlined">timer</span>2 min por questão</li>
-                                                        <li><span class="material-symbols-outlined">bolt</span>Power-ups em cadeia</li>
+                                </div>
+                                <div class="mode-area__grid">
+                                        <a href="{% url 'quiz:questions' %}?modo=classico" class="mode-card" data-mode="classico">
+                                                <span class="mode-card__header">
+                                                        <span class="material-symbols-outlined mode-card__icon">auto_stories</span>
+                                                        <span class="mode-card__meta">Curadoria dinâmica</span>
+                                                </span>
+                                                <h4 class="mode-card__title">Modo Clássico</h4>
+                                                <p class="mode-card__description">Feedback completo, ritmo flexível e reforço inteligente entre temas.</p>
+                                                <ul class="mode-card__tags">
+                                                        <li>15 questões</li>
+                                                        <li>Multiplicador de pontos</li>
                                                 </ul>
-                                        </div>
-                                </a>
-                                <a
-                                        href="{% url 'quiz:questions' %}?modo=maratona"
-                                        class="game-mode-card"
-                                        data-mode="maratona"
-                                >
-                                        <span class="material-symbols-outlined game-mode-card__icon">track_changes</span>
-                                        <div class="game-mode-card__body">
-                                                <div class="game-mode-card__header">
-                                                        <h3 class="game-mode-card__title">Maratona</h3>
-                                                        <span class="game-mode-card__chip">Alta resistência</span>
-                                                </div>
-                                                <p class="game-mode-card__description">
-                                                        Sessões longas com checkpoints, metas intermediárias e resumo estratégico.
-                                                </p>
-                                                <ul class="game-mode-card__meta">
-                                                        <li><span class="material-symbols-outlined">flag</span>Objetivos personalizáveis</li>
-                                                        <li><span class="material-symbols-outlined">insights</span>Relatório avançado</li>
+                                        </a>
+                                        <a href="{% url 'quiz:questions' %}?modo=sprint" class="mode-card mode-card--accent" data-mode="sprint">
+                                                <span class="mode-card__header">
+                                                        <span class="material-symbols-outlined mode-card__icon">speed</span>
+                                                        <span class="mode-card__meta">Alta intensidade</span>
+                                                </span>
+                                                <h4 class="mode-card__title">Sprint Relâmpago</h4>
+                                                <p class="mode-card__description">Corridas contra o tempo com boosters de combo e checkpoints estratégicos.</p>
+                                                <ul class="mode-card__tags">
+                                                        <li>2 min por questão</li>
+                                                        <li>Power-ups de streak</li>
                                                 </ul>
+                                        </a>
+                                </div>
+                        </div>
+
+                        <div class="mode-area" aria-labelledby="advanced-modes-heading">
+                                <div class="mode-area__header">
+                                        <span class="material-symbols-outlined mode-area__icon">hub</span>
+                                        <div>
+                                                <h3 class="mode-area__title" id="advanced-modes-heading">Experiências avançadas</h3>
+                                                <p class="mode-area__description">Ideal para aprofundar conhecimento com metas de longo prazo e relatórios detalhados.</p>
                                         </div>
-                                </a>
-                                <a
-                                        href="{% url 'quiz:questions' %}?modo=estudo"
-                                        class="game-mode-card game-mode-card--ghost"
-                                        data-mode="estudo"
-                                        id="view-all-questions-alt-link"
-                                >
-                                        <span class="material-symbols-outlined game-mode-card__icon">menu_book</span>
-                                        <div class="game-mode-card__body">
-                                                <div class="game-mode-card__header">
-                                                        <h3 class="game-mode-card__title">Estudo livre</h3>
-                                                        <span class="game-mode-card__chip">Catálogo completo</span>
-                                                </div>
-                                                <p class="game-mode-card__description">
-                                                        Explore todo o banco de questões, filtre por temas e acompanhe seus favoritos.
-                                                </p>
-                                                <ul class="game-mode-card__meta">
-                                                        <li><span class="material-symbols-outlined">filter_alt</span>Filtros avançados</li>
-                                                        <li><span class="material-symbols-outlined">bookmarks</span>Salvar coleções</li>
+                                </div>
+                                <div class="mode-area__grid">
+                                        <a href="{% url 'quiz:questions' %}?modo=maratona" class="mode-card" data-mode="maratona">
+                                                <span class="mode-card__header">
+                                                        <span class="material-symbols-outlined mode-card__icon">track_changes</span>
+                                                        <span class="mode-card__meta">Resistência</span>
+                                                </span>
+                                                <h4 class="mode-card__title">Maratona Estratégica</h4>
+                                                <p class="mode-card__description">Sessões longas com checkpoints configuráveis e resumo avançado de desempenho.</p>
+                                                <ul class="mode-card__tags">
+                                                        <li>Objetivos personalizáveis</li>
+                                                        <li>Insights pós-jogo</li>
                                                 </ul>
+                                        </a>
+                                        <a href="{% url 'quiz:questions' %}?modo=estudo" class="mode-card mode-card--ghost" data-mode="estudo" id="view-all-questions-alt-link">
+                                                <span class="mode-card__header">
+                                                        <span class="material-symbols-outlined mode-card__icon">menu_book</span>
+                                                        <span class="mode-card__meta">Catálogo total</span>
+                                                </span>
+                                                <h4 class="mode-card__title">Estudo Livre</h4>
+                                                <p class="mode-card__description">Explore todo o banco, use filtros avançados e salve coleções temáticas.</p>
+                                                <ul class="mode-card__tags">
+                                                        <li>Filtros avançados</li>
+                                                        <li>Favoritos &amp; marcadores</li>
+                                                </ul>
+                                        </a>
+                                </div>
+                        </div>
+
+                        <div class="mode-area" aria-labelledby="social-modes-heading">
+                                <div class="mode-area__header">
+                                        <span class="material-symbols-outlined mode-area__icon">groups_3</span>
+                                        <div>
+                                                <h3 class="mode-card__title mode-area__title" id="social-modes-heading">Jogos sociais e competitivos</h3>
+                                                <p class="mode-area__description">Perfeito para squad, desafios semanais e temporadas ranqueadas com recompensas.</p>
                                         </div>
-                                </a>
+                                </div>
+                                <div class="mode-area__grid mode-area__grid--stretch">
+                                        <a href="{% url 'quiz:questions' %}?modo=classico&partida=dupla" class="mode-card" data-mode="duo">
+                                                <span class="mode-card__header">
+                                                        <span class="material-symbols-outlined mode-card__icon">diversity_2</span>
+                                                        <span class="mode-card__meta">Sincronização</span>
+                                                </span>
+                                                <h4 class="mode-card__title">Dupla Tática</h4>
+                                                <p class="mode-card__description">Monte duplas, defina temas compartilhados e receba briefing conjunto ao final.</p>
+                                                <ul class="mode-card__tags">
+                                                        <li>Matchmaking amigo</li>
+                                                        <li>Resumo colaborativo</li>
+                                                </ul>
+                                        </a>
+                                        <a href="{% url 'quiz:questions' %}?modo=sprint&evento=arena" class="mode-card mode-card--accent" data-mode="arena">
+                                                <span class="mode-card__header">
+                                                        <span class="material-symbols-outlined mode-card__icon">stadium</span>
+                                                        <span class="mode-card__meta">Rankeado</span>
+                                                </span>
+                                                <h4 class="mode-card__title">Arena Competitiva</h4>
+                                                <p class="mode-card__description">Partidas rápidas com placar global, boosts sazonais e conquistas exclusivas.</p>
+                                                <ul class="mode-card__tags">
+                                                        <li>Temporadas mensais</li>
+                                                        <li>Recompensas lendárias</li>
+                                                </ul>
+                                        </a>
+                                        <a href="{% url 'quiz:questions' %}?modo=maratona&evento=raid" class="mode-card" data-mode="raid">
+                                                <span class="mode-card__header">
+                                                        <span class="material-symbols-outlined mode-card__icon">diversity_3</span>
+                                                        <span class="mode-card__meta">Coop Squad</span>
+                                                </span>
+                                                <h4 class="mode-card__title">Raid Colaborativo</h4>
+                                                <p class="mode-card__description">Monte squads, distribua roles e avance por fases progressivas para derrotar o boss clínico.</p>
+                                                <ul class="mode-card__tags">
+                                                        <li>Checkpoints por fase</li>
+                                                        <li>Liderança compartilhada</li>
+                                                </ul>
+                                        </a>
+                                </div>
                         </div>
                 </aside>
         </div>


### PR DESCRIPTION
## Summary
- redesenhei o bloco principal do Challenge Hub com cabeçalho, destaques e atalhos rápidos para modos sugeridos
- estruturei novos grupos de modos (solo, avançado e social) com cartões responsivos que acomodam mais estilos de jogo
- atualizei o CSS do componente para refletir o novo layout, mantendo o visual moderno alinhado à identidade do site

## Testing
- python manage.py check *(falhou: dependência Django não disponível no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68d73cdb59c88333bca1728304917c41