### PR TITLE
feat: redesign challenge hub with new game modes

### DIFF
--- a/assets/css/components/challenge-hub.css
+++ b/assets/css/components/challenge-hub.css
@@ -1,60 +1,502 @@
-/* assets/css/components/challenge-hub.css (Refatoração Completa v3) */
+/* assets/css/components/challenge-hub.css (Modern Challenge Hub 2024) */
 
-/* Container Principal do Hub */
+/* ----------------------------- */
+/* Novo layout do Challenge Hub */
+/* ----------------------------- */
+
 .challenge-hub {
+    position: relative;
+    overflow: hidden;
+    width: min(1120px, 100%);
+    margin: clamp(12px, 3vw, 32px) auto;
+    padding: clamp(24px, 4vw, 42px);
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-lg, 25px);
-    width: 100%;
-    max-width: 820px;
-    margin: var(--spacing-xl, 30px) auto;
-    padding: clamp(40px, 7vh, 55px) var(--spacing-lg, 30px);
-    background-color: var(--color-gray-100);
-    border-radius: var(--border-radius-lg);
-    box-shadow: var(--shadow-md);
+    gap: clamp(24px, 3vw, 36px);
+    border-radius: var(--border-radius-xl, 20px);
+    border: 1px solid rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.14);
+    background: linear-gradient(135deg,
+        rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.12) 0%,
+        rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.06) 46%,
+        rgba(255, 255, 255, 0.94) 100%);
+    box-shadow: 0 28px 64px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.15);
+    backdrop-filter: blur(6px);
+    color: var(--color-text-primary);
 }
 
-.challenge-hub__header {
-    text-align: center;
-    margin-bottom: var(--spacing-md, 20px);
+.challenge-hub::before {
+    content: "";
+    position: absolute;
+    inset: -35% -25% 10% 45%;
+    background: radial-gradient(
+        circle at top right,
+        rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.28) 0%,
+        rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0) 65%
+    );
+    opacity: 0.9;
+    pointer-events: none;
+}
+
+.challenge-hub > * {
+    position: relative;
+    z-index: 1;
+}
+
+.challenge-hub__hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1.45fr) minmax(0, 1fr);
+    gap: clamp(24px, 3vw, 40px);
+    align-items: stretch;
+}
+
+.challenge-hub__intro {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(16px, 2.4vw, 20px);
+}
+
+.challenge-hub__eyebrow {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-secondary-green, #2a9d8f);
 }
 
 .challenge-hub__title {
+    margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(1.8rem, 4.5vw, 2.2rem);
-    color: var(--color-primary-dark);
-    font-weight: var(--font-weight-bold);
-    margin-top: 0;
-    margin-bottom: var(--spacing-xs, 8px);
+    font-size: clamp(1.9rem, 4.6vw, 2.4rem);
+    line-height: 1.18;
+    color: var(--color-primary-dark, #0d3b66);
 }
 
 .challenge-hub__subtitle {
-    font-family: var(--font-family-sans);
-    font-size: clamp(0.95rem, 2.5vw, 1.1rem);
-    color: var(--color-text-secondary);
     margin: 0;
-    font-weight: var(--font-weight-normal);
+    font-size: clamp(1rem, 2.2vw, 1.15rem);
+    line-height: 1.5;
+    color: var(--color-text-secondary);
+    max-width: 58ch;
 }
 
-/* Grade de Opções */
-.challenge-hub__options-grid {
+.challenge-hub__cta-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-md, 20px);
+}
+
+.challenge-hub__cta {
+    flex: 1 1 260px;
+    justify-content: flex-start;
+    align-items: flex-start;
+    gap: var(--spacing-sm, 14px);
+    padding: clamp(14px, 2.6vw, 20px) clamp(18px, 3vw, 24px);
+    text-align: left;
+    transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.challenge-hub__cta:hover {
+    transform: translateY(-3px);
+}
+
+.challenge-hub__cta-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border-radius: var(--border-radius-circle);
+    background: rgba(255, 255, 255, 0.2);
+    color: var(--color-secondary-green, #2a9d8f);
+    font-size: 1.8rem;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3);
+}
+
+.challenge-hub__cta-content {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    align-items: flex-start;
+}
+
+.challenge-hub__cta-title {
+    font-size: 1.05rem;
+    font-weight: var(--font-weight-semibold);
+}
+
+.challenge-hub__cta-subtitle {
+    font-size: 0.9rem;
+    color: rgba(255, 255, 255, 0.85);
+    max-width: 32ch;
+}
+
+.button--secondary.challenge-hub__cta {
+    background: linear-gradient(135deg, rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.14), rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.28));
+    color: var(--color-primary-dark);
+    border: 1px solid rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.2);
+    box-shadow: 0 12px 32px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.16);
+}
+
+.button--secondary.challenge-hub__cta .challenge-hub__cta-icon {
+    background: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.12);
+    color: var(--color-primary-dark);
+    box-shadow: none;
+}
+
+.button--secondary.challenge-hub__cta .challenge-hub__cta-subtitle {
+    color: var(--color-primary-dark);
+    opacity: 0.76;
+}
+
+.challenge-hub__summary-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md, 20px);
+    padding: clamp(22px, 3vw, 28px);
+    border-radius: var(--border-radius-xl, 20px);
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.12);
+    box-shadow: 0 24px 48px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.12);
+    backdrop-filter: blur(4px);
+    color: var(--color-text-primary);
+}
+
+.challenge-hub__summary-title {
+    margin: 0;
+    font-size: 1.05rem;
+    font-family: var(--font-family-heading);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
+}
+
+.challenge-hub__summary-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm, 16px);
+}
+
+.challenge-hub__summary-item {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--spacing-sm, 16px);
+}
+
+.challenge-hub__summary-icon {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 46px;
+    height: 46px;
+    border-radius: var(--border-radius-circle);
+    background: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.1);
+    color: var(--color-primary-dark);
+    font-size: 1.6rem;
+}
+
+.challenge-hub__summary-text {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.challenge-hub__summary-label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-secondary-green, #2a9d8f);
+}
+
+.challenge-hub__summary-value {
+    font-size: 0.95rem;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+}
+
+/* ------------------------- */
+/* Card de continuação (CTA) */
+/* ------------------------- */
+
+.hub-resume-card {
     display: grid;
-    grid-template-columns: 1fr;
-    gap: var(--spacing-lg, 25px);
-    width: 100%;
+    grid-template-columns: auto 1fr auto;
+    gap: var(--spacing-lg, 24px);
+    align-items: center;
+    padding: clamp(20px, 3vw, 26px);
+    border-radius: var(--border-radius-xl, 20px);
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.35);
+    box-shadow: 0 24px 48px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.14);
 }
 
-@media (min-width: 768px) {
-    .challenge-hub__options-grid {
-        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+.hub-resume-card__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 60px;
+    height: 60px;
+    border-radius: var(--border-radius-circle);
+    background: linear-gradient(135deg, var(--color-primary-dark, #0d3b66), rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.75));
+    color: var(--color-white);
+    font-size: 2rem;
+}
+
+.hub-resume-card__content {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.hub-resume-card__eyebrow {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: var(--color-secondary-green, #2a9d8f);
+    font-weight: var(--font-weight-semibold);
+}
+
+.hub-resume-card__title {
+    margin: 0;
+    font-size: 1.3rem;
+    font-family: var(--font-family-heading);
+    color: var(--color-primary-dark);
+}
+
+.hub-resume-card__description {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--color-text-secondary);
+}
+
+.hub-resume-card__actions {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs, 10px);
+    align-items: flex-end;
+}
+
+.hub-resume-card__actions .button {
+    width: max-content;
+    min-width: 140px;
+}
+
+/* --------------------------- */
+/* Grade de modos de desafio   */
+/* --------------------------- */
+
+.challenge-hub__mode-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: clamp(20px, 2.8vw, 28px);
+}
+
+.hub-mode-card {
+    position: relative;
+    overflow: hidden;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    column-gap: var(--spacing-md, 20px);
+    row-gap: var(--spacing-xs, 8px);
+    align-items: flex-start;
+    padding: clamp(22px, 3vw, 28px);
+    border-radius: var(--border-radius-xl, 20px);
+    border: 1px solid rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.14);
+    background: rgba(255, 255, 255, 0.96);
+    color: var(--color-text-primary);
+    text-align: left;
+    cursor: pointer;
+    transition: transform var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast);
+    box-shadow: 0 22px 48px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.12);
+}
+
+.hub-mode-card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg,
+        rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.2) 0%,
+        rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.05) 55%,
+        transparent 70%);
+    opacity: 0;
+    transition: opacity var(--transition-fast);
+    pointer-events: none;
+}
+
+.hub-mode-card:hover,
+.hub-mode-card:focus-visible {
+    transform: translateY(-6px);
+    border-color: rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.55);
+    box-shadow: 0 28px 60px rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.18);
+}
+
+.hub-mode-card:hover::after,
+.hub-mode-card:focus-visible::after {
+    opacity: 1;
+}
+
+.hub-mode-card:focus-visible {
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline-offset: var(--focus-outline-offset);
+}
+
+.hub-mode-card__icon {
+    grid-row: 1 / span 2;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 52px;
+    height: 52px;
+    border-radius: var(--border-radius-circle);
+    background: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.12);
+    color: var(--color-primary-dark);
+    font-size: 1.9rem;
+    z-index: 1;
+}
+
+.hub-mode-card__content {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    z-index: 1;
+}
+
+.hub-mode-card__eyebrow {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-secondary-green, #2a9d8f);
+}
+
+.hub-mode-card__title {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: 1.25rem;
+    color: var(--color-primary-dark);
+}
+
+.hub-mode-card__description {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.55;
+    color: var(--color-text-secondary);
+}
+
+.hub-mode-card__meta {
+    align-self: end;
+    justify-self: end;
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-size: 0.82rem;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
+    background: rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.18);
+    z-index: 1;
+}
+
+.hub-mode-card--highlight {
+    border-color: rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.55);
+    box-shadow: 0 32px 70px rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.25);
+}
+
+.hub-mode-card--highlight .hub-mode-card__icon {
+    background: rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.25);
+    color: var(--color-primary-dark);
+}
+
+.hub-mode-card--highlight .hub-mode-card__meta {
+    background: rgba(var(--color-primary-dark-rgb, 13, 59, 102), 0.14);
+    color: var(--color-primary-dark);
+}
+
+/* --------------------------- */
+/* Responsividade              */
+/* --------------------------- */
+
+@media (max-width: 1024px) {
+    .challenge-hub {
+        padding: clamp(24px, 6vw, 36px);
+    }
+
+    .challenge-hub__hero {
+        grid-template-columns: 1fr;
+    }
+
+    .challenge-hub__summary-card {
+        order: -1;
     }
 }
 
-/* ========================================================================== */
-/* == REGRAS DE CARD (BASE E VARIANTES) - REFAFORADO COM FLEXBOX ANINHADO == */
-/* ========================================================================== */
+@media (max-width: 768px) {
+    .challenge-hub {
+        margin: clamp(8px, 3vw, 20px) auto;
+    }
 
-/* Base para todos os cards de desafio */
+    .challenge-hub__cta-group {
+        flex-direction: column;
+    }
+
+    .challenge-hub__cta {
+        width: 100%;
+    }
+
+    .hub-resume-card {
+        grid-template-columns: 1fr;
+        text-align: left;
+    }
+
+    .hub-resume-card__actions {
+        flex-direction: row;
+        justify-content: flex-start;
+        align-items: center;
+    }
+
+    .hub-resume-card__actions .button {
+        width: auto;
+        min-width: 0;
+    }
+
+    .challenge-hub__mode-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 520px) {
+    .challenge-hub__subtitle {
+        font-size: 0.98rem;
+    }
+
+    .hub-mode-card {
+        grid-template-columns: 1fr;
+    }
+
+    .hub-mode-card__icon {
+        width: 46px;
+        height: 46px;
+        font-size: 1.6rem;
+    }
+
+    .hub-mode-card__meta {
+        justify-self: flex-start;
+        margin-top: var(--spacing-sm, 12px);
+    }
+
+    .hub-resume-card__icon {
+        width: 52px;
+        height: 52px;
+        font-size: 1.6rem;
+    }
+}
+
+/* ----------------------------------------------------------- */
+/* Estilos herdados para .challenge-card utilizados em outras  */
+/* áreas (Gamification Dashboard, etc.). Mantidos para suporte */
+/* ----------------------------------------------------------- */
+
 .challenge-card {
     background-color: var(--color-white);
     border: var(--border-width) solid var(--color-gray-300);
@@ -65,28 +507,25 @@
     color: inherit;
     text-decoration: none;
     transition: transform var(--transition-fast), box-shadow var(--transition-fast);
-
-    /* --- Layout Base (para cards simples como "Personalizar" e "Quiz Rápido") --- */
     display: flex;
-    align-items: center; /* Centraliza verticalmente ícone e conteúdo */
+    align-items: center;
     gap: var(--spacing-md, 20px);
 }
 
-/* Efeito de hover para cards clicáveis */
 .challenge-card:not(.challenge-card--resume):hover,
 .challenge-card:not(.challenge-card--resume):focus-visible {
     transform: translateY(-3px);
     box-shadow: var(--shadow-lg);
     border-color: var(--color-primary-medium);
 }
+
 .challenge-card:focus-visible {
     outline: var(--focus-outline-width) solid var(--focus-outline-color);
     outline-offset: var(--focus-outline-offset);
 }
 
-/* Ícone */
 .challenge-card__icon-wrapper {
-    flex-shrink: 0; /* Impede que o ícone seja esmagado */
+    flex-shrink: 0;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -101,9 +540,8 @@
     display: block;
 }
 
-/* Conteúdo (Título e Descrição) */
 .challenge-card__content {
-    flex-grow: 1; /* Permite que a área de conteúdo cresça */
+    flex-grow: 1;
 }
 
 .challenge-card__title {
@@ -124,38 +562,35 @@
     overflow-wrap: break-word;
 }
 
-/* --- Variante de Card de Resumo (layout mais complexo) --- */
 .challenge-card--resume {
     cursor: default;
     background-color: var(--color-primary-xlight);
     border-color: var(--color-primary-medium);
-    grid-column: 1 / -1; /* Ocupa a largura toda da grade */
+    grid-column: 1 / -1;
 }
 
-/* Novo container principal que agrupa conteúdo e ações */
 .challenge-card__main {
     flex-grow: 1;
     display: flex;
     flex-direction: column;
-    justify-content: space-between; /* Garante que as ações fiquem no fundo */
-    min-height: 90px; /* Altura mínima para garantir alinhamento em textos curtos */
+    justify-content: space-between;
+    min-height: 90px;
 }
 
-/* Ações (botões) */
 .challenge-card__actions {
     display: flex;
-    justify-content: flex-end; /* Alinha botões à direita */
+    justify-content: flex-end;
     align-items: center;
     gap: var(--spacing-sm, 12px);
-    margin-top: var(--spacing-md, 20px); /* Espaço entre a descrição e os botões */
+    margin-top: var(--spacing-md, 20px);
 }
 
-/* --- Outras Variantes --- */
 .challenge-card--disabled {
     background-color: var(--color-gray-200);
     cursor: not-allowed;
     opacity: 0.7;
 }
+
 .challenge-card--disabled:hover,
 .challenge-card--disabled:focus-visible {
     transform: none;
@@ -163,31 +598,34 @@
     border-color: var(--color-gray-300);
 }
 
-/* Responsividade */
 @media (max-width: 480px) {
-    .challenge-card, .challenge-card--resume {
+    .challenge-card,
+    .challenge-card--resume {
         padding: var(--spacing-md, 20px);
         gap: var(--spacing-sm, 15px);
     }
+
     .challenge-card__title {
         font-size: 1.15rem;
     }
+
     .challenge-card__icon-wrapper {
         padding: var(--spacing-xs, 10px);
     }
+
     .challenge-card__icon {
         font-size: 1.8rem;
     }
-    .challenge-hub {
-        padding: var(--spacing-lg, 25px) var(--spacing-sm, 15px);
-    }
+
     .challenge-card__main {
         min-height: auto;
     }
+
     .challenge-card__actions {
         flex-direction: column;
-        align-items: stretch; /* Faz botões ocuparem 100% da largura */
+        align-items: stretch;
     }
+
     .challenge-card__actions .button {
         width: 100%;
     }

--- a/assets/js/app/App.js
+++ b/assets/js/app/App.js
@@ -125,9 +125,7 @@ export default class App {
             const challengeHub = new ChallengeHub(this.quizUI);
             challengeHub.setActionOrchestrator(this.actionOrchestrator);
             this.quizUI.setChallengeHubInstance(challengeHub);
-            const totalQuestions = typeof state.geral.totalQuestionsAvailable === 'number'
-                ? state.geral.totalQuestionsAvailable.toLocaleString('pt-BR')
-                : state.geral.totalQuestionsAvailable;
+            const totalQuestions = state.geral.totalQuestionsAvailable;
             challengeHub.updateTotalQuestionsCount(totalQuestions);
             const quickQuizCount = state.geral.homeSummary?.quickQuizDefaultCount ?? QUICK_QUIZ_COUNT;
             challengeHub.updateQuickQuizCount(quickQuizCount);
@@ -156,7 +154,8 @@ export default class App {
         this._ensureActiveSection(initialSectionId);
 
         if (initialSectionId === 'home') {
-            const totalQuestionsSpanHome = document.getElementById('hub-total-questions-count');
+            const totalQuestionsSpanHome = document.querySelector('#home-section #hub-total-questions-count')
+                || document.getElementById('hub-total-questions-count');
             if (totalQuestionsSpanHome) {
                 const state = this.store.getState();
                 const totalQuestions = state.geral.totalQuestionsAvailable;

--- a/assets/js/app/flux/ActionOrchestrator.js
+++ b/assets/js/app/flux/ActionOrchestrator.js
@@ -339,6 +339,37 @@ export default class ActionOrchestrator {
         await this._fetchAndInitiateQuiz({ mode: 'Rápido' });
     }
 
+    async startWarmupQuiz() {
+        await this._fetchAndInitiateQuiz({
+            mode: 'Rápido',
+            count: 5,
+            difficulty_levels: ['fácil', 'médio'],
+        });
+    }
+
+    async startFocusedQuiz() {
+        await this._fetchAndInitiateQuiz({
+            mode: 'Rápido',
+            count: 15,
+            difficulty_levels: ['médio', 'difícil'],
+        });
+    }
+
+    async startMarathonQuiz() {
+        await this._fetchAndInitiateQuiz({
+            mode: 'Rápido',
+            count: 30,
+        });
+    }
+
+    async startHardcoreQuiz() {
+        await this._fetchAndInitiateQuiz({
+            mode: 'Rápido',
+            count: 12,
+            difficulty_levels: ['difícil'],
+        });
+    }
+
     async startPredefinedQuiz(quizDefinicaoId) {
         await this._fetchAndInitiateQuiz({ quiz_definicao_id: quizDefinicaoId, mode: 'Definido' });
     }

--- a/assets/js/ui/ChallengeHub.js
+++ b/assets/js/ui/ChallengeHub.js
@@ -18,9 +18,14 @@ export default class ChallengeHub {
             hubQuickQuizBtn: this.quizUI.elements.hubQuickQuizBtn,
             hubTotalQuestionsCount: this.quizUI.elements.hubTotalQuestionsCount,
             hubQuickQuizCount: this.quizUI.elements.hubQuickQuizCount,
+            hubTotalQuestionsCountSummary: document.getElementById('hub-total-questions-count-summary'),
+            hubWarmupQuizBtn: document.getElementById('hub-warmup-quiz-btn'),
+            hubFocusedQuizBtn: document.getElementById('hub-focused-quiz-btn'),
+            hubMarathonQuizBtn: document.getElementById('hub-marathon-quiz-btn'),
+            hubHardcoreQuizBtn: document.getElementById('hub-hardcore-quiz-btn'),
             placeholderFiltrosContainer: this.quizUI.elements.placeholderFiltrosContainer,
             closeFiltersAndShowHubBtn: this.quizUI.elements.closeFiltersAndShowHubBtn,
-            
+
             // --- INÍCIO DA CORREÇÃO: Mapeando para os novos IDs e estrutura ---
             resumeCard: document.getElementById('hub-resume-quiz-card'),
             resumeCardDescription: document.getElementById('hub-resume-card-description'),
@@ -77,13 +82,32 @@ export default class ChallengeHub {
      * @param {number|string} count - O número de questões.
      */
     updateTotalQuestionsCount(count) {
-        if (this.elements.hubTotalQuestionsCount) {
-            this.elements.hubTotalQuestionsCount.textContent = count || '0';
+        let formattedCount = '0';
+
+        if (typeof count === 'number' && Number.isFinite(count)) {
+            formattedCount = count.toLocaleString('pt-BR');
+        } else if (typeof count === 'string') {
+            const trimmed = count.trim();
+            if (trimmed.length > 0) {
+                const normalized = trimmed.replace(/\./g, '').replace(',', '.');
+                const numericCount = Number(normalized);
+                formattedCount = Number.isFinite(numericCount)
+                    ? numericCount.toLocaleString('pt-BR')
+                    : trimmed;
+            }
         }
-        
-        const totalQuestionsSpanHome = document.getElementById('hub-total-questions-count');
+
+        if (this.elements.hubTotalQuestionsCount) {
+            this.elements.hubTotalQuestionsCount.textContent = formattedCount;
+        }
+
+        if (this.elements.hubTotalQuestionsCountSummary) {
+            this.elements.hubTotalQuestionsCountSummary.textContent = formattedCount;
+        }
+
+        const totalQuestionsSpanHome = document.querySelector('#home-section #hub-total-questions-count');
         if (totalQuestionsSpanHome && totalQuestionsSpanHome !== this.elements.hubTotalQuestionsCount) {
-            totalQuestionsSpanHome.textContent = count || '0';
+            totalQuestionsSpanHome.textContent = formattedCount;
         }
     }
 
@@ -143,7 +167,35 @@ export default class ChallengeHub {
                 console.error("ChallengeHub: actionOrchestrator indisponível ao clicar em Quiz Rápido.");
             }
         });
-        
+
+        this.elements.hubWarmupQuizBtn?.addEventListener('click', () => {
+            if (this.actionOrchestrator) {
+                this.hideHub();
+                this.actionOrchestrator.startWarmupQuiz();
+            }
+        });
+
+        this.elements.hubFocusedQuizBtn?.addEventListener('click', () => {
+            if (this.actionOrchestrator) {
+                this.hideHub();
+                this.actionOrchestrator.startFocusedQuiz();
+            }
+        });
+
+        this.elements.hubMarathonQuizBtn?.addEventListener('click', () => {
+            if (this.actionOrchestrator) {
+                this.hideHub();
+                this.actionOrchestrator.startMarathonQuiz();
+            }
+        });
+
+        this.elements.hubHardcoreQuizBtn?.addEventListener('click', () => {
+            if (this.actionOrchestrator) {
+                this.hideHub();
+                this.actionOrchestrator.startHardcoreQuiz();
+            }
+        });
+
         // --- INÍCIO DA CORREÇÃO: Listeners agora nos botões corretos e separados ---
         this.elements.confirmResumeBtn?.addEventListener('click', () => {
              if (this.actionOrchestrator) {

--- a/assets/js/ui/QuizUI.js
+++ b/assets/js/ui/QuizUI.js
@@ -225,7 +225,8 @@ export default class QuizUI {
             btnTogglePauseLabel: document.getElementById('btn-toggle-pausa-label'),
             btnTogglePauseIcon: document.getElementById('btn-toggle-pausa-icon'),
             challengeHubContainer: document.getElementById('challenge-hub-container'),
-            hubTotalQuestionsCount: document.getElementById('hub-total-questions-count'),
+            hubTotalQuestionsCount: document.querySelector('#challenge-hub-container #hub-total-questions-count')
+                || document.getElementById('hub-total-questions-count'),
             hubQuickQuizCount: document.getElementById('hub-quick-quiz-count'),
             hubCustomizeQuizBtn: document.getElementById('hub-customize-quiz-btn'),
             hubQuickQuizBtn: document.getElementById('hub-quick-quiz-btn'),

--- a/quiz/templates/quiz/questions_page.html
+++ b/quiz/templates/quiz/questions_page.html
@@ -63,51 +63,114 @@
         <div class="question-section__main-content">
             
             <div id="challenge-hub-container" class="challenge-hub">
-                <div class="challenge-hub__header">
-                    <h2 class="challenge-hub__title">Escolha seu Desafio</h2>
-                    <p class="challenge-hub__subtitle">Explore nosso banco de <span id="hub-total-questions-count">0</span> questões.</p>
-                </div>
-                <div class="challenge-hub__options-grid">
-                    
-                    {# ========================================================================== #}
-                    {# ============ CARD DE RESUMO REFAFORADO (COM HTML MELHORADO) ============ #}
-                    {# ========================================================================== #}
-                    <div id="hub-resume-quiz-card" class="challenge-card challenge-card--resume u-is-hidden">
-                        <div class="challenge-card__icon-wrapper">
-                            <span class="material-symbols-outlined challenge-card__icon">play_arrow</span>
-                        </div>
-                        <div class="challenge-card__main">
-                            <div class="challenge-card__content">
-                                <h3 class="challenge-card__title">Continuar Desafio</h3>
-                                <p class="challenge-card__description" id="hub-resume-card-description">
-                                    Você tem uma sessão em andamento.
-                                </p>
-                            </div>
-                            <div class="challenge-card__actions">
-                                <button id="hub-discard-resume-btn" class="button button--text button--compact">Descartar</button>
-                                <button id="hub-confirm-resume-btn" class="button button--primary button--small">Continuar</button>
-                            </div>
+                <section class="challenge-hub__hero" aria-labelledby="challenge-hub-title">
+                    <div class="challenge-hub__intro">
+                        <span class="challenge-hub__eyebrow">Challenge Hub</span>
+                        <h2 id="challenge-hub-title" class="challenge-hub__title">Escolha como quer treinar hoje</h2>
+                        <p class="challenge-hub__subtitle">
+                            Explore nosso banco de <span id="hub-total-questions-count">0</span> questões e encontre o modo perfeito para o seu momento de estudo.
+                        </p>
+                        <div class="challenge-hub__cta-group">
+                            <button id="hub-quick-quiz-btn" type="button" class="button button--primary challenge-hub__cta">
+                                <span class="material-symbols-outlined challenge-hub__cta-icon" aria-hidden="true">bolt</span>
+                                <span class="challenge-hub__cta-content">
+                                    <span class="challenge-hub__cta-title">Iniciar Quiz Rápido</span>
+                                    <span class="challenge-hub__cta-subtitle">Comece agora com <span id="hub-quick-quiz-count">10</span> questões aleatórias.</span>
+                                </span>
+                            </button>
+                            <button id="hub-customize-quiz-btn" type="button" class="button button--secondary challenge-hub__cta">
+                                <span class="material-symbols-outlined challenge-hub__cta-icon" aria-hidden="true">tune</span>
+                                <span class="challenge-hub__cta-content">
+                                    <span class="challenge-hub__cta-title">Montar estudo personalizado</span>
+                                    <span class="challenge-hub__cta-subtitle">Defina categorias, níveis e o ritmo ideal para você.</span>
+                                </span>
+                            </button>
                         </div>
                     </div>
-                    {# ======================= FIM DA REFAFORAÇÃO DO CARD ====================== #}
+                    <div class="challenge-hub__summary-card" aria-label="Resumo do challenge hub">
+                        <h3 class="challenge-hub__summary-title">Painel rápido</h3>
+                        <ul class="challenge-hub__summary-list">
+                            <li class="challenge-hub__summary-item">
+                                <span class="challenge-hub__summary-icon material-symbols-outlined" aria-hidden="true">quiz</span>
+                                <div class="challenge-hub__summary-text">
+                                    <span class="challenge-hub__summary-label">Banco disponível</span>
+                                    <span class="challenge-hub__summary-value"><span id="hub-total-questions-count-summary">0</span> questões prontas para você.</span>
+                                </div>
+                            </li>
+                            <li class="challenge-hub__summary-item">
+                                <span class="challenge-hub__summary-icon material-symbols-outlined" aria-hidden="true">schedule</span>
+                                <div class="challenge-hub__summary-text">
+                                    <span class="challenge-hub__summary-label">Tempo otimizado</span>
+                                    <span class="challenge-hub__summary-value">Escolha um modo que cabe na sua rotina agora.</span>
+                                </div>
+                            </li>
+                            <li class="challenge-hub__summary-item">
+                                <span class="challenge-hub__summary-icon material-symbols-outlined" aria-hidden="true">military_tech</span>
+                                <div class="challenge-hub__summary-text">
+                                    <span class="challenge-hub__summary-label">Evolução constante</span>
+                                    <span class="challenge-hub__summary-value">Intercale modos para avançar em velocidade e profundidade.</span>
+                                </div>
+                            </li>
+                        </ul>
+                    </div>
+                </section>
 
-                    <button id="hub-customize-quiz-btn" class="challenge-card">
-                        <div class="challenge-card__icon-wrapper">
-                            <span class="material-symbols-outlined challenge-card__icon">tune</span>
+                <div id="hub-resume-quiz-card" class="hub-resume-card u-is-hidden">
+                    <div class="hub-resume-card__icon" aria-hidden="true">
+                        <span class="material-symbols-outlined">play_circle</span>
+                    </div>
+                    <div class="hub-resume-card__content">
+                        <span class="hub-resume-card__eyebrow">Sessão em andamento</span>
+                        <h3 class="hub-resume-card__title">Continuar desafio</h3>
+                        <p class="hub-resume-card__description" id="hub-resume-card-description">
+                            Você tem uma sessão em andamento.
+                        </p>
+                    </div>
+                    <div class="hub-resume-card__actions">
+                        <button id="hub-discard-resume-btn" class="button button--text button--compact">Descartar</button>
+                        <button id="hub-confirm-resume-btn" class="button button--primary button--small">Continuar</button>
+                    </div>
+                </div>
+
+                <div class="challenge-hub__mode-grid" aria-label="Modos de jogo disponíveis">
+                    <button id="hub-warmup-quiz-btn" type="button" class="hub-mode-card">
+                        <span class="hub-mode-card__icon material-symbols-outlined" aria-hidden="true">auto_awesome</span>
+                        <div class="hub-mode-card__content">
+                            <span class="hub-mode-card__eyebrow">Ritmo leve</span>
+                            <h3 class="hub-mode-card__title">Aquecimento Direcionado</h3>
+                            <p class="hub-mode-card__description">5 questões fáceis e médias para despertar a memória e criar foco.</p>
                         </div>
-                        <div class="challenge-card__content">
-                            <h3 class="challenge-card__title">Personalizar Quiz</h3>
-                            <p class="challenge-card__description">Escolha temas, dificuldade e modo de estudo.</p>
-                        </div>
+                        <span class="hub-mode-card__meta">5 questões</span>
                     </button>
-                    <button id="hub-quick-quiz-btn" class="challenge-card">
-                        <div class="challenge-card__icon-wrapper">
-                            <span class="material-symbols-outlined challenge-card__icon">bolt</span>
+
+                    <button id="hub-focused-quiz-btn" type="button" class="hub-mode-card">
+                        <span class="hub-mode-card__icon material-symbols-outlined" aria-hidden="true">target</span>
+                        <div class="hub-mode-card__content">
+                            <span class="hub-mode-card__eyebrow">Concentração total</span>
+                            <h3 class="hub-mode-card__title">Bloco de Foco</h3>
+                            <p class="hub-mode-card__description">15 questões de nível médio e difícil para treinar raciocínio clínico avançado.</p>
                         </div>
-                        <div class="challenge-card__content">
-                            <h3 class="challenge-card__title">Quiz Rápido</h3>
-                            <p class="challenge-card__description">Um desafio de <span id="hub-quick-quiz-count">10</span> questões aleatórias para começar.</p>
+                        <span class="hub-mode-card__meta">15 questões</span>
+                    </button>
+
+                    <button id="hub-marathon-quiz-btn" type="button" class="hub-mode-card">
+                        <span class="hub-mode-card__icon material-symbols-outlined" aria-hidden="true">flag</span>
+                        <div class="hub-mode-card__content">
+                            <span class="hub-mode-card__eyebrow">Sessão completa</span>
+                            <h3 class="hub-mode-card__title">Maratona Adaptativa</h3>
+                            <p class="hub-mode-card__description">30 questões variadas para um treino longo com feedback imediato.</p>
                         </div>
+                        <span class="hub-mode-card__meta">30 questões</span>
+                    </button>
+
+                    <button id="hub-hardcore-quiz-btn" type="button" class="hub-mode-card hub-mode-card--highlight">
+                        <span class="hub-mode-card__icon material-symbols-outlined" aria-hidden="true">local_fire_department</span>
+                        <div class="hub-mode-card__content">
+                            <span class="hub-mode-card__eyebrow">Desafio máximo</span>
+                            <h3 class="hub-mode-card__title">Modo Intensivo</h3>
+                            <p class="hub-mode-card__description">12 questões apenas de nível difícil para testar seus limites.</p>
+                        </div>
+                        <span class="hub-mode-card__meta">12 questões</span>
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- rebuild the challenge hub markup with a two-column hero, status summary, redesigned resume panel, and four dedicated mode cards
- refresh the challenge hub component styles to match the new layout while keeping legacy challenge-card styling available for other areas
- hook the new hub controls into the orchestrator with warmup, focus, marathon, and hardcore quick modes and ensure counts are formatted across home and hub

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7edc9f80c8333a18e2bf425c7b1ce