### PR TITLE
Add predefined quiz list to challenge hub

### DIFF
--- a/assets/css/components/challenge-hub.css
+++ b/assets/css/components/challenge-hub.css
@@ -169,6 +169,44 @@
     align-items: stretch;
 }
 
+.challenge-hub__predefined {
+    margin-top: clamp(26px, 3vw, 36px);
+    padding: clamp(22px, 3vw, 30px);
+    border-radius: var(--border-radius-md);
+    border: 1px solid rgba(13, 59, 102, 0.12);
+    background: var(--color-surface, #ffffff);
+    box-shadow: var(--shadow-sm);
+}
+
+.challenge-hub__section-header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xxs, 6px);
+    margin-bottom: clamp(14px, 2vw, 18px);
+}
+
+.challenge-hub__section-title {
+    margin: 0;
+    font-size: clamp(1.05rem, 2.1vw, 1.28rem);
+    font-family: var(--font-family-heading);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
+}
+
+.challenge-hub__section-subtitle {
+    margin: 0;
+    font-size: var(--font-size-sm, 0.95rem);
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+}
+
+.challenge-hub__predefined-grid {
+    display: grid;
+    gap: clamp(16px, 2.4vw, 24px);
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    align-items: stretch;
+}
+
 /* =============================== CARDS =============================== */
 .challenge-card {
     position: relative;
@@ -340,6 +378,14 @@
     }
 
     .challenge-hub__grid {
+        grid-template-columns: 1fr;
+    }
+
+    .challenge-hub__predefined {
+        padding: clamp(20px, 6vw, 26px);
+    }
+
+    .challenge-hub__predefined-grid {
         grid-template-columns: 1fr;
     }
 

--- a/assets/js/app/App.js
+++ b/assets/js/app/App.js
@@ -56,9 +56,9 @@ export default class App {
         try {
             if (initialSectionId === 'questions') {
                 await this.actionOrchestrator.initializeAppData();
-            } else if (initialSectionId === 'home') {
-                await this.actionOrchestrator.loadInitialSummary();
             }
+
+            await this.actionOrchestrator.loadInitialSummary();
 
             this._setupUIComponents();
             this._determineInitialSection(initialSectionId);
@@ -125,13 +125,8 @@ export default class App {
             const challengeHub = new ChallengeHub(this.quizUI);
             challengeHub.setActionOrchestrator(this.actionOrchestrator);
             this.quizUI.setChallengeHubInstance(challengeHub);
-            const totalQuestions = typeof state.geral.totalQuestionsAvailable === 'number'
-                ? state.geral.totalQuestionsAvailable.toLocaleString('pt-BR')
-                : state.geral.totalQuestionsAvailable;
-            challengeHub.updateTotalQuestionsCount(totalQuestions);
-            const quickQuizCount = state.geral.homeSummary?.quickQuizDefaultCount ?? QUICK_QUIZ_COUNT;
-            challengeHub.updateQuickQuizCount(quickQuizCount);
             challengeHub.setupEventListeners();
+            challengeHub.handleStateChange(state);
         }
 
         const resultDisplay = new ResultDisplay(this.quizUI, this.quizUI.timer);

--- a/assets/js/app/flux/ActionOrchestrator.js
+++ b/assets/js/app/flux/ActionOrchestrator.js
@@ -75,6 +75,7 @@ export default class ActionOrchestrator {
                     categories: summary.categories,
                     totalCategories: summary.total_categories,
                     quickQuizDefaultCount: summary.quick_quiz_default_count,
+                    predefinedQuizzes: summary.predefined_quizzes,
                 }));
                 return true;
             }

--- a/assets/js/app/flux/actions.js
+++ b/assets/js/app/flux/actions.js
@@ -150,13 +150,14 @@ export const quizActions = {
         payload: { error }
     }),
 
-    setGeneralSummary: ({ totalQuestions, categories, totalCategories, quickQuizDefaultCount }) => ({
+    setGeneralSummary: ({ totalQuestions, categories, totalCategories, quickQuizDefaultCount, predefinedQuizzes }) => ({
         type: ActionTypes.SET_GENERAL_SUMMARY,
         payload: {
             totalQuestions,
             categories,
             totalCategories,
             quickQuizDefaultCount,
+            predefinedQuizzes,
         }
     }),
 };

--- a/assets/js/app/flux/reducer.js
+++ b/assets/js/app/flux/reducer.js
@@ -9,6 +9,10 @@ const initialState = {
         totalQuestionsAvailable: 0,
         isInitialDataLoaded: false,
         lastFetchedQuizDefinitionName: null,
+        predefinedQuizzes: {
+            items: [],
+            lastUpdatedAt: null,
+        },
         homeSummary: {
             totalCategories: 0,
             quickQuizDefaultCount: QUICK_QUIZ_COUNT,
@@ -183,6 +187,7 @@ export function quizReducer(state = initialState, action) {
                 categories,
                 totalCategories,
                 quickQuizDefaultCount,
+                predefinedQuizzes,
             } = action.payload;
 
             const sanitizedCategories = Array.isArray(categories) ? categories : state.geral.allCategories;
@@ -195,6 +200,19 @@ export function quizReducer(state = initialState, action) {
             const sanitizedQuickQuiz = typeof quickQuizDefaultCount === 'number' && quickQuizDefaultCount > 0
                 ? quickQuizDefaultCount
                 : state.geral.homeSummary.quickQuizDefaultCount;
+            const sanitizedPredefined = Array.isArray(predefinedQuizzes)
+                ? predefinedQuizzes
+                    .filter(item => item && Object.prototype.hasOwnProperty.call(item, 'id'))
+                    .map(item => ({
+                        id: Number.parseInt(item.id, 10),
+                        nome: typeof item.nome === 'string' ? item.nome : String(item.nome ?? ''),
+                        descricao: typeof item.descricao === 'string' ? item.descricao : '',
+                        total_perguntas: Number.isFinite(Number(item.total_perguntas))
+                            ? Number(item.total_perguntas)
+                            : 0,
+                    }))
+                    .filter(item => Number.isInteger(item.id) && item.id > 0)
+                : state.geral.predefinedQuizzes.items;
 
             return {
                 ...state,
@@ -202,6 +220,10 @@ export function quizReducer(state = initialState, action) {
                     ...state.geral,
                     totalQuestionsAvailable: sanitizedTotalQuestions,
                     allCategories: sanitizedCategories,
+                    predefinedQuizzes: {
+                        items: sanitizedPredefined,
+                        lastUpdatedAt: Date.now(),
+                    },
                     homeSummary: {
                         totalCategories: sanitizedTotalCategories,
                         quickQuizDefaultCount: sanitizedQuickQuiz,
@@ -225,7 +247,7 @@ export function quizReducer(state = initialState, action) {
                         ...state.geral.homeSummary,
                         totalCategories: categorias?.length || state.geral.homeSummary.totalCategories,
                     },
-                    isHomeSummaryLoaded: true,
+                    isHomeSummaryLoaded: state.geral.isHomeSummaryLoaded,
                 }
             };
         }

--- a/assets/js/ui/ChallengeHub.js
+++ b/assets/js/ui/ChallengeHub.js
@@ -2,15 +2,21 @@
 
 export default class ChallengeHub {
     constructor(quizUIInstance) {
-        this.quizUI = quizUIInstance; 
-        
+        this.quizUI = quizUIInstance;
+
         // A dependência do actionOrchestrator será injetada via setter
         this.actionOrchestrator = null;
 
         // Atalho para os elementos DOM relevantes gerenciados por QuizUI
         this._cacheElements();
+
+        this.lastTotalQuestions = null;
+        this.lastQuickQuizCount = null;
+        this.predefinedQuizzesCache = [];
+        this.lastResumableSessionId = null;
+        this.lastResumeQuestionCount = null;
     }
-    
+
     _cacheElements() {
         this.elements = {
             challengeHubContainer: this.quizUI.elements.challengeHubContainer,
@@ -25,7 +31,9 @@ export default class ChallengeHub {
             challengeStatTotal: this.quizUI.elements.challengeStatTotal,
             placeholderFiltrosContainer: this.quizUI.elements.placeholderFiltrosContainer,
             closeFiltersAndShowHubBtn: this.quizUI.elements.closeFiltersAndShowHubBtn,
-            
+            predefinedSection: this.quizUI.elements.hubPredefinedSection,
+            predefinedList: this.quizUI.elements.hubPredefinedList,
+
             // --- INÍCIO DA CORREÇÃO: Mapeando para os novos IDs e estrutura ---
             resumeCard: document.getElementById('hub-resume-quiz-card'),
             resumeCardDescription: document.getElementById('hub-resume-card-description'),
@@ -121,6 +129,8 @@ export default class ChallengeHub {
         this.elements.resumeCardDescription.innerHTML = `Você tem uma sessão em andamento de <strong>${questionCount}</strong> questões.`;
 
         this.quizUI.showElement(this.elements.resumeCard);
+        this.lastResumableSessionId = resumableSession.session_id ?? null;
+        this.lastResumeQuestionCount = questionCount;
     }
 
     /**
@@ -129,6 +139,45 @@ export default class ChallengeHub {
     hideResumeOption() {
         if (this.elements.resumeCard) {
             this.quizUI.hideElement(this.elements.resumeCard);
+        }
+        this.lastResumableSessionId = null;
+        this.lastResumeQuestionCount = null;
+    }
+
+    handleStateChange(currentState, previousState = {}) {
+        if (!currentState) {
+            return;
+        }
+
+        const totalQuestionsRaw = currentState?.geral?.totalQuestionsAvailable;
+        const normalizedTotal = this._normalizeCount(totalQuestionsRaw);
+        if (normalizedTotal !== null && normalizedTotal !== this.lastTotalQuestions) {
+            this.lastTotalQuestions = normalizedTotal;
+            this.updateTotalQuestionsCount(normalizedTotal);
+        }
+
+        const quickQuizRaw = currentState?.geral?.homeSummary?.quickQuizDefaultCount;
+        const normalizedQuickQuiz = this._normalizeCount(quickQuizRaw);
+        if (normalizedQuickQuiz !== null && normalizedQuickQuiz !== this.lastQuickQuizCount) {
+            this.lastQuickQuizCount = normalizedQuickQuiz;
+            this.updateQuickQuizCount(normalizedQuickQuiz);
+        }
+
+        const predefinedQuizzes = Array.isArray(currentState?.geral?.predefinedQuizzes?.items)
+            ? currentState.geral.predefinedQuizzes.items
+            : [];
+        if (this._predefinedQuizzesChanged(predefinedQuizzes)) {
+            this.renderPredefinedQuizzes(predefinedQuizzes);
+        }
+
+        const resumableSession = currentState?.quiz?.resumableSession || null;
+        const sessionId = resumableSession?.session_id ?? null;
+        const questionCount = resumableSession?.perguntas ? resumableSession.perguntas.length : null;
+
+        if (resumableSession && (this.lastResumableSessionId !== sessionId || this.lastResumeQuestionCount !== questionCount)) {
+            this.showResumeOption(resumableSession);
+        } else if (!resumableSession && this.lastResumableSessionId !== null) {
+            this.hideResumeOption();
         }
     }
 
@@ -201,5 +250,157 @@ export default class ChallengeHub {
             }
         });
         // --- FIM DA CORREÇÃO ---
+
+        this.elements.predefinedList?.addEventListener('click', (event) => {
+            const targetCard = event.target.closest('[data-quiz-def-id]');
+            if (!targetCard) {
+                return;
+            }
+            if (!this.actionOrchestrator) {
+                console.error('ChallengeHub: actionOrchestrator indisponível ao iniciar quiz pré-definido.');
+                return;
+            }
+
+            const quizId = Number.parseInt(targetCard.dataset.quizDefId, 10);
+            if (Number.isNaN(quizId)) {
+                return;
+            }
+
+            this.hideHub();
+            this.actionOrchestrator.startPredefinedQuiz(quizId);
+        });
+    }
+
+    _normalizeCount(value) {
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return value;
+        }
+        if (typeof value === 'string') {
+            const sanitized = value.replace(/[^0-9]/g, '');
+            if (sanitized) {
+                const parsed = Number.parseInt(sanitized, 10);
+                if (!Number.isNaN(parsed)) {
+                    return parsed;
+                }
+            }
+        }
+        return null;
+    }
+
+    _formatCount(value) {
+        const normalized = this._normalizeCount(value);
+        if (normalized === null) {
+            return '0';
+        }
+        return normalized.toLocaleString('pt-BR');
+    }
+
+    _predefinedQuizzesChanged(newList) {
+        if (!Array.isArray(newList)) {
+            return this.predefinedQuizzesCache.length > 0;
+        }
+
+        if (newList.length !== this.predefinedQuizzesCache.length) {
+            return true;
+        }
+
+        for (let index = 0; index < newList.length; index += 1) {
+            const cached = this.predefinedQuizzesCache[index];
+            const current = newList[index];
+            if (!cached || !current) {
+                return true;
+            }
+            if (
+                cached.id !== current.id
+                || cached.total_perguntas !== current.total_perguntas
+                || cached.nome !== current.nome
+                || cached.descricao !== current.descricao
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    renderPredefinedQuizzes(quizzes = []) {
+        if (!this.elements.predefinedList || !this.elements.predefinedSection) {
+            return;
+        }
+
+        const sanitizedList = Array.isArray(quizzes)
+            ? quizzes
+                .map((quiz) => ({
+                    id: Number.parseInt(quiz.id, 10),
+                    nome: typeof quiz.nome === 'string' ? quiz.nome : String(quiz.nome ?? ''),
+                    descricao: typeof quiz.descricao === 'string' ? quiz.descricao : '',
+                    total_perguntas: this._normalizeCount(quiz.total_perguntas) ?? 0,
+                }))
+                .filter((quiz) => Number.isInteger(quiz.id) && quiz.id > 0)
+            : [];
+
+        this.elements.predefinedList.innerHTML = '';
+
+        if (sanitizedList.length === 0) {
+            this.quizUI.hideElement(this.elements.predefinedSection);
+            this.predefinedQuizzesCache = [];
+            return;
+        }
+
+        sanitizedList.forEach((quiz) => {
+            const cardButton = document.createElement('button');
+            cardButton.type = 'button';
+            cardButton.classList.add('challenge-card');
+            cardButton.dataset.quizDefId = String(quiz.id);
+            cardButton.dataset.quizName = quiz.nome;
+            cardButton.title = `${quiz.nome} • ${this._formatCount(quiz.total_perguntas)} questões`;
+            cardButton.setAttribute('aria-label', `${quiz.nome} com ${this._formatCount(quiz.total_perguntas)} questões`);
+            cardButton.setAttribute('role', 'listitem');
+
+            const header = document.createElement('div');
+            header.classList.add('challenge-card__header');
+
+            const iconWrapper = document.createElement('div');
+            iconWrapper.classList.add('challenge-card__icon-wrapper');
+
+            const icon = document.createElement('span');
+            icon.classList.add('material-symbols-outlined', 'challenge-card__icon');
+            icon.setAttribute('aria-hidden', 'true');
+            icon.textContent = 'menu_book';
+
+            iconWrapper.appendChild(icon);
+
+            const content = document.createElement('div');
+            content.classList.add('challenge-card__content');
+
+            const title = document.createElement('h3');
+            title.classList.add('challenge-card__title');
+            title.textContent = quiz.nome;
+            content.appendChild(title);
+
+            if (quiz.descricao && quiz.descricao.trim().length > 0) {
+                const description = document.createElement('p');
+                description.classList.add('challenge-card__description');
+                description.textContent = quiz.descricao.trim();
+                content.appendChild(description);
+            }
+
+            header.append(iconWrapper, content);
+
+            const footer = document.createElement('div');
+            footer.classList.add('challenge-card__footer');
+
+            const meta = document.createElement('span');
+            meta.classList.add('challenge-card__meta');
+            meta.textContent = `${this._formatCount(quiz.total_perguntas)} questões`;
+            footer.appendChild(meta);
+
+            cardButton.append(header, footer);
+
+            this.elements.predefinedList.appendChild(cardButton);
+        });
+
+        this.quizUI.showElement(this.elements.predefinedSection);
+        this.predefinedQuizzesCache = sanitizedList;
     }
 }

--- a/assets/js/ui/QuizUI.js
+++ b/assets/js/ui/QuizUI.js
@@ -103,6 +103,10 @@ export default class QuizUI {
         }
         
         const currentState = this.store.getState();
+
+        if (this.challengeHubInstance) {
+            this.challengeHubInstance.handleStateChange(currentState, this.previousState);
+        }
         const previousSessionId = this.previousState.quiz?.currentSessionId;
         const currentSessionId = currentState.quiz?.currentSessionId;
         const wasQuizActive = previousSessionId !== null && previousSessionId !== undefined;
@@ -127,19 +131,6 @@ export default class QuizUI {
             this.displayQuizLayout(false);
         }
     
-        // --- INÍCIO DA ALTERAÇÃO: Lógica reativa agora delega ao ChallengeHub ---
-        const hadResumableSession = !!this.previousState.quiz?.resumableSession;
-        const hasResumableSession = !!currentState.quiz.resumableSession;
-
-        if (this.challengeHubInstance) {
-            if (!hadResumableSession && hasResumableSession) {
-                this.challengeHubInstance.showResumeOption(currentState.quiz.resumableSession);
-            } else if (hadResumableSession && !hasResumableSession) {
-                this.challengeHubInstance.hideResumeOption();
-            }
-        }
-        // --- FIM DA ALTERAÇÃO ---
-
         const prevQuestionIndex = this.previousState.quiz?.currentQuestionIndex ?? -1;
         if (isQuizActive && currentState.quiz.currentQuestionIndex !== prevQuestionIndex) {
             this._handleQuestionChange(currentState);
@@ -234,6 +225,8 @@ export default class QuizUI {
             hubTimedQuizBtn: document.getElementById('hub-timed-quiz-btn'),
             hubFavoriteReviewBtn: document.getElementById('hub-favorite-review-btn'),
             hubRepeatLastBtn: document.getElementById('hub-repeat-last-btn'),
+            hubPredefinedSection: document.getElementById('hub-predefined-section'),
+            hubPredefinedList: document.getElementById('hub-predefined-list'),
             placeholderFiltrosContainer: document.getElementById('placeholder-filtros-container'),
             closeFiltersAndShowHubBtn: document.getElementById('close-filters-and-show-hub-btn'),
             avisoContainer: document.getElementById('aviso-container'),

--- a/quiz/api/viewsets.py
+++ b/quiz/api/viewsets.py
@@ -120,12 +120,15 @@ class QuizViewSet(viewsets.ViewSet):
                 for categoria in categorias_qs
             ]
 
+            predefined_quizzes = QuizDataService.get_active_predefined_quizzes_summary()
+
             return Response({
                 'status': 'success',
                 'total_questions': total_questions,
                 'total_categories': len(categorias_data),
                 'quick_quiz_default_count': quick_quiz_default,
                 'categories': categorias_data,
+                'predefined_quizzes': predefined_quizzes,
             })
         except Exception:
             return Response(

--- a/quiz/services/quiz_service.py
+++ b/quiz/services/quiz_service.py
@@ -6,7 +6,7 @@ import random
 from collections import defaultdict
 from typing import Iterable, List, Optional
 
-from django.db.models import Case, Prefetch, Q, When
+from django.db.models import Case, Count, Prefetch, Q, When
 
 from quiz.models import (
     Categoria,
@@ -219,6 +219,34 @@ class QuizDataService:
             "opcoesResposta": [opt for opts_list in opcoes_dict_por_pergunta.values() for opt in opts_list],
             "quiz_definition_name": quiz_definition_name,
         }
+
+    @staticmethod
+    def get_active_predefined_quizzes_summary():
+        """Retorna metadados resumidos dos quizzes pré-definidos ativos."""
+
+        quizzes_qs = (
+            QuizDefinicao.objects.filter(ativo=True)
+            .annotate(total_perguntas=Count('perguntas', distinct=True))
+            .order_by('nome_quiz')
+        )
+
+        quizzes_summary = []
+        for quiz in quizzes_qs:
+            question_count = quiz.total_perguntas
+            if question_count is None:
+                # Fallback defensivo caso a anotação não esteja disponível
+                question_count = quiz.perguntas.count()
+
+            quizzes_summary.append(
+                {
+                    'id': quiz.pk,
+                    'nome': quiz.nome_quiz,
+                    'descricao': quiz.descricao or '',
+                    'total_perguntas': question_count,
+                }
+            )
+
+        return quizzes_summary
 
     @staticmethod
     def get_descendant_category_ids(category_ids_str_list: Iterable[str]):

--- a/quiz/templates/quiz/questions_page.html
+++ b/quiz/templates/quiz/questions_page.html
@@ -176,6 +176,14 @@
                         </div>
                     </button>
                 </div>
+
+                <div id="hub-predefined-section" class="challenge-hub__predefined u-is-hidden">
+                    <div class="challenge-hub__section-header">
+                        <h3 class="challenge-hub__section-title">Listas especiais</h3>
+                        <p class="challenge-hub__section-subtitle">Explore quizzes prontos com curadoria da equipe MedQuiz.</p>
+                    </div>
+                    <div id="hub-predefined-list" class="challenge-hub__predefined-grid" role="list"></div>
+                </div>
             </div>
 
             <div id="placeholder-filtros-container" class="card card--placeholder-filtros u-is-hidden">

--- a/quiz/tests/test_api_quiz.py
+++ b/quiz/tests/test_api_quiz.py
@@ -109,6 +109,8 @@ class QuizApiTests(TestCase):
         payload = response.json()
         self.assertEqual(payload['total_questions'], 1)
         self.assertEqual(payload['total_categories'], 1)
+        self.assertIn('predefined_quizzes', payload)
+        self.assertIsInstance(payload['predefined_quizzes'], list)
 
     def test_quiz_data_endpoint_returns_question_payload(self):
         url = reverse('quiz:quiz-alldata')

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -741,12 +741,15 @@ def api_get_quiz_summary_view(request):
             for categoria in categorias_qs
         ]
 
+        predefined_quizzes = QuizDataService.get_active_predefined_quizzes_summary()
+
         return JsonResponse({
             'status': 'success',
             'total_questions': total_questions,
             'total_categories': len(categorias_data),
             'quick_quiz_default_count': quick_quiz_default,
             'categories': categorias_data,
+            'predefined_quizzes': predefined_quizzes,
         })
     except Exception:
         return JsonResponse(


### PR DESCRIPTION
## Summary
- extend quiz summary endpoints to include predefined quiz metadata
- render predefined quiz cards in the challenge hub and wire them to the orchestrator
- refresh challenge hub styling and state handling so counts and modes stay in sync

## Testing
- python manage.py test *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68d7fe8c69208333b3ea28011db7df29