### PR TITLE
Seed challenge hub data for predefined quizzes

### DIFF
--- a/assets/js/app/flux/ActionOrchestrator.js
+++ b/assets/js/app/flux/ActionOrchestrator.js
@@ -13,6 +13,8 @@ export default class ActionOrchestrator {
         this.timerIntervalId = null;
 
         this.lastQuizRequest = null;
+
+        this.preloadedHubSummary = null;
     }
 
     // --- MÉTODOS DE CONTROLE DO TIMER ---
@@ -61,9 +63,53 @@ export default class ActionOrchestrator {
     }
 
     // --- MÉTODOS DE INICIALIZAÇÃO E FLUXO ---
+    _getPreloadedHubSummary() {
+        if (this.preloadedHubSummary) {
+            return this.preloadedHubSummary;
+        }
+
+        if (typeof document === 'undefined') {
+            return null;
+        }
+
+        const scriptElement = document.getElementById('challenge-hub-initial-data');
+        if (!scriptElement) {
+            return null;
+        }
+
+        const rawContent = scriptElement.textContent || scriptElement.innerText || '';
+        if (!rawContent.trim()) {
+            return null;
+        }
+
+        try {
+            const parsed = JSON.parse(rawContent);
+            if (parsed && typeof parsed === 'object') {
+                this.preloadedHubSummary = parsed;
+                return this.preloadedHubSummary;
+            }
+        } catch (error) {
+            console.warn('ActionOrchestrator: falha ao interpretar dados iniciais do Challenge Hub.', error);
+        }
+
+        return null;
+    }
+
     async loadInitialSummary() {
         const state = this.store.getState();
         if (state.geral.isHomeSummaryLoaded) {
+            return true;
+        }
+
+        const preloadedSummary = this._getPreloadedHubSummary();
+        if (preloadedSummary) {
+            this.store.dispatch(quizActions.setGeneralSummary({
+                totalQuestions: preloadedSummary.total_questions,
+                categories: preloadedSummary.categories,
+                totalCategories: preloadedSummary.total_categories,
+                quickQuizDefaultCount: preloadedSummary.quick_quiz_default_count,
+                predefinedQuizzes: preloadedSummary.predefined_quizzes,
+            }));
             return true;
         }
 

--- a/quiz/api/viewsets.py
+++ b/quiz/api/viewsets.py
@@ -97,39 +97,9 @@ class QuizViewSet(viewsets.ViewSet):
     @action(detail=False, methods=['get'], url_path='summary')
     def summary(self, request):
         try:
-            perguntas_ativas = Pergunta.objects.filter(ativa=True)
-            total_questions = perguntas_ativas.count()
-
-            categorias_qs = Categoria.objects.annotate(
-                total_perguntas=Count(
-                    'perguntas_associadas',
-                    filter=Q(perguntas_associadas__ativa=True)
-                )
-            ).order_by('nome_categoria')
-
-            quiz_config = get_quiz_config()
-            quick_quiz_default = getattr(quiz_config, 'numero_perguntas_quiz_rapido', None)
-
-            categorias_data = [
-                {
-                    'id_categoria': categoria.pk,
-                    'nome_categoria': categoria.nome_categoria,
-                    'id_categoria_pai': categoria.id_categoria_pai_id,
-                    'total_perguntas': categoria.total_perguntas or 0,
-                }
-                for categoria in categorias_qs
-            ]
-
-            predefined_quizzes = QuizDataService.get_active_predefined_quizzes_summary()
-
-            return Response({
-                'status': 'success',
-                'total_questions': total_questions,
-                'total_categories': len(categorias_data),
-                'quick_quiz_default_count': quick_quiz_default,
-                'categories': categorias_data,
-                'predefined_quizzes': predefined_quizzes,
-            })
+            summary_payload = QuizDataService.build_quiz_summary()
+            summary_payload['status'] = 'success'
+            return Response(summary_payload)
         except Exception:
             return Response(
                 {'status': 'error', 'message': 'Erro ao buscar resumo inicial.'},

--- a/quiz/services/quiz_service.py
+++ b/quiz/services/quiz_service.py
@@ -11,6 +11,7 @@ from django.db.models import Case, Count, Prefetch, Q, When
 from quiz.models import (
     Categoria,
     CategoriaHierarquia,
+    ConfiguracoesGeraisQuiz,
     OpcaoResposta,
     Pergunta,
     QuestaoFavorita,
@@ -247,6 +248,45 @@ class QuizDataService:
             )
 
         return quizzes_summary
+
+    @staticmethod
+    def build_quiz_summary():
+        """Constrói o payload usado para popular o Challenge Hub."""
+
+        perguntas_ativas = Pergunta.objects.filter(ativa=True)
+        total_questions = perguntas_ativas.count()
+
+        categorias_qs = Categoria.objects.annotate(
+            total_perguntas=Count(
+                'perguntas_associadas',
+                filter=Q(perguntas_associadas__ativa=True)
+            )
+        ).order_by('nome_categoria')
+
+        quiz_config = ConfiguracoesGeraisQuiz.objects.first()
+        quick_quiz_default = None
+        if quiz_config and quiz_config.numero_perguntas_quiz_rapido is not None:
+            quick_quiz_default = quiz_config.numero_perguntas_quiz_rapido
+
+        categorias_data = [
+            {
+                'id_categoria': categoria.pk,
+                'nome_categoria': categoria.nome_categoria,
+                'id_categoria_pai': categoria.id_categoria_pai_id,
+                'total_perguntas': categoria.total_perguntas or 0,
+            }
+            for categoria in categorias_qs
+        ]
+
+        predefined_quizzes = QuizDataService.get_active_predefined_quizzes_summary()
+
+        return {
+            'total_questions': total_questions,
+            'total_categories': len(categorias_data),
+            'quick_quiz_default_count': quick_quiz_default,
+            'categories': categorias_data,
+            'predefined_quizzes': predefined_quizzes,
+        }
 
     @staticmethod
     def get_descendant_category_ids(category_ids_str_list: Iterable[str]):

--- a/quiz/templates/quiz/questions_page.html
+++ b/quiz/templates/quiz/questions_page.html
@@ -61,7 +61,11 @@
         </aside>
 
         <div class="question-section__main-content">
-            
+
+            {% if hub_summary_json %}
+            <script id="challenge-hub-initial-data" type="application/json">{{ hub_summary_json|safe }}</script>
+            {% endif %}
+
             <div id="challenge-hub-container" class="challenge-hub">
                 <div class="challenge-hub__hero">
                     <div class="challenge-hub__hero-info">

--- a/quiz/tests/test_services.py
+++ b/quiz/tests/test_services.py
@@ -16,6 +16,7 @@ from quiz.models import (
     OpcaoResposta,
     Pergunta,
     QuestaoFavorita,
+    QuizDefinicao,
     SessoesQuizUsuario,
     DesafioDinamico,
     RecompensaNivelResgatada,
@@ -98,6 +99,21 @@ class QuizDataServiceTests(TestCase):
         data_by_reference = service.get_quiz_data_dict(search_query='NEURO')
         self.assertEqual(len(data_by_reference['perguntas']), 1)
         self.assertEqual(data_by_reference['perguntas'][0]['id_pergunta'], other_question.pk)
+
+    def test_build_quiz_summary_includes_predefined_list(self):
+        quiz_def = QuizDefinicao.objects.create(
+            nome_quiz='Rotina Cardiologia',
+            descricao='Lista de revisão',
+            ativo=True,
+        )
+        quiz_def.perguntas.add(self.question, through_defaults={'ordem': 1})
+
+        summary = QuizDataService.build_quiz_summary()
+
+        self.assertEqual(summary['total_questions'], 1)
+        self.assertEqual(summary['total_categories'], 1)
+        self.assertIn('predefined_quizzes', summary)
+        self.assertTrue(any(item['id'] == quiz_def.pk for item in summary['predefined_quizzes']))
 
 
 class StatisticsServiceTests(TestCase):

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -530,8 +530,19 @@ def home_view(request):
 
 @login_required
 def questions_view(request):
+    hub_summary = {}
+    hub_summary_json = '{}'
+    try:
+        hub_summary = QuizDataService.build_quiz_summary()
+        hub_summary_json = json.dumps(hub_summary, ensure_ascii=False)
+    except Exception:
+        hub_summary = {}
+        hub_summary_json = '{}'
+
     context = {
         'page_title': 'MedQuiz - Questões',
+        'hub_summary': hub_summary,
+        'hub_summary_json': hub_summary_json,
     }
     return render(request, 'quiz/questions_page.html', context)
 
@@ -716,41 +727,9 @@ def delete_account_view(request):
 def api_get_quiz_summary_view(request):
     """Retorna estatísticas agregadas leves para inicialização da interface."""
     try:
-        perguntas_ativas = Pergunta.objects.filter(ativa=True)
-        total_questions = perguntas_ativas.count()
-
-        categorias_qs = Categoria.objects.annotate(
-            total_perguntas=Count(
-                'perguntas_associadas',
-                filter=Q(perguntas_associadas__ativa=True)
-            )
-        ).order_by('nome_categoria')
-
-        quiz_config = get_quiz_config()
-        quick_quiz_default = None
-        if quiz_config:
-            quick_quiz_default = getattr(quiz_config, 'numero_perguntas_quiz_rapido', None)
-
-        categorias_data = [
-            {
-                'id_categoria': categoria.pk,
-                'nome_categoria': categoria.nome_categoria,
-                'id_categoria_pai': categoria.id_categoria_pai_id,
-                'total_perguntas': categoria.total_perguntas or 0,
-            }
-            for categoria in categorias_qs
-        ]
-
-        predefined_quizzes = QuizDataService.get_active_predefined_quizzes_summary()
-
-        return JsonResponse({
-            'status': 'success',
-            'total_questions': total_questions,
-            'total_categories': len(categorias_data),
-            'quick_quiz_default_count': quick_quiz_default,
-            'categories': categorias_data,
-            'predefined_quizzes': predefined_quizzes,
-        })
+        summary_payload = QuizDataService.build_quiz_summary()
+        summary_payload['status'] = 'success'
+        return JsonResponse(summary_payload)
     except Exception:
         return JsonResponse(
             {'status': 'error', 'message': 'Erro ao buscar resumo inicial.'},


### PR DESCRIPTION
## Summary
- expose a reusable `QuizDataService.build_quiz_summary` helper and feed it to the API and questions page context
- embed the serialized challenge hub summary in the template and let the front-end consume it before falling back to a network request
- cover the summary builder with a service test to ensure predefined quizzes appear in the payload

## Testing
- not run (Django is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d80852788883338a53490c0ee9f902