### PR TITLE
Improve mobile layout for challenge hub hero

### DIFF
--- a/assets/css/components/challenge-hub.css
+++ b/assets/css/components/challenge-hub.css
@@ -340,6 +340,37 @@
 
     .challenge-hub__hero {
         padding: clamp(24px, 6vw, 32px);
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+    }
+
+    .challenge-hub__hero-info,
+    .challenge-hub__hero-actions {
+        width: 100%;
+        min-width: 0;
+    }
+
+    .challenge-hub__hero-info {
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-md, 20px);
+    }
+
+    .challenge-hub__stats {
+        width: 100%;
+        justify-items: center;
+    }
+
+    .challenge-stat {
+        align-items: center;
+        text-align: center;
+        padding: var(--spacing-sm, 16px) clamp(18px, 6vw, 22px);
+    }
+
+    .challenge-stat__value {
+        font-size: clamp(1.05rem, 5vw, 1.3rem);
     }
 
     body[data-page-id="questions"] .challenge-hub {


### PR DESCRIPTION
## Summary
- center the challenge hub hero content on smaller screens
- realign and resize challenge stats for better mobile readability

## Testing
- `python manage.py runserver 0.0.0.0:8000` *(fails: Django is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8250fd9a0833388653e0546b421dd