### PR TITLE
Improve mobile layout for challenge hub hero

### DIFF
--- a/assets/css/components/challenge-hub.css
+++ b/assets/css/components/challenge-hub.css
@@ -340,6 +340,13 @@
 
     .challenge-hub__hero {
         padding: clamp(24px, 6vw, 32px);
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+    }
+
+    .challenge-hub__hero-info {
+        align-items: center;
     }
 
     body[data-page-id="questions"] .challenge-hub {
@@ -353,6 +360,10 @@
 
     .challenge-hub__hero-actions {
         flex-direction: column;
+        width: 100%;
+        max-width: 420px;
+        margin: 0 auto;
+        align-items: stretch;
     }
 
     .challenge-hub__grid {
@@ -365,6 +376,23 @@
 
     .challenge-hub__predefined-grid {
         grid-template-columns: 1fr;
+    }
+
+    .challenge-hub__stats {
+        width: 100%;
+        grid-template-columns: 1fr;
+        justify-items: center;
+    }
+
+    .challenge-stat {
+        width: min(100%, 320px);
+        margin: 0 auto;
+        align-items: center;
+        text-align: center;
+    }
+
+    .challenge-stat__value {
+        font-size: clamp(1.25rem, 6vw, 1.6rem);
     }
 
     .challenge-card {


### PR DESCRIPTION
## Summary
- center the challenge hub hero content on small screens for better readability
- widen and center the action buttons stack for mobile users
- refine challenge stats layout and typography for the mobile breakpoint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8250fd9a0833388653e0546b421dd