### PR TITLE
Enable quiz score panel overrides per mode

### DIFF
--- a/docs/score_panel_configuration.md
+++ b/docs/score_panel_configuration.md
@@ -22,15 +22,26 @@ O payload segue o formato abaixo:
   },
   "Por Categoria": { "allow_pause": false },
   "Rápido": { "show_timer": false },
-  "Definido": {}
+  "Definido": {},
+  "Revisão": { "show_timer": false, "allow_pause": false }
 }
 ```
 
 - A chave `default` serve como fallback para todos os modos.
-- As chaves `Por Categoria`, `Rápido` e `Definido` podem sobrescrever qualquer
+- As chaves `Por Categoria`, `Rápido`, `Definido` e `Revisão` podem sobrescrever qualquer
   flag individualmente.
 - Valores são coeridos para booleanos; strings como "sim"/"não" ou `1`/`0`
   também são aceitas.
+
+### Modos adicionais (frontend)
+
+Se existirem experiências de quiz que não criam uma sessão tradicional no
+backend, mas precisam de regras próprias de painel (por exemplo a revisão de
+favoritos), você pode cadastrá-las na configuração
+`QUIZ_SCORE_PANEL_EXTRA_MODES` em `settings.py`. Cada item pode ser uma tupla
+`("valor", "rótulo amigável")` ou apenas uma string. Esses modos adicionais
+passam a aparecer automaticamente no Django Admin tanto nas configurações
+globais quanto nas definições específicas de quiz.
 
 ## Flags disponíveis
 
@@ -52,6 +63,9 @@ O payload segue o formato abaixo:
      conjunto final de flags por modo, fundindo `default` com as sobrescritas.
    - Os endpoints `start_session` e `resume_session` retornam `score_panel_settings`
      junto com os demais dados da sessão.
+   - Quando a sessão é baseada em uma `QuizDefinicao`, os ajustes armazenados em
+     `QuizDefinicao.score_panel_overrides` são mesclados sobre a configuração
+     global, permitindo personalizar o painel para cada quiz definido.
 
 2. **Front-end**
    - O reducer armazena `quiz.scorePanelSettings` durante a inicialização ou
@@ -65,5 +79,7 @@ O payload segue o formato abaixo:
 - `0013_alter_respostasusuarioporsessao_data_resposta` atualiza o campo
   `data_resposta` para `DateTimeField` com `timezone.now` como default, permitindo
   granularidade de horário nas respostas.
+- `0015_quizdefinicao_score_panel_overrides` adiciona ajustes específicos por
+  definição de quiz para o painel lateral.
 
 Certifique-se de rodar `python manage.py migrate` após atualizar o código.

--- a/medquiz_project/settings.py
+++ b/medquiz_project/settings.py
@@ -150,3 +150,11 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 LOGIN_URL = 'login'  # Ou '/accounts/login/' se você estiver usando as URLs padrão do Django Auth diretamente
 LOGIN_REDIRECT_URL = 'quiz:home' # Para onde ir após o login bem-sucedido
 LOGOUT_REDIRECT_URL = 'quiz:home' # Para onde ir após o logout
+
+
+# Modos adicionais de quiz que não criam sessão no backend, mas precisam
+# compartilhar a configuração do painel de pontuação (ex.: revisões locais).
+# Cada item é uma tupla (valor_usado_no_frontend, rótulo_amigável).
+QUIZ_SCORE_PANEL_EXTRA_MODES = [
+    ('Revisão', 'Revisão de Favoritos'),
+]

--- a/quiz/admin.py
+++ b/quiz/admin.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 from django import forms
 from django.urls import reverse
 from django.utils.html import format_html
+from django.utils.text import slugify
 from django.db.models import Count
 from django.forms.models import BaseInlineFormSet
 from django.core.exceptions import ValidationError
@@ -19,11 +20,32 @@ from .models import (
     DesafioDinamico, ProgressoDesafioUsuario, RecompensaNivelResgatada,
     SystemMessageBroadcast,
 )
-from .models import DEFAULT_SCORE_PANEL_SETTINGS
+from .models import (
+    DEFAULT_SCORE_PANEL_SETTINGS,
+    sanitize_score_panel_config,
+    get_registered_score_panel_modes,
+)
 
 admin.site.site_header = "MedQuiz Admin"
 admin.site.site_title = "MedQuiz Administracao"
 admin.site.index_title = "Gestao de Conteudo"
+
+
+def get_score_panel_modes_with_labels():
+    modes = [('default', 'Configuração padrão (todos os modos)')]
+    for mode_value, mode_label in get_registered_score_panel_modes():
+        friendly_label = mode_label or mode_value
+        modes.append((mode_value, f'Modo "{friendly_label}"'))
+    return modes
+
+
+def get_score_panel_mode_prefix(mode_key: str) -> str:
+    if mode_key == 'default':
+        return 'default'
+    try:
+        return SessoesQuizUsuario.ModoQuiz(mode_key).name.lower()
+    except ValueError:
+        return slugify(mode_key, allow_unicode=False).replace('-', '_')
 
 
 class OpcaoRespostaInlineFormSet(BaseInlineFormSet):
@@ -476,31 +498,6 @@ class QuizDefinicaoPerguntaInline(admin.TabularInline):
     verbose_name_plural = "Perguntas do Quiz (com ordem)"
 
 
-@admin.register(QuizDefinicao)
-class QuizDefinicaoAdmin(admin.ModelAdmin):
-    list_display = ('nome_quiz', 'ativo', 'data_criacao_formatada', 'data_atualizacao_formatada', 'contagem_perguntas_definidas')
-    list_filter = ('ativo', 'data_criacao')
-    search_fields = ('nome_quiz', 'descricao')
-    inlines = [QuizDefinicaoPerguntaInline]
-    readonly_fields = ('data_criacao', 'data_atualizacao')
-    fieldsets = (
-        (None, {'fields': ('nome_quiz', 'descricao', 'ativo')}),
-        ('Datas de Auditoria', {'fields': ('data_criacao', 'data_atualizacao'), 'classes': ('collapse',)}),
-    )
-
-    @admin.display(description='Nº de Perguntas')
-    def contagem_perguntas_definidas(self, obj):
-        return obj.perguntas.count()
-
-    @admin.display(description='Criação', ordering='data_criacao')
-    def data_criacao_formatada(self, obj):
-        return obj.data_criacao.strftime("%d/%m/%Y %H:%M") if obj.data_criacao else "-"
-
-    @admin.display(description='Atualização', ordering='data_atualizacao')
-    def data_atualizacao_formatada(self, obj):
-        return obj.data_atualizacao.strftime("%d/%m/%Y %H:%M") if obj.data_atualizacao else "-"
-
-
 class ConfiguracoesGeraisQuizForm(forms.ModelForm):
     """ModelForm customizado para facilitar o gerenciamento do Score Panel."""
 
@@ -547,27 +544,17 @@ class ConfiguracoesGeraisQuizForm(forms.ModelForm):
         ),
     ]
 
-    SCORE_PANEL_MODES = [
-        ('default', 'Configuração padrão (todos os modos)'),
-        (SessoesQuizUsuario.ModoQuiz.POR_CATEGORIA, 'Modo "Por Categoria"'),
-        (SessoesQuizUsuario.ModoQuiz.RAPIDO, 'Modo "Rápido"'),
-        (SessoesQuizUsuario.ModoQuiz.DEFINIDO, 'Modo "Pré-Definido"'),
-    ]
-
-    MODE_FIELD_PREFIXES = {
-        'default': 'default',
-        SessoesQuizUsuario.ModoQuiz.POR_CATEGORIA: 'por_categoria',
-        SessoesQuizUsuario.ModoQuiz.RAPIDO: 'rapido',
-        SessoesQuizUsuario.ModoQuiz.DEFINIDO: 'definido',
-    }
-
     class Meta:
         model = ConfiguracoesGeraisQuiz
         fields = '__all__'
 
     @classmethod
+    def get_score_panel_modes(cls):
+        return get_score_panel_modes_with_labels()
+
+    @classmethod
     def build_field_name(cls, mode_key, flag_key):
-        prefix = cls.MODE_FIELD_PREFIXES[mode_key]
+        prefix = get_score_panel_mode_prefix(mode_key)
         return f"{prefix}_{flag_key}"
 
     def __init__(self, *args, **kwargs):
@@ -578,20 +565,13 @@ class ConfiguracoesGeraisQuizForm(forms.ModelForm):
             self.fields['score_panel_config'].widget = forms.HiddenInput()
             self.fields['score_panel_config'].required = False
 
-        instance_for_sanitization = (
-            self.instance if isinstance(self.instance, ConfiguracoesGeraisQuiz) else ConfiguracoesGeraisQuiz()
-        )
-        sanitized = instance_for_sanitization._sanitize_score_panel_config(
+        sanitized = sanitize_score_panel_config(
             getattr(self.instance, 'score_panel_config', None)
         )
 
-        for mode_key, _mode_label in self.SCORE_PANEL_MODES:
-            prefix = self.MODE_FIELD_PREFIXES[mode_key]
-            mode_settings = (
-                sanitized.get(mode_key)
-                or sanitized.get('default')
-                or DEFAULT_SCORE_PANEL_SETTINGS
-            )
+        for mode_key, _mode_label in self.get_score_panel_modes():
+            prefix = get_score_panel_mode_prefix(mode_key)
+            mode_settings = sanitized.get(mode_key) or sanitized.get('default') or DEFAULT_SCORE_PANEL_SETTINGS
 
             for flag_key, label, help_text in self.SCORE_PANEL_FIELDS:
                 field_name = f"{prefix}_{flag_key}"
@@ -606,32 +586,148 @@ class ConfiguracoesGeraisQuizForm(forms.ModelForm):
         cleaned_data = super().clean()
 
         config_payload = {}
-        for mode_key, _mode_label in self.SCORE_PANEL_MODES:
-            prefix = self.MODE_FIELD_PREFIXES[mode_key]
+        for mode_key, _mode_label in self.get_score_panel_modes():
+            prefix = get_score_panel_mode_prefix(mode_key)
             config_payload[mode_key] = {}
             for flag_key, _label, _help_text in self.SCORE_PANEL_FIELDS:
                 field_name = f"{prefix}_{flag_key}"
                 config_payload[mode_key][flag_key] = bool(cleaned_data.get(field_name, False))
 
-        if isinstance(self.instance, ConfiguracoesGeraisQuiz):
-            cleaned_data['score_panel_config'] = self.instance._sanitize_score_panel_config(config_payload)
-        else:
-            cleaned_data['score_panel_config'] = ConfiguracoesGeraisQuiz()._sanitize_score_panel_config(config_payload)
+        cleaned_data['score_panel_config'] = sanitize_score_panel_config(config_payload)
 
         return cleaned_data
 
 
-for _mode_key, _mode_label in ConfiguracoesGeraisQuizForm.SCORE_PANEL_MODES:
-    for _flag_key, _label, _help_text in ConfiguracoesGeraisQuizForm.SCORE_PANEL_FIELDS:
-        _field_name = ConfiguracoesGeraisQuizForm.build_field_name(_mode_key, _flag_key)
-        if _field_name not in ConfiguracoesGeraisQuizForm.base_fields:
-            _field = forms.BooleanField(
-                label=_label,
-                required=False,
-                help_text=_help_text,
+def register_score_panel_boolean_fields(form_cls):
+    for mode_key, _mode_label in form_cls.get_score_panel_modes():
+        for flag_key, label, help_text in form_cls.SCORE_PANEL_FIELDS:
+            field_name = form_cls.build_field_name(mode_key, flag_key)
+            if field_name not in form_cls.base_fields:
+                field = forms.BooleanField(
+                    label=label,
+                    required=False,
+                    help_text=help_text,
+                )
+                form_cls.base_fields[field_name] = field
+                form_cls.declared_fields[field_name] = field
+
+
+register_score_panel_boolean_fields(ConfiguracoesGeraisQuizForm)
+
+
+
+
+
+class QuizDefinicaoAdminForm(forms.ModelForm):
+    SCORE_PANEL_FIELDS = ConfiguracoesGeraisQuizForm.SCORE_PANEL_FIELDS
+
+    class Meta:
+        model = QuizDefinicao
+        fields = '__all__'
+
+    @classmethod
+    def get_score_panel_modes(cls):
+        return get_score_panel_modes_with_labels()
+
+    @classmethod
+    def build_field_name(cls, mode_key, flag_key):
+        return ConfiguracoesGeraisQuizForm.build_field_name(mode_key, flag_key)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if 'score_panel_overrides' in self.fields:
+            self.fields['score_panel_overrides'].widget = forms.HiddenInput()
+            self.fields['score_panel_overrides'].required = False
+
+        sanitized = sanitize_score_panel_config(
+            getattr(self.instance, 'score_panel_overrides', None)
+        )
+
+        for mode_key, _mode_label in self.get_score_panel_modes():
+            prefix = get_score_panel_mode_prefix(mode_key)
+            mode_settings = sanitized.get(mode_key) or sanitized.get('default') or DEFAULT_SCORE_PANEL_SETTINGS
+            for flag_key, label, help_text in self.SCORE_PANEL_FIELDS:
+                field_name = f"{prefix}_{flag_key}"
+                field = self.fields[field_name]
+                field.initial = bool(
+                    mode_settings.get(
+                        flag_key, DEFAULT_SCORE_PANEL_SETTINGS.get(flag_key, True)
+                    )
+                )
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        overrides_payload = {}
+        for mode_key, _mode_label in self.get_score_panel_modes():
+            prefix = get_score_panel_mode_prefix(mode_key)
+            overrides_payload[mode_key] = {}
+            for flag_key, _label, _help_text in self.SCORE_PANEL_FIELDS:
+                field_name = f"{prefix}_{flag_key}"
+                overrides_payload[mode_key][flag_key] = bool(cleaned_data.get(field_name, False))
+
+        cleaned_data['score_panel_overrides'] = sanitize_score_panel_config(overrides_payload)
+        return cleaned_data
+
+
+register_score_panel_boolean_fields(QuizDefinicaoAdminForm)
+
+
+@admin.register(QuizDefinicao)
+class QuizDefinicaoAdmin(admin.ModelAdmin):
+    form = QuizDefinicaoAdminForm
+    list_display = ('nome_quiz', 'ativo', 'data_criacao_formatada', 'data_atualizacao_formatada', 'contagem_perguntas_definidas')
+    list_filter = ('ativo', 'data_criacao')
+    search_fields = ('nome_quiz', 'descricao')
+    inlines = [QuizDefinicaoPerguntaInline]
+    readonly_fields = ('data_criacao', 'data_atualizacao')
+
+    def get_fieldsets(self, request, obj=None):
+        fieldsets = [
+            (None, {'fields': ('nome_quiz', 'descricao', 'ativo')}),
+        ]
+
+        for mode_key, mode_label in self.form.get_score_panel_modes():
+            title = 'Painel de Pontuação - Configuração Padrão' if mode_key == 'default' else f'Painel de Pontuação - {mode_label}'
+            classes = () if mode_key == 'default' else ('collapse',)
+            description = (
+                'Definições básicas aplicadas a todos os modos quando nenhum ajuste específico estiver definido.'
+                if mode_key == 'default'
+                else 'Personalize os elementos do painel lateral para este modo de quiz nesta definição.'
             )
-            ConfiguracoesGeraisQuizForm.base_fields[_field_name] = _field
-            ConfiguracoesGeraisQuizForm.declared_fields[_field_name] = _field
+            fields = tuple(
+                self.form.build_field_name(mode_key, flag_key)
+                for flag_key, *_ in self.form.SCORE_PANEL_FIELDS
+            )
+            fieldsets.append((title, {'fields': fields, 'classes': classes, 'description': description}))
+
+        fieldsets.append((
+            'Painel de Pontuação - Dados Internos',
+            {
+                'fields': ('score_panel_overrides',),
+                'classes': ('collapse', 'wide'),
+                'description': 'Representação estruturada dos ajustes armazenados para esta definição.',
+            },
+        ))
+        fieldsets.append((
+            'Datas de Auditoria',
+            {'fields': ('data_criacao', 'data_atualizacao'), 'classes': ('collapse',)},
+        ))
+
+        return fieldsets
+
+    @admin.display(description='Nº de Perguntas')
+    def contagem_perguntas_definidas(self, obj):
+        return obj.perguntas.count()
+
+    @admin.display(description='Criação', ordering='data_criacao')
+    def data_criacao_formatada(self, obj):
+        return obj.data_criacao.strftime("%d/%m/%Y %H:%M") if obj.data_criacao else "-"
+
+    @admin.display(description='Atualização', ordering='data_atualizacao')
+    def data_atualizacao_formatada(self, obj):
+        return obj.data_atualizacao.strftime("%d/%m/%Y %H:%M") if obj.data_atualizacao else "-"
 
 
 @admin.register(ConfiguracoesGeraisQuiz)
@@ -646,91 +742,64 @@ class ConfiguracoesGeraisQuizAdmin(admin.ModelAdmin):
         'data_modificacao_formatada',
     )
     readonly_fields = ('data_modificacao',)
-    fieldsets = (
-        (None, {
-            'fields': (
-                'numero_perguntas_quiz_rapido',
-                'pontuacao_por_acerto',
-                'penalidade_por_erro',
-                'multiplicador_bonus_maximo',
+
+    def get_fieldsets(self, request, obj=None):
+        fieldsets = [
+            (
+                None,
+                {
+                    'fields': (
+                        'numero_perguntas_quiz_rapido',
+                        'pontuacao_por_acerto',
+                        'penalidade_por_erro',
+                        'multiplicador_bonus_maximo',
+                    )
+                },
+            ),
+            (
+                'Pontuação Dinâmica',
+                {
+                    'fields': (
+                        'configuracao_pontuacao_dificuldade',
+                        'bonus_sequencia_acertos',
+                    ),
+                    'classes': ('collapse',),
+                    'description': (
+                        'Configure recompensas específicas por dificuldade e os bônus aplicados a sequências de acertos. '
+                        'Essas estruturas JSON permitem integrar regras avançadas sem alterar o código.'
+                    ),
+                },
+            ),
+        ]
+
+        for mode_key, mode_label in self.form.get_score_panel_modes():
+            title = 'Painel de Pontuação - Configuração Padrão' if mode_key == 'default' else f'Painel de Pontuação - {mode_label}'
+            classes = () if mode_key == 'default' else ('collapse',)
+            description = (
+                'Definições básicas aplicadas a todos os modos de quiz por padrão.'
+                if mode_key == 'default'
+                else 'Personalize a visibilidade dos elementos do painel para este modo específico.'
             )
-        }),
-        ('Pontuação Dinâmica', {
-            'fields': (
-                'configuracao_pontuacao_dificuldade',
-                'bonus_sequencia_acertos',
-            ),
-            'classes': ('collapse',),
-            'description': (
-                'Configure recompensas específicas por dificuldade e os bônus aplicados a sequências de acertos. '
-                'Essas estruturas JSON permitem integrar regras avançadas sem alterar o código.'
-            ),
-        }),
-        (
-            'Painel de Pontuação - Configuração Padrão',
-            {
-                'fields': tuple(
-                    ConfiguracoesGeraisQuizForm.build_field_name('default', flag_key)
-                    for flag_key, *_ in ConfiguracoesGeraisQuizForm.SCORE_PANEL_FIELDS
-                ),
-                'description': 'Definições básicas aplicadas a todos os modos de quiz por padrão.',
-            },
-        ),
-        (
-            'Painel de Pontuação - Modo "Por Categoria"',
-            {
-                'fields': tuple(
-                    ConfiguracoesGeraisQuizForm.build_field_name(
-                        SessoesQuizUsuario.ModoQuiz.POR_CATEGORIA,
-                        flag_key,
-                    )
-                    for flag_key, *_ in ConfiguracoesGeraisQuizForm.SCORE_PANEL_FIELDS
-                ),
-                'classes': ('collapse',),
-                'description': 'Personalize quais elementos ficam visíveis quando o usuário escolhe o modo "Por Categoria".',
-            },
-        ),
-        (
-            'Painel de Pontuação - Modo "Rápido"',
-            {
-                'fields': tuple(
-                    ConfiguracoesGeraisQuizForm.build_field_name(
-                        SessoesQuizUsuario.ModoQuiz.RAPIDO,
-                        flag_key,
-                    )
-                    for flag_key, *_ in ConfiguracoesGeraisQuizForm.SCORE_PANEL_FIELDS
-                ),
-                'classes': ('collapse',),
-                'description': 'Controle a visibilidade do painel para quizzes rápidos.',
-            },
-        ),
-        (
-            'Painel de Pontuação - Modo "Pré-Definido"',
-            {
-                'fields': tuple(
-                    ConfiguracoesGeraisQuizForm.build_field_name(
-                        SessoesQuizUsuario.ModoQuiz.DEFINIDO,
-                        flag_key,
-                    )
-                    for flag_key, *_ in ConfiguracoesGeraisQuizForm.SCORE_PANEL_FIELDS
-                ),
-                'classes': ('collapse',),
-                'description': 'Defina quais blocos ficam ativos em quizzes criados previamente.',
-            },
-        ),
-        (
+            fields = tuple(
+                self.form.build_field_name(mode_key, flag_key)
+                for flag_key, *_ in self.form.SCORE_PANEL_FIELDS
+            )
+            fieldsets.append((title, {'fields': fields, 'classes': classes, 'description': description}))
+
+        fieldsets.append((
             'Painel de Pontuação - Dados Internos',
             {
                 'fields': ('score_panel_config',),
                 'classes': ('collapse', 'wide'),
                 'description': 'Campo técnico utilizado para armazenar a configuração consolidada do painel.',
             },
-        ),
-        ('Datas de Auditoria', {
-            'fields': ('data_modificacao',),
-            'classes': ('collapse',),
-        }),
-    )
+        ))
+        fieldsets.append((
+            'Datas de Auditoria',
+            {'fields': ('data_modificacao',), 'classes': ('collapse',)},
+        ))
+
+        return fieldsets
 
     def has_add_permission(self, request):
         # Impede a adição de novas instâncias se uma já existir (padrão Singleton)

--- a/quiz/api/viewsets.py
+++ b/quiz/api/viewsets.py
@@ -314,7 +314,10 @@ class QuizViewSet(viewsets.ViewSet):
                 pass
 
         quiz_config = get_quiz_config()
-        score_panel_settings = quiz_config.get_score_panel_settings_for_mode(modo_quiz_frontend)
+        score_panel_settings = quiz_config.get_score_panel_settings_for_mode(
+            modo_quiz_frontend,
+            quiz_definicao=quiz_definicao_obj,
+        )
 
         return Response({
             'status': 'success',
@@ -666,7 +669,10 @@ class QuizViewSet(viewsets.ViewSet):
                 'sequencia_atual': sessao_ativa.sequencia_acertos_atual,
                 'melhor_sequencia': sessao_ativa.melhor_sequencia_acertos,
                 'data_inicio_sessao_iso': sessao_ativa.data_inicio.isoformat(),
-                'score_panel_settings': quiz_config.get_score_panel_settings_for_mode(sessao_ativa.modo_quiz),
+                'score_panel_settings': quiz_config.get_score_panel_settings_for_mode(
+                    sessao_ativa.modo_quiz,
+                    quiz_definicao=sessao_ativa.id_quiz_definicao,
+                ),
             })
         except Exception:
             return Response(

--- a/quiz/migrations/0015_quizdefinicao_score_panel_overrides.py
+++ b/quiz/migrations/0015_quizdefinicao_score_panel_overrides.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('quiz', '0014_systemmessagebroadcast'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='quizdefinicao',
+            name='score_panel_overrides',
+            field=models.JSONField(
+                blank=True,
+                default=dict,
+                help_text='Permite personalizar a visibilidade dos itens do painel lateral para cada modo de quiz suportado.',
+                verbose_name='Ajustes do Painel de Pontuação',
+            ),
+        ),
+    ]

--- a/quiz/models.py
+++ b/quiz/models.py
@@ -1,8 +1,9 @@
 # quiz/models.py
 from copy import deepcopy
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple, Set
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
@@ -42,12 +43,117 @@ DEFAULT_SCORE_PANEL_SETTINGS: Dict[str, bool] = {
 
 
 def default_score_panel_config() -> Dict[str, Dict[str, bool]]:
-    return {
-        "default": deepcopy(DEFAULT_SCORE_PANEL_SETTINGS),
-        "Por Categoria": deepcopy(DEFAULT_SCORE_PANEL_SETTINGS),
-        "Rápido": deepcopy(DEFAULT_SCORE_PANEL_SETTINGS),
-        "Definido": deepcopy(DEFAULT_SCORE_PANEL_SETTINGS),
+    """Retorna um dicionário padrão para todos os modos de quiz disponíveis."""
+
+    config = {"default": deepcopy(DEFAULT_SCORE_PANEL_SETTINGS)}
+    for mode_value in get_available_quiz_mode_values():
+        config[mode_value] = deepcopy(DEFAULT_SCORE_PANEL_SETTINGS)
+    return config
+
+
+def get_available_quiz_mode_values() -> List[str]:
+    """Lista os valores de todos os modos de quiz registrados."""
+
+    return [value for value, _label in get_registered_score_panel_modes()]
+
+
+def get_additional_score_panel_modes() -> List[Tuple[str, str]]:
+    """Normaliza a configuração de modos extras definidos nas settings."""
+
+    extra_modes = getattr(settings, "QUIZ_SCORE_PANEL_EXTRA_MODES", [])
+    normalized: List[Tuple[str, str]] = []
+
+    if isinstance(extra_modes, dict):
+        iterator = extra_modes.items()
+    else:
+        iterator = extra_modes
+
+    for entry in iterator:
+        value: Optional[str]
+        label: Optional[str]
+
+        if isinstance(entry, (list, tuple)):
+            if not entry:
+                continue
+            value = str(entry[0]) if entry[0] is not None else None
+            label = str(entry[1]) if len(entry) > 1 and entry[1] is not None else None
+        elif isinstance(entry, str):
+            value = entry
+            label = entry
+        else:
+            continue
+
+        if not value:
+            continue
+
+        normalized.append((value, label or value))
+
+    return normalized
+
+
+def get_registered_score_panel_modes() -> List[Tuple[str, str]]:
+    """Retorna todos os modos conhecidos para configuração do painel."""
+
+    modes: List[Tuple[str, str]] = []
+    seen: Set[str] = set()
+
+    try:
+        for choice in SessoesQuizUsuario.ModoQuiz:
+            value = str(choice.value)
+            if value and value not in seen:
+                modes.append((value, str(choice.label)))
+                seen.add(value)
+    except NameError:
+        # Durante migrações iniciais SessoesQuizUsuario pode não estar disponível ainda.
+        pass
+
+    for value, label in get_additional_score_panel_modes():
+        if value not in seen:
+            modes.append((value, label))
+            seen.add(value)
+
+    return modes
+
+
+def _coerce_score_panel_flag(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on", "sim"}:
+            return True
+        if normalized in {"false", "0", "no", "off", "nao", "não"}:
+            return False
+    return default
+
+
+def _coerce_score_panel_settings(data: Optional[Dict[str, Any]]) -> Dict[str, bool]:
+    settings = deepcopy(DEFAULT_SCORE_PANEL_SETTINGS)
+    if not isinstance(data, dict):
+        return settings
+    for key in settings.keys():
+        if key in data:
+            settings[key] = _coerce_score_panel_flag(data[key], settings[key])
+    return settings
+
+
+def sanitize_score_panel_config(payload: Optional[Dict[str, Any]]) -> Dict[str, Dict[str, bool]]:
+    """Normaliza um payload bruto de configuração do painel de pontuação."""
+
+    payload = payload or {}
+    if not isinstance(payload, dict):
+        payload = {}
+
+    sanitized: Dict[str, Dict[str, bool]] = {
+        "default": _coerce_score_panel_settings(payload.get("default"))
     }
+
+    for mode in get_available_quiz_mode_values():
+        sanitized[mode] = _coerce_score_panel_settings(payload.get(mode))
+
+    return sanitized
 
 # --- Modelos de Conteúdo do Quiz ---
 
@@ -394,11 +500,27 @@ class QuizDefinicao(models.Model):
         verbose_name="Quiz Ativo",
         help_text="Se este quiz pode ser selecionado pelos usuários."
     )
+    score_panel_overrides = models.JSONField(
+        default=dict,
+        blank=True,
+        verbose_name="Ajustes do Painel de Pontuação",
+        help_text=(
+            "Permite personalizar a visibilidade dos itens do painel lateral "
+            "para cada modo de quiz suportado."
+        ),
+    )
     data_criacao = models.DateTimeField(auto_now_add=True, verbose_name="Data de Criação")
     data_atualizacao = models.DateTimeField(auto_now=True, verbose_name="Data de Atualização")
 
     def __str__(self):
         return self.nome_quiz
+
+    def save(self, *args, **kwargs):
+        self.score_panel_overrides = sanitize_score_panel_config(self.score_panel_overrides)
+        super().save(*args, **kwargs)
+
+    def get_score_panel_overrides(self) -> Dict[str, Dict[str, bool]]:
+        return sanitize_score_panel_config(self.score_panel_overrides)
 
     class Meta:
         verbose_name = "Definição de Quiz"
@@ -886,7 +1008,7 @@ class ConfiguracoesGeraisQuiz(models.Model):
             raise ValidationError({'penalidade_por_erro': 'A penalidade por erro não pode ser negativa.'})
         self._validate_dificuldades()
         self._validate_bonus()
-        self.score_panel_config = self._sanitize_score_panel_config(self.score_panel_config)
+        self.score_panel_config = sanitize_score_panel_config(self.score_panel_config)
         result = super().save(*args, **kwargs)
         try:
             from .views import invalidate_quiz_config_cache
@@ -948,56 +1070,41 @@ class ConfiguracoesGeraisQuiz(models.Model):
                 raise ValidationError({'bonus_sequencia_acertos': f"O bônus na posição {index} deve ser numérico."})
             last_streak = streak_value
 
-    @staticmethod
-    def _coerce_score_panel_flag(value: Any, default: bool) -> bool:
-        if isinstance(value, bool):
-            return value
-        if isinstance(value, (int, float)):
-            return bool(value)
-        if isinstance(value, str):
-            normalized = value.strip().lower()
-            if normalized in {'true', '1', 'yes', 'on', 'sim'}:
-                return True
-            if normalized in {'false', '0', 'no', 'off', 'nao', 'não'}:
-                return False
-        return default
-
-    def _coerce_score_panel_settings(self, data: Optional[Dict[str, Any]]) -> Dict[str, bool]:
-        settings = deepcopy(DEFAULT_SCORE_PANEL_SETTINGS)
-        if not isinstance(data, dict):
-            return settings
-        for key in settings.keys():
-            if key in data:
-                settings[key] = self._coerce_score_panel_flag(data[key], settings[key])
-        return settings
-
     def _sanitize_score_panel_config(self, payload: Optional[Dict[str, Any]]) -> Dict[str, Dict[str, bool]]:
-        payload = payload or {}
-        if not isinstance(payload, dict):
-            payload = {}
+        """Mantido por compatibilidade retroativa com chamadas existentes."""
 
-        sanitized: Dict[str, Dict[str, bool]] = {}
-        sanitized['default'] = self._coerce_score_panel_settings(payload.get('default'))
+        return sanitize_score_panel_config(payload)
 
-        for mode in (
-            SessoesQuizUsuario.ModoQuiz.POR_CATEGORIA,
-            SessoesQuizUsuario.ModoQuiz.RAPIDO,
-            SessoesQuizUsuario.ModoQuiz.DEFINIDO,
-        ):
-            sanitized[mode] = self._coerce_score_panel_settings(payload.get(mode))
+    @staticmethod
+    def _apply_score_panel_override(
+        base_settings: Dict[str, bool],
+        override_settings: Optional[Dict[str, Any]],
+    ) -> Dict[str, bool]:
+        if not isinstance(override_settings, dict):
+            return base_settings
 
-        return sanitized
+        for key in base_settings.keys():
+            if key in override_settings:
+                base_settings[key] = bool(override_settings[key])
+        return base_settings
 
-    def get_score_panel_settings_for_mode(self, mode: Optional[str] = None) -> Dict[str, bool]:
-        sanitized = self._sanitize_score_panel_config(self.score_panel_config)
+    def get_score_panel_settings_for_mode(
+        self,
+        mode: Optional[str] = None,
+        quiz_definicao: Optional['QuizDefinicao'] = None,
+    ) -> Dict[str, bool]:
+        sanitized = sanitize_score_panel_config(self.score_panel_config)
         resolved = deepcopy(sanitized.get('default', DEFAULT_SCORE_PANEL_SETTINGS))
 
         mode_key = str(mode) if mode else None
         if mode_key and mode_key in sanitized:
-            mode_settings = sanitized.get(mode_key) or {}
-            for key in resolved.keys():
-                if key in mode_settings:
-                    resolved[key] = bool(mode_settings[key])
+            resolved = self._apply_score_panel_override(resolved, sanitized.get(mode_key))
+
+        if quiz_definicao is not None:
+            overrides = quiz_definicao.get_score_panel_overrides()
+            resolved = self._apply_score_panel_override(resolved, overrides.get('default'))
+            if mode_key and mode_key in overrides:
+                resolved = self._apply_score_panel_override(resolved, overrides.get(mode_key))
 
         return resolved
 

--- a/quiz/tests/test_models.py
+++ b/quiz/tests/test_models.py
@@ -1,9 +1,11 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from quiz.models import (
     Categoria,
     CategoriaHierarquia,
     ConfiguracoesGeraisQuiz,
+    DEFAULT_SCORE_PANEL_SETTINGS,
+    QuizDefinicao,
     SessoesQuizUsuario,
 )
 from quiz.views import (
@@ -51,6 +53,35 @@ class QuizConfigCacheTests(TestCase):
 
         category_settings = config.get_score_panel_settings_for_mode(SessoesQuizUsuario.ModoQuiz.POR_CATEGORIA)
         self.assertFalse(category_settings['allow_pause'])
+
+    def test_score_panel_overrides_from_quiz_definition(self):
+        config = get_quiz_config()
+        quiz_def = QuizDefinicao.objects.create(nome_quiz='Simulado Especial', ativo=True)
+
+        overrides = quiz_def.get_score_panel_overrides()
+        overrides['default']['show_timer'] = False
+        overrides[SessoesQuizUsuario.ModoQuiz.DEFINIDO]['show_points'] = False
+        quiz_def.score_panel_overrides = overrides
+        quiz_def.save(update_fields=['score_panel_overrides'])
+
+        inherited = config.get_score_panel_settings_for_mode(quiz_definicao=quiz_def)
+        self.assertFalse(inherited['show_timer'])
+
+        definido_settings = config.get_score_panel_settings_for_mode(
+            SessoesQuizUsuario.ModoQuiz.DEFINIDO,
+            quiz_definicao=quiz_def,
+        )
+        self.assertFalse(definido_settings['show_points'])
+
+    @override_settings(QUIZ_SCORE_PANEL_EXTRA_MODES=[('Revisão', 'Revisão de Favoritos')])
+    def test_extra_modes_inherit_default_score_panel_flags(self):
+        config = get_quiz_config()
+        # O modo adicional deve estar presente no JSON sanitizado e carregar todas as flags.
+        self.assertIn('Revisão', config.score_panel_config)
+
+        revision_settings = config.get_score_panel_settings_for_mode('Revisão')
+        for flag in DEFAULT_SCORE_PANEL_SETTINGS.keys():
+            self.assertIn(flag, revision_settings)
 
 
 class CategoriaHierarchyTests(TestCase):


### PR DESCRIPTION
## Summary
- expose score panel flags in the admin using dynamic mode lists and add a specialized form for quiz definitions
- persist per-definition score panel overrides with sanitization helpers and merge them when returning session payloads
- document the override behaviour and add coverage plus a migration for the new quiz definition field

## Testing
- python manage.py test quiz.tests.test_models

------
https://chatgpt.com/codex/tasks/task_e_68d835f2da9083339c927b68c0f49d14