### PR TITLE
Fix mobile question tab horizontal scroll

### DIFF
--- a/assets/css/components/challenge-hub.css
+++ b/assets/css/components/challenge-hub.css
@@ -343,12 +343,13 @@
         background: linear-gradient(180deg, rgba(13, 59, 102, 0.12) 0%, rgba(13, 59, 102, 0) 45%), var(--color-surface, #ffffff);
         border-radius: clamp(22px, 7vw, 32px);
         box-shadow: none;
+        overflow-x: hidden;
     }
 
     .challenge-hub::before {
         content: '';
         position: absolute;
-        inset: -42% -48% auto;
+        inset: -42% 0 auto;
         height: clamp(200px, 60vw, 260px);
         background: radial-gradient(80% 80% at 50% 18%, rgba(13, 59, 102, 0.28), rgba(13, 59, 102, 0));
         z-index: -1;


### PR DESCRIPTION
## Summary
- prevent the questions hub from introducing horizontal overflow on small screens
- confine the decorative background glow so it no longer forces lateral scrolling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ac7e09e4833395c4af5910d1f145