### PR TITLE
Rebuild home experience with strategic dashboard

### DIFF
--- a/assets/css/sections/home-section.css
+++ b/assets/css/sections/home-section.css
@@ -1,87 +1,720 @@
 /* assets/css/sections/home-section.css */
 
-#home-section {
-    /* >>> ADICIONAR ESTAS DUAS LINHAS <<< */
-    display: flex;            /* Habilita Flexbox */
-    flex-direction: column; /* Empilha os filhos verticalmente */
-    /* >>> FIM DAS LINHAS A ADICIONAR <<< */
-
-    align-items: center; /* Centraliza os filhos horizontalmente */
-    gap: var(--home-section-gap, clamp(40px, 7vh, 60px)); /* Espaçamento vertical entre filhos */
-    min-height: var(--home-section-min-height, calc(100vh - var(--header-height, 80px) - var(--main-nav-height, 50px) - var(--footer-height, 65px)));
-    padding-bottom: var(--spacing-xl); /* Espaço antes do footer */
-    /* background-color: var(--color-gray-100); */ /* Se precisar de cor de fundo específica */
-    overflow-x: hidden; /* Previne scroll horizontal acidental */
-}
-
-.home-section__additional-content {
+#home-section.home-shell {
     width: 100%;
-    max-width: var(--container-width-md, 800px);
-    margin-left: auto;
-    margin-right: auto;
-    /* Margens superior/inferior são controladas pelo gap da #home-section
-       e pelo padding-bottom da #home-section */
+    padding: clamp(32px, 6vw, 72px) clamp(16px, 6vw, 56px);
+    background: var(--color-gray-50, #f7f9fc);
+    box-sizing: border-box;
 }
 
-/* ... (resto das regras para .card__title, p, .button dentro de .home-section__additional-content) ... */
-.home-section__additional-content .card__title {
-    font-family: var(--font-family-heading);
-    color: var(--color-primary-dark);
-    font-size: clamp(1.4rem, 3.5vw, 1.6rem);
-    margin-bottom: var(--spacing-md, 15px);
+.home-shell__container {
+    width: 100%;
+    max-width: 1240px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(24px, 4vw, 36px);
 }
 
-.home-section__additional-content p {
-    color: var(--color-gray-800);
-    line-height: 1.7;
-    margin-bottom: var(--spacing-lg, 25px);
-    font-size: clamp(0.9rem, 2.2vw, 1rem);
+.home-shell__layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+    gap: clamp(24px, 4vw, 32px);
+    align-items: start;
 }
 
-.home-section__additional-content .button {
-    border-color: var(--color-primary-medium);
-    color: var(--color-primary-medium);
+.home-shell__primary,
+.home-shell__sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(20px, 3vw, 28px);
+}
+
+.home-hero.card {
+    --card-padding: clamp(24px, 5vw, 40px);
+    --card-border-color: transparent;
+    position: relative;
+    overflow: hidden;
+    background: linear-gradient(140deg,
+            rgba(var(--color-primary-light-rgb, 180, 219, 245), 0.55) 0%,
+            rgba(255, 255, 255, 0.96) 55%,
+            rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.3) 100%);
+    box-shadow: var(--shadow-xl, 0 40px 90px -50px rgba(14, 63, 116, 0.55));
+    border-radius: var(--border-radius-xxl, 28px);
+    display: grid;
+    grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+    gap: clamp(24px, 4vw, 32px);
+}
+
+.home-hero__intro {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(16px, 3vw, 20px);
+    color: var(--color-gray-900);
+}
+
+.home-hero__eyebrow {
+    font-size: 0.75rem;
     font-weight: var(--font-weight-semibold);
-    padding: 10px 20px;
-    font-size: clamp(0.85rem, 2vw, 0.95rem);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--color-primary-dark, #0f4c81);
 }
 
-.home-section__additional-content .button:hover {
-    background-color: var(--color-primary-light);
-    border-color: var(--color-primary-dark);
-    color: var(--color-primary-dark);
+.home-hero__eyebrow::before {
+    content: "";
+    width: 32px;
+    height: 2px;
+    background: currentColor;
+    opacity: 0.6;
 }
 
+.home-hero__title {
+    font-size: clamp(2rem, 4vw, 2.6rem);
+    font-weight: var(--font-weight-semibold);
+    margin: 0;
+}
 
-/* --- Responsividade --- */
-/* (As media queries permanecem as mesmas da resposta anterior) */
-@media (max-width: 992px) {
-    .home-section__additional-content {
-        margin-left: clamp(20px, 3vw, 40px);
-        margin-right: clamp(20px, 3vw, 40px);
-        width: auto;
+.home-hero__subtitle {
+    font-size: clamp(1rem, 2.2vw, 1.2rem);
+    margin: 0;
+    color: var(--color-gray-800);
+    line-height: 1.6;
+}
+
+.home-hero__cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.home-hero__summary {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(16px, 3vw, 24px);
+}
+
+.home-progress {
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: var(--border-radius-xl, 22px);
+    padding: clamp(18px, 3.5vw, 24px);
+    border: 1px solid rgba(var(--color-primary-light-rgb, 180, 219, 245), 0.6);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.home-progress__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+    font-weight: var(--font-weight-medium, 500);
+    color: var(--color-gray-900);
+}
+
+.home-progress__title {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.85rem;
+}
+
+.home-progress__counter {
+    font-size: 0.95rem;
+    color: var(--color-primary-dark, #0f4c81);
+}
+
+.home-progress__bar {
+    position: relative;
+    width: 100%;
+    height: 12px;
+    border-radius: 999px;
+    background: rgba(var(--color-primary-light-rgb, 180, 219, 245), 0.4);
+    overflow: hidden;
+}
+
+.home-progress__bar span {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, var(--color-primary-medium, #3b82f6), var(--color-secondary-green, #2a9d8f));
+    border-radius: inherit;
+    transition: width var(--transition-medium, 0.35s) ease;
+}
+
+.home-progress__message,
+.home-progress__meta,
+.home-progress__session {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--color-gray-700);
+    line-height: 1.5;
+}
+
+.home-progress__session {
+    font-weight: var(--font-weight-medium, 500);
+    color: var(--color-primary-dark, #0f4c81);
+}
+
+.home-hero__callout {
+    background: rgba(15, 76, 129, 0.08);
+    border-radius: var(--border-radius-xl, 22px);
+    padding: clamp(18px, 3.2vw, 24px);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    color: var(--color-primary-dark, #0f4c81);
+}
+
+.home-hero__callout-label {
+    font-size: 0.85rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    opacity: 0.8;
+}
+
+.home-hero__callout-value {
+    font-size: clamp(1.8rem, 3vw, 2.2rem);
+    font-weight: var(--font-weight-semibold);
+}
+
+.home-hero__callout-text {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--color-gray-800);
+    line-height: 1.5;
+}
+
+.home-plan.card,
+.home-focus.card,
+.home-strengths.card,
+.home-momentum.card,
+.home-weekly.card,
+.home-sessions.card,
+.home-actions.card,
+.home-lifetime.card {
+    --card-padding: clamp(20px, 3.6vw, 28px);
+}
+
+.home-plan__header,
+.home-focus__header,
+.home-strengths__header,
+.home-weekly__header,
+.home-sessions__header,
+.home-actions__header,
+.home-lifetime__header,
+.home-momentum__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+    margin-bottom: clamp(12px, 2vw, 18px);
+}
+
+.home-plan__title,
+.home-focus__title,
+.home-strengths__title,
+.home-weekly__title,
+.home-sessions__title,
+.home-actions__title,
+.home-lifetime__title,
+.home-momentum__title {
+    margin: 0;
+    font-size: clamp(1.2rem, 2.4vw, 1.35rem);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-gray-900);
+}
+
+.home-plan__subtitle,
+.home-focus__subtitle,
+.home-strengths__subtitle,
+.home-sessions__subtitle,
+.home-lifetime__subtitle {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--color-gray-600);
+}
+
+.plan-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(12px, 2.4vw, 18px);
+}
+
+.plan-list__item {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 16px;
+    align-items: start;
+    padding: clamp(14px, 2.6vw, 18px);
+    border-radius: var(--border-radius-lg, 18px);
+    background: var(--color-gray-50, #f7f9fc);
+    border: 1px solid rgba(15, 76, 129, 0.08);
+}
+
+.plan-list__item--priority {
+    border-color: rgba(15, 76, 129, 0.35);
+    background: rgba(15, 76, 129, 0.08);
+}
+
+.plan-list__item--completed {
+    border-color: rgba(42, 157, 143, 0.25);
+    background: rgba(42, 157, 143, 0.08);
+}
+
+.plan-list__icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: white;
+    color: var(--color-primary-medium, #3b82f6);
+    box-shadow: 0 12px 28px -18px rgba(15, 76, 129, 0.45);
+}
+
+.plan-list__icon .material-symbols-outlined {
+    font-size: 1.6rem;
+}
+
+.plan-list__content {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.plan-list__header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.plan-list__title {
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-gray-900);
+}
+
+.plan-list__badge {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    border-radius: 999px;
+    padding: 4px 10px;
+    background: var(--color-gray-200, #e4e8ef);
+    color: var(--color-gray-700);
+    font-weight: var(--font-weight-semibold);
+}
+
+.plan-list__badge--priority,
+.plan-list__item--priority .plan-list__badge {
+    background: rgba(191, 72, 0, 0.15);
+    color: #b74800;
+}
+
+.plan-list__badge--active {
+    background: rgba(59, 130, 246, 0.15);
+    color: #1d4ed8;
+}
+
+.plan-list__badge--completed {
+    background: rgba(42, 157, 143, 0.2);
+    color: #1f7a6c;
+}
+
+.plan-list__badge--suggestion {
+    background: rgba(107, 114, 128, 0.18);
+    color: rgba(55, 65, 81, 0.9);
+}
+
+.plan-list__description {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--color-gray-700);
+    line-height: 1.5;
+}
+
+.plan-list__progress {
+    width: 100%;
+    height: 8px;
+    border-radius: 999px;
+    background: rgba(15, 76, 129, 0.15);
+    overflow: hidden;
+}
+
+.plan-list__progress span {
+    display: block;
+    height: 100%;
+    background: linear-gradient(90deg, var(--color-secondary-green, #2a9d8f), var(--color-primary-medium, #3b82f6));
+}
+
+.plan-list__progress-hint {
+    font-size: 0.8rem;
+    color: var(--color-gray-600);
+}
+
+.plan-list__action {
+    align-self: center;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark, #0f4c81);
+    text-decoration: none;
+}
+
+.plan-list__action:hover {
+    text-decoration: underline;
+}
+
+.focus-list,
+.strengths-list,
+.quick-links,
+.sessions-timeline {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(12px, 2.6vw, 18px);
+}
+
+.focus-list__item {
+    padding: clamp(14px, 2.4vw, 18px);
+    border-radius: var(--border-radius-lg, 18px);
+    border: 1px solid rgba(15, 76, 129, 0.1);
+    background: var(--color-gray-50, #f8fbff);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.strengths-list__item {
+    padding: clamp(14px, 2.4vw, 18px);
+    border-radius: var(--border-radius-lg, 18px);
+    border: 1px solid rgba(15, 76, 129, 0.1);
+    background: rgba(42, 157, 143, 0.08);
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.focus-list__item--alta {
+    border-color: rgba(191, 72, 0, 0.35);
+    background: rgba(191, 72, 0, 0.08);
+}
+
+.focus-list__item--moderada {
+    border-color: rgba(15, 76, 129, 0.2);
+}
+
+.focus-list__head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+}
+
+.focus-list__name,
+.strengths-list__name {
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-gray-900);
+}
+
+.focus-list__accuracy,
+.strengths-list__accuracy {
+    font-size: 1.1rem;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark, #0f4c81);
+}
+
+.focus-list__tip {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--color-gray-700);
+    line-height: 1.5;
+}
+
+.focus-list__meta,
+.strengths-list__meta {
+    font-size: 0.85rem;
+    color: var(--color-gray-600);
+}
+
+.focus-list__empty,
+.strengths-list__empty,
+.sessions-timeline__empty {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--color-gray-600);
+}
+
+.momentum-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: clamp(12px, 2.6vw, 18px);
+}
+
+.momentum-grid__item {
+    border: 1px solid rgba(15, 76, 129, 0.12);
+    border-radius: var(--border-radius-lg, 18px);
+    padding: clamp(14px, 2.6vw, 18px);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    background: var(--color-gray-50, #f7f9fc);
+}
+
+.momentum-grid__icon {
+    font-size: 1.6rem;
+    color: var(--color-primary-medium, #3b82f6);
+}
+
+.momentum-grid__value {
+    font-size: 1.4rem;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-gray-900);
+}
+
+.momentum-grid__label {
+    font-size: 0.9rem;
+    color: var(--color-gray-600);
+}
+
+.momentum-grid__hint {
+    font-size: 0.82rem;
+    color: var(--color-gray-600);
+    margin: 0;
+    line-height: 1.4;
+}
+
+.home-weekly__accuracy {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--color-primary-dark, #0f4c81);
+}
+
+.home-weekly__grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: clamp(12px, 2.6vw, 18px);
+}
+
+.home-weekly__item {
+    border: 1px solid rgba(15, 76, 129, 0.12);
+    border-radius: var(--border-radius-lg, 18px);
+    padding: clamp(12px, 2.4vw, 16px);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    background: var(--color-gray-50, #f7f9fc);
+}
+
+.home-weekly__icon {
+    font-size: 1.4rem;
+    color: var(--color-primary-medium, #3b82f6);
+}
+
+.home-weekly__value {
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-gray-900);
+}
+
+.home-weekly__label {
+    font-size: 0.85rem;
+    color: var(--color-gray-600);
+}
+
+.home-weekly__insight {
+    margin: clamp(12px, 2.2vw, 16px) 0 0;
+    font-size: 0.95rem;
+    color: var(--color-gray-700);
+    line-height: 1.5;
+}
+
+.sessions-timeline__item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 16px;
+    align-items: start;
+}
+
+.sessions-timeline__marker {
+    display: flex;
+    align-items: flex-start;
+    padding-top: 4px;
+    color: var(--color-primary-medium, #3b82f6);
+}
+
+.sessions-timeline__content {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    border-left: 2px solid rgba(15, 76, 129, 0.12);
+    padding-left: 16px;
+}
+
+.sessions-timeline__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+}
+
+.sessions-timeline__mode {
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-gray-900);
+}
+
+.sessions-timeline__date {
+    font-size: 0.85rem;
+    color: var(--color-gray-600);
+}
+
+.sessions-timeline__stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.sessions-timeline__metric {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.9rem;
+    color: var(--color-gray-700);
+}
+
+.sessions-timeline__metric .material-symbols-outlined {
+    font-size: 1.1rem;
+    color: var(--color-primary-medium, #3b82f6);
+}
+
+.quick-links__item {
+    border: 1px solid rgba(15, 76, 129, 0.12);
+    border-radius: var(--border-radius-lg, 18px);
+    overflow: hidden;
+    background: var(--color-gray-50, #f7f9fc);
+}
+
+.quick-links__link {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 16px;
+    align-items: center;
+    padding: clamp(14px, 2.6vw, 18px);
+    text-decoration: none;
+    color: inherit;
+}
+
+.quick-links__icon {
+    font-size: 1.6rem;
+    color: var(--color-primary-medium, #3b82f6);
+}
+
+.quick-links__title {
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-gray-900);
+}
+
+.quick-links__description {
+    font-size: 0.9rem;
+    color: var(--color-gray-600);
+}
+
+.quick-links__cta {
+    font-size: 0.85rem;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark, #0f4c81);
+}
+
+.home-lifetime__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: clamp(16px, 3vw, 24px);
+}
+
+.home-lifetime__item {
+    border: 1px solid rgba(15, 76, 129, 0.12);
+    border-radius: var(--border-radius-xl, 22px);
+    padding: clamp(16px, 3vw, 20px);
+    display: flex;
+    gap: 14px;
+    align-items: center;
+    background: var(--color-gray-50, #f7f9fc);
+}
+
+.home-lifetime__icon {
+    font-size: 1.8rem;
+    color: var(--color-primary-medium, #3b82f6);
+}
+
+.home-lifetime__value {
+    font-size: 1.2rem;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-gray-900);
+}
+
+.home-lifetime__label {
+    font-size: 0.9rem;
+    color: var(--color-gray-600);
+}
+
+@media (max-width: 1180px) {
+    .home-hero.card {
+        grid-template-columns: 1fr;
+    }
+
+    .home-hero__summary {
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+
+    .home-hero__summary > * {
+        flex: 1 1 260px;
     }
 }
 
-@media (max-width: 768px) {
-    #home-section {
-        min-height: calc(100vh - var(--header-height-mobile, 70px) - var(--bottom-nav-height, 60px));
-        gap: var(--home-section-gap-mobile, clamp(30px, 6vh, 50px));
-        padding-bottom: var(--spacing-lg);
+@media (max-width: 980px) {
+    .home-shell__layout {
+        grid-template-columns: 1fr;
     }
-    .home-section__additional-content {
-        margin-left: var(--spacing-md, 20px);
-        margin-right: var(--spacing-md, 20px);
+
+    .home-shell__sidebar {
+        flex-direction: column;
     }
 }
 
-@media (max-width: 480px) {
-    #home-section {
-        min-height: calc(100vh - var(--header-height-small-mobile, 65px) - var(--bottom-nav-height, 60px));
-        gap: var(--home-section-gap-small-mobile, clamp(25px, 5vh, 40px));
+@media (max-width: 640px) {
+    #home-section.home-shell {
+        padding: clamp(24px, 8vw, 40px) clamp(12px, 5vw, 20px);
     }
-    .home-section__additional-content {
-        margin-left: var(--spacing-sm, 15px);
-        margin-right: var(--spacing-sm, 15px);
+
+    .home-hero__cta {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .plan-list__item {
+        grid-template-columns: auto 1fr;
+    }
+
+    .plan-list__action {
+        grid-column: span 2;
+        justify-self: flex-start;
+    }
+
+    .quick-links__link {
+        grid-template-columns: auto 1fr;
+        grid-template-rows: auto auto;
+    }
+
+    .quick-links__cta {
+        grid-column: 2;
+        justify-self: flex-end;
     }
 }

--- a/quiz/templates/quiz/home.html
+++ b/quiz/templates/quiz/home.html
@@ -1,169 +1,262 @@
-{# Arquivo: templates/quiz/home.html #} 
-{% extends "quiz/base.html" %} 
-{% load static %} 
-{% block title %}{{ page_title|default:"MedQuiz - Início" }}{%endblock title %} 
+{% extends "quiz/base.html" %}
+{% load static %}
+{% block title %}{{ page_title|default:"MedQuiz - Início" }}{% endblock title %}
 {% block content %}
-<section id="home-section" class="main-section">
-	<div class="hero-block">
-		<div class="hero-block__welcome">
-			{% if user.is_authenticated %}
-			<h1 class="hero-block__title">
-				Olá, {{ user.first_name|default:user.username }}!
-			</h1>
-			{% else %}
-			<h1 class="hero-block__title">Bem-vindo ao MedQuiz!</h1>
-			{% endif %}
-			<p class="hero-block__subtitle">
-				Pronto para expandir seus conhecimentos hoje?
-			</p>
-		</div>
+<section id="home-section" class="home-shell">
+    <div class="home-shell__container">
+        <div class="home-shell__layout">
+            <div class="home-shell__primary">
+                <section class="card home-hero">
+                    <div class="home-hero__intro">
+                        <p class="home-hero__eyebrow">Seu hub estratégico</p>
+                        <h1 class="home-hero__title">Olá, {{ user.first_name|default:user.username }}!</h1>
+                        <p class="home-hero__subtitle">{{ weekly_insight }}</p>
+                        <div class="home-hero__cta">
+                            {% if ongoing_session %}
+                                <a href="{% url 'quiz:questions' %}" class="button button--fancy button--fancy-primary">
+                                    <span class="material-symbols-outlined button__icon">play_arrow</span>
+                                    <span class="button__label">Retomar sessão</span>
+                                </a>
+                                <a href="{% url 'quiz:questions' %}" class="button button--fancy button--fancy-secondary">
+                                    <span class="material-symbols-outlined button__icon">auto_awesome</span>
+                                    <span class="button__label">Novo desafio</span>
+                                </a>
+                            {% else %}
+                                <a href="{% url 'quiz:questions' %}" class="button button--fancy button--fancy-primary">
+                                    <span class="material-symbols-outlined button__icon">rocket_launch</span>
+                                    <span class="button__label">Iniciar agora</span>
+                                </a>
+                                <a href="{% url 'quiz:questions' %}" class="button button--ghost">
+                                    <span class="material-symbols-outlined button__icon">grid_view</span>
+                                    <span class="button__label">Explorar modos</span>
+                                </a>
+                            {% endif %}
+                        </div>
+                    </div>
+                    <div class="home-hero__summary">
+                        <div class="home-progress">
+                            <header class="home-progress__header">
+                                <span class="home-progress__title">Meta diária</span>
+                                <span class="home-progress__counter">{{ daily_goal.answered }}/{{ daily_goal.target }} questões</span>
+                            </header>
+                            <div class="home-progress__bar" role="progressbar" aria-valuenow="{{ daily_goal.progress }}" aria-valuemin="0" aria-valuemax="100">
+                                <span style="width: {{ daily_goal.progress }}%;"></span>
+                            </div>
+                            <p class="home-progress__message">{{ daily_goal.message }}</p>
+                            <p class="home-progress__meta">Tempo de estudo hoje: {{ daily_goal.study_time }}</p>
+                            {% if ongoing_session %}
+                                <p class="home-progress__session">
+                                    Sessão em andamento: {{ ongoing_session.answered }}/{{ ongoing_session.total }} questões • {{ ongoing_session.progress }}% concluído.
+                                </p>
+                            {% endif %}
+                        </div>
+                        <div class="home-hero__callout">
+                            <span class="home-hero__callout-label">Precisão semanal</span>
+                            <span class="home-hero__callout-value">{{ weekly_accuracy }}</span>
+                            <p class="home-hero__callout-text">{{ weekly_insight }}</p>
+                        </div>
+                    </div>
+                </section>
 
-		{% if user.is_authenticated and daily_stats %}
-		<div class="stats-deck">
-			<div class="stat-card">
-				<span class="material-symbols-outlined stat-card__icon"
-					>checklist</span
-				>
-				<span class="stat-card__label">Respondidas Hoje</span>
-				<span class="stat-card__value" id="daily-questions"
-					>{{ daily_stats.perguntas_respondidas_dia }}</span
-				>
-			</div>
-			<div class="stat-card">
-				<span class="material-symbols-outlined stat-card__icon"
-					>target</span
-				>
-				<span class="stat-card__label">Acertos Hoje</span>
-				<span class="stat-card__value" id="daily-accuracy"
-					>{{ accuracy_percentage }}</span
-				>
-			</div>
-			<div class="stat-card">
-				<span class="material-symbols-outlined stat-card__icon"
-					>military_tech</span
-				>
-				<span class="stat-card__label">Pontos Hoje</span>
-				<span class="stat-card__value" id="daily-points"
-					>{{ daily_stats.pontos_dia }}</span
-				>
-			</div>
-			<div class="stat-card">
-				<span class="material-symbols-outlined stat-card__icon"
-					>local_fire_department</span
-				>
-				<span class="stat-card__label">Sequência Dias</span>
-				<span class="stat-card__value" id="streak-value"
-					>{{ daily_stats.sequencia_dias_quiz }}</span
-				>
-			</div>
-		</div>
-		{% else %}
-		<div class="stats-deck">
-			<div class="stat-card">
-				<span class="material-symbols-outlined stat-card__icon"
-					>quiz</span
-				>
-				<span class="stat-card__label">Muitas Questões</span>
-				{# Este span será preenchido pelo script.js após carregar os
-				dados da API #}
-				<span class="stat-card__value" id="hub-total-questions-count"
-					>...</span
-				>
-			</div>
-			<div class="stat-card">
-				<span class="material-symbols-outlined stat-card__icon"
-					>school</span
-				>
-				<span class="stat-card__label">Aprenda Mais</span>
-				<span class="stat-card__value">Sempre!</span>
-			</div>
-			<div class="stat-card">
-				<span class="material-symbols-outlined stat-card__icon"
-					>military_tech</span
-				>
-				<span class="stat-card__label">Ganhe Pontos</span>
-				<span class="stat-card__value">Jogue!</span>
-			</div>
-			<div class="stat-card">
-				<span class="material-symbols-outlined stat-card__icon"
-					>person_add</span
-				>
-				<span class="stat-card__label">Crie Conta</span>
-				<span class="stat-card__value">Grátis!</span>
-			</div>
-		</div>
-		{% endif %}
+                <section class="card home-plan">
+                    <header class="home-plan__header">
+                        <div>
+                            <h2 class="home-plan__title">Plano do dia</h2>
+                            <p class="home-plan__subtitle">Atualize seu ritmo com as próximas ações prioritárias.</p>
+                        </div>
+                    </header>
+                    <ol class="plan-list" role="list">
+                        {% for item in daily_plan %}
+                            <li class="plan-list__item plan-list__item--{{ item.status }}">
+                                <div class="plan-list__icon">
+                                    <span class="material-symbols-outlined">{{ item.icon }}</span>
+                                </div>
+                                <div class="plan-list__content">
+                                    <div class="plan-list__header">
+                                        <span class="plan-list__title">{{ item.title }}</span>
+                                        <span class="plan-list__badge plan-list__badge--{{ item.status }}">
+                                            {% if item.status == 'priority' %}Prioridade{% elif item.status == 'active' %}Em andamento{% elif item.status == 'completed' %}Concluído{% else %}Sugestão{% endif %}
+                                        </span>
+                                    </div>
+                                    <p class="plan-list__description">{{ item.description }}</p>
+                                    {% if item.progress is not None %}
+                                        <div class="plan-list__progress" role="progressbar" aria-valuenow="{{ item.progress }}" aria-valuemin="0" aria-valuemax="100">
+                                            <span style="width: {{ item.progress }}%;"></span>
+                                        </div>
+                                        <span class="plan-list__progress-hint">{{ item.progress }}% concluído</span>
+                                    {% endif %}
+                                </div>
+                                {% if item.action_url and item.action_label %}
+                                    <a href="{{ item.action_url }}" class="plan-list__action">{{ item.action_label }}</a>
+                                {% endif %}
+                            </li>
+                        {% endfor %}
+                    </ol>
+                </section>
 
-		<div class="hero-block__cta">
-			{% if user.is_authenticated %}
-			<p class="hero-block__cta-text">
-				Pronto para testar seus conhecimentos?
-			</p>
-			<div class="hero-block__cta-actions">
-				<a
-					href="{% url 'quiz:questions' %}"
-					class="button button--fancy button--fancy-primary"
-					id="go-to-challenges-hub-link"
-				>
-					<span class="material-symbols-outlined button__icon"
-						>rocket_launch</span
-					>
-					<span class="button__label">Iniciar Desafio</span>
-				</a>
-			</div>
-			{% else %}
-			<p class="hero-block__cta-text">
-				Crie sua conta ou faça login para salvar seu progresso e
-				competir!
-			</p>
-			<div
-				class="hero-block__cta-actions"
-				style="
-					display: flex;
-					gap: 15px;
-					flex-wrap: wrap;
-					justify-content: center;
-				"
-			>
-				<a
-					href="{% url 'quiz:register' %}"
-					class="button button--fancy button--fancy-primary"
-				>
-					<span class="material-symbols-outlined button__icon"
-						>person_add</span
-					>
-					Cadastre-se Gratuitamente
-				</a>
-				<a
-					href="{% url 'login' %}"
-					class="button button--fancy button--fancy-secondary"
-				>
-					<span class="material-symbols-outlined button__icon"
-						>login</span
-					>
-					Fazer Login
-				</a>
-			</div>
-			{% endif %}
-		</div>
-	</div>
-	<div class="home-section__additional-content">
-		<div class="card card--additional-content card--centered-content">
-			<h2 class="card__title">Explore Mais</h2>
-			<div class="card__body">
-				<p>
-					Ainda desenvolvendo esta área, mas aqui você poderá
-					encontrar artigos, dicas de estudo e outros recursos para
-					complementar seu aprendizado.
-				</p>
-				<a
-					href="{% url 'quiz:questions' %}"
-					class="button button--outline button--small"
-					id="view-all-questions-alt-link"
-					>Ver Banco de Questões</a
-				>
-			</div>
-		</div>
-	</div>
+                <section class="card home-focus">
+                    <header class="home-focus__header">
+                        <div>
+                            <h2 class="home-focus__title">Áreas que pedem atenção</h2>
+                            <p class="home-focus__subtitle">Baseado no desempenho dos últimos 30 dias.</p>
+                        </div>
+                    </header>
+                    {% if focus_areas %}
+                        <ul class="focus-list" role="list">
+                            {% for area in focus_areas %}
+                                <li class="focus-list__item focus-list__item--{{ area.priority }}">
+                                    <div class="focus-list__head">
+                                        <span class="focus-list__name">{{ area.name }}</span>
+                                        <span class="focus-list__accuracy">{{ area.accuracy_display }}</span>
+                                    </div>
+                                    <p class="focus-list__tip">{{ area.tip }}</p>
+                                    <span class="focus-list__meta">{{ area.total_questions }} questões analisadas</span>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    {% else %}
+                        <p class="focus-list__empty">Nenhuma lacuna relevante detectada. Continue respondendo quizzes para identificar novas oportunidades.</p>
+                    {% endif %}
+                </section>
+
+                <section class="card home-strengths">
+                    <header class="home-strengths__header">
+                        <div>
+                            <h2 class="home-strengths__title">Seus pontos fortes</h2>
+                            <p class="home-strengths__subtitle">Categorias nas quais você mantém alta consistência.</p>
+                        </div>
+                    </header>
+                    {% if strengths %}
+                        <ul class="strengths-list" role="list">
+                            {% for category in strengths %}
+                                <li class="strengths-list__item">
+                                    <span class="strengths-list__name">{{ category.name }}</span>
+                                    <span class="strengths-list__accuracy">{{ category.accuracy }}</span>
+                                    <span class="strengths-list__meta">{{ category.total }} questões</span>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    {% else %}
+                        <p class="strengths-list__empty">Responda mais quizzes para revelar suas especialidades.</p>
+                    {% endif %}
+                </section>
+            </div>
+
+            <aside class="home-shell__sidebar">
+                <section class="card home-momentum">
+                    <header class="home-momentum__header">
+                        <h2 class="home-momentum__title">Ritmo de hoje</h2>
+                    </header>
+                    <div class="momentum-grid">
+                        {% for stat in today_momentum %}
+                            <article class="momentum-grid__item">
+                                <span class="material-symbols-outlined momentum-grid__icon">{{ stat.icon }}</span>
+                                <span class="momentum-grid__value">{{ stat.value }}</span>
+                                <span class="momentum-grid__label">{{ stat.label }}</span>
+                                {% if stat.hint %}
+                                    <p class="momentum-grid__hint">{{ stat.hint }}</p>
+                                {% endif %}
+                            </article>
+                        {% endfor %}
+                    </div>
+                </section>
+
+                <section class="card home-weekly">
+                    <header class="home-weekly__header">
+                        <h2 class="home-weekly__title">Resumo da semana</h2>
+                        <span class="home-weekly__accuracy">Precisão média: {{ weekly_accuracy }}</span>
+                    </header>
+                    <div class="home-weekly__grid">
+                        {% for metric in weekly_metrics %}
+                            <div class="home-weekly__item">
+                                <span class="material-symbols-outlined home-weekly__icon">{{ metric.icon }}</span>
+                                <span class="home-weekly__value">{{ metric.value }}</span>
+                                <span class="home-weekly__label">{{ metric.label }}</span>
+                            </div>
+                        {% endfor %}
+                    </div>
+                    <p class="home-weekly__insight">{{ weekly_insight }}</p>
+                </section>
+
+                <section class="card home-sessions">
+                    <header class="home-sessions__header">
+                        <h2 class="home-sessions__title">Progresso recente</h2>
+                        <p class="home-sessions__subtitle">Últimas sessões concluídas</p>
+                    </header>
+                    {% if recent_sessions %}
+                        <ul class="sessions-timeline" role="list">
+                            {% for session in recent_sessions %}
+                                <li class="sessions-timeline__item">
+                                    <div class="sessions-timeline__marker">
+                                        <span class="material-symbols-outlined" aria-hidden="true">radio_button_checked</span>
+                                    </div>
+                                    <div class="sessions-timeline__content">
+                                        <div class="sessions-timeline__header">
+                                            <span class="sessions-timeline__mode">{{ session.mode }}</span>
+                                            <time class="sessions-timeline__date" datetime="{{ session.date|date:'Y-m-d' }}">{{ session.date|date:"d 'de' M" }}</time>
+                                        </div>
+                                        <div class="sessions-timeline__stats">
+                                            <span class="sessions-timeline__metric">
+                                                <span class="material-symbols-outlined" aria-hidden="true">target</span>
+                                                {{ session.accuracy }}
+                                            </span>
+                                            <span class="sessions-timeline__metric">
+                                                <span class="material-symbols-outlined" aria-hidden="true">military_tech</span>
+                                                {{ session.score }} pts
+                                            </span>
+                                            <span class="sessions-timeline__metric">
+                                                <span class="material-symbols-outlined" aria-hidden="true">quiz</span>
+                                                {{ session.questions }}
+                                            </span>
+                                        </div>
+                                    </div>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    {% else %}
+                        <p class="sessions-timeline__empty">Finalize um desafio para começar a construir seu histórico por aqui.</p>
+                    {% endif %}
+                </section>
+
+                <section class="card home-actions">
+                    <header class="home-actions__header">
+                        <h2 class="home-actions__title">Atalhos estratégicos</h2>
+                    </header>
+                    <ul class="quick-links" role="list">
+                        {% for action in quick_actions %}
+                            <li class="quick-links__item">
+                                <a href="{{ action.url }}" class="quick-links__link">
+                                    <span class="quick-links__icon material-symbols-outlined">{{ action.icon }}</span>
+                                    <span class="quick-links__content">
+                                        <span class="quick-links__title">{{ action.title }}</span>
+                                        <span class="quick-links__description">{{ action.description }}</span>
+                                    </span>
+                                    <span class="quick-links__cta">{{ action.cta_label }}</span>
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </section>
+            </aside>
+        </div>
+
+        <section class="card home-lifetime">
+            <header class="home-lifetime__header">
+                <h2 class="home-lifetime__title">Panorama geral</h2>
+                <p class="home-lifetime__subtitle">Indicadores acumulados da sua jornada.</p>
+            </header>
+            <div class="home-lifetime__grid">
+                {% for item in lifetime_overview_items %}
+                    <div class="home-lifetime__item">
+                        <span class="material-symbols-outlined home-lifetime__icon">{{ item.icon }}</span>
+                        <div class="home-lifetime__content">
+                            <span class="home-lifetime__value">{{ item.value }}</span>
+                            <span class="home-lifetime__label">{{ item.label }}</span>
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+        </section>
+    </div>
 </section>
-{% endblock content %} 
+{% endblock content %}

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -9,12 +9,14 @@ from django.utils import timezone
 from datetime import timedelta  # Mantido, pode ser útil
 from django.db.models import (
     Q, Sum, Count, Case, When, Value, FloatField, ExpressionWrapper, Prefetch,
-    Max,
+    Max, IntegerField, F,
 )
 from django.contrib import messages
 from django.urls import reverse, reverse_lazy
 from django.contrib.auth.models import User
 from collections import defaultdict
+
+from typing import Optional
 
 from .models import (
     Pergunta, Categoria, CategoriaHierarquia, OpcaoResposta,
@@ -153,6 +155,230 @@ def _get_theme_options_metadata():
 
 def _filter_queryset_by_period(queryset, period_str: str, date_field_name: str = "data_estatistica"):
     return StatisticsService.filter_queryset_by_period(queryset, period_str, date_field_name)
+
+# endregion
+
+# region Auxiliares da Home
+
+
+def _format_duration_from_seconds(total_seconds: int) -> str:
+    """Converte segundos em uma string legível (ex.: ``1h 20m``)."""
+    if not total_seconds:
+        return "0m"
+
+    total_seconds = int(total_seconds)
+    hours, remainder = divmod(max(total_seconds, 0), 3600)
+    minutes, seconds = divmod(remainder, 60)
+
+    parts = []
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes:
+        parts.append(f"{minutes}m")
+    if not parts:
+        parts.append(f"{seconds}s")
+    return " ".join(parts)
+
+
+def _get_top_categories_for_user(user: User, *, period_days: int = 30, limit: int = 3):
+    """Retorna as principais categorias do usuário em um período específico."""
+    time_threshold = timezone.now() - timedelta(days=period_days)
+    categories_qs = (
+        Categoria.objects.filter(
+            perguntas_associadas__respostas_dadas_em_sessoes__id_sessao_quiz__id_usuario=user,
+            perguntas_associadas__respostas_dadas_em_sessoes__id_sessao_quiz__status_sessao=SessoesQuizUsuario.StatusSessao.COMPLETA,
+            perguntas_associadas__respostas_dadas_em_sessoes__foi_correta__isnull=False,
+            perguntas_associadas__respostas_dadas_em_sessoes__data_resposta__gte=time_threshold,
+        )
+        .annotate(
+            total_respostas=Count('perguntas_associadas__respostas_dadas_em_sessoes'),
+            acertos=Sum(
+                Case(
+                    When(
+                        perguntas_associadas__respostas_dadas_em_sessoes__foi_correta=True,
+                        then=1,
+                    ),
+                    default=0,
+                    output_field=IntegerField(),
+                )
+            ),
+        )
+        .filter(total_respostas__gt=0)
+        .order_by('-acertos', '-total_respostas')
+    )
+
+    top_categories = []
+    for category in categories_qs[:limit]:
+        accuracy = 0
+        if category.total_respostas:
+            accuracy = (category.acertos or 0) / category.total_respostas * 100
+        top_categories.append({
+            'name': category.nome_categoria,
+            'accuracy': f"{accuracy:.0f}%",
+            'total': category.total_respostas,
+        })
+    return top_categories
+
+
+# region Novos auxiliares da Home remodelada
+
+
+def _build_focus_area_tip(accuracy_value: float) -> str:
+    """Gera uma orientação textual baseada no desempenho da categoria."""
+    if accuracy_value < 40:
+        return (
+            "Reserve um bloco guiado de revisão e resolva 10 questões comentadas para recuperar a base."
+        )
+    if accuracy_value < 60:
+        return (
+            "Reveja suas anotações e refaça um mini simulado focado nesta categoria ainda hoje."
+        )
+    if accuracy_value < 75:
+        return (
+            "Faça uma sessão concentrada com 5 questões de dificuldade média e revise cada explicação."
+        )
+    return "Mantenha revisões leves para consolidar o que já foi aprendido."
+
+
+def _get_focus_areas_for_user(user: User, *, period_days: int = 30, limit: int = 3):
+    """Retorna as categorias com menor desempenho para orientar revisões."""
+    time_threshold = timezone.now() - timedelta(days=period_days)
+    categories_qs = (
+        Categoria.objects.filter(
+            perguntas_associadas__respostas_dadas_em_sessoes__id_sessao_quiz__id_usuario=user,
+            perguntas_associadas__respostas_dadas_em_sessoes__id_sessao_quiz__status_sessao=SessoesQuizUsuario.StatusSessao.COMPLETA,
+            perguntas_associadas__respostas_dadas_em_sessoes__foi_correta__isnull=False,
+            perguntas_associadas__respostas_dadas_em_sessoes__data_resposta__gte=time_threshold,
+        )
+        .annotate(
+            total_respostas=Count('perguntas_associadas__respostas_dadas_em_sessoes'),
+            acertos=Sum(
+                Case(
+                    When(
+                        perguntas_associadas__respostas_dadas_em_sessoes__foi_correta=True,
+                        then=1,
+                    ),
+                    default=0,
+                    output_field=IntegerField(),
+                )
+            ),
+        )
+        .annotate(
+            accuracy=ExpressionWrapper(
+                Case(
+                    When(total_respostas__gt=0, then=F('acertos') * 100.0 / F('total_respostas')),
+                    default=Value(0.0),
+                    output_field=FloatField(),
+                ),
+                output_field=FloatField(),
+            )
+        )
+        .filter(total_respostas__gte=3)
+        .order_by('accuracy', '-total_respostas')
+    )
+
+    focus_areas = []
+    for category in categories_qs[:limit]:
+        accuracy_value = float(category.accuracy or 0)
+        if accuracy_value >= 85:
+            continue
+        priority = 'alta' if accuracy_value < 50 else 'moderada'
+        focus_areas.append({
+            'name': category.nome_categoria,
+            'accuracy_display': f"{accuracy_value:.0f}%",
+            'accuracy_value': accuracy_value,
+            'total_questions': category.total_respostas,
+            'priority': priority,
+            'tip': _build_focus_area_tip(accuracy_value),
+        })
+
+    return focus_areas
+
+
+def _build_daily_plan(
+    daily_goal_context: dict,
+    ongoing_session_data: Optional[dict],
+    focus_areas: list,
+    favorites_count: int,
+    *,
+    questions_url: str,
+    favorites_url: str,
+):
+    """Monta o plano do dia exibido no hub principal."""
+    plan_items = []
+
+    if ongoing_session_data:
+        plan_items.append({
+            'icon': 'play_circle',
+            'title': 'Retomar sessão em andamento',
+            'description': (
+                f"{ongoing_session_data['answered']} de {ongoing_session_data['total']} questões concluídas."
+            ),
+            'status': 'priority',
+            'progress': ongoing_session_data['progress'],
+            'action_url': questions_url,
+            'action_label': 'Continuar',
+        })
+
+    if daily_goal_context['progress'] < 100:
+        plan_items.append({
+            'icon': 'flag',
+            'title': 'Completar meta diária',
+            'description': daily_goal_context['message'],
+            'status': 'active',
+            'progress': daily_goal_context['progress'],
+            'action_url': questions_url,
+            'action_label': 'Responder agora',
+        })
+    else:
+        plan_items.append({
+            'icon': 'emoji_events',
+            'title': 'Meta diária batida',
+            'description': 'Ótimo ritmo! Escolha um próximo desafio para manter a constância.',
+            'status': 'completed',
+            'progress': daily_goal_context['progress'],
+            'action_url': questions_url,
+            'action_label': 'Explorar desafios',
+        })
+
+    if focus_areas:
+        focus_area = focus_areas[0]
+        plan_items.append({
+            'icon': 'lightbulb',
+            'title': f"Reforçar {focus_area['name']}",
+            'description': focus_area['tip'],
+            'status': 'suggestion' if focus_area['priority'] == 'moderada' else 'priority',
+            'progress': None,
+            'action_url': None,
+            'action_label': None,
+        })
+
+    if favorites_count:
+        plan_items.append({
+            'icon': 'bookmark_added',
+            'title': 'Revisar questões favoritas',
+            'description': (
+                'Consolide os aprendizados revisitando as questões marcadas como favoritas.'
+            ),
+            'status': 'active' if favorites_count > 5 else 'suggestion',
+            'progress': None,
+            'action_url': favorites_url,
+            'action_label': 'Abrir lista',
+        })
+
+    if not plan_items:
+        plan_items.append({
+            'icon': 'celebration',
+            'title': 'Tudo em dia!',
+            'description': 'Você está com o plano atualizado. Experimente um novo modo de estudo.',
+            'status': 'completed',
+            'progress': None,
+            'action_url': questions_url,
+            'action_label': 'Criar sessão',
+        })
+
+    return plan_items
+
 
 # endregion
 
@@ -508,22 +734,315 @@ def _get_difficulty_performance_data(user_sessions_period_qs):
 
 @login_required
 def home_view(request):
-    daily_stats = None
-    accuracy_percentage_str = "0%"
-    if request.user.is_authenticated:
-        # **** CHAMADA CORRIGIDA ****
-        daily_stats = get_or_create_daily_stats(request.user)
-        if daily_stats and daily_stats.perguntas_respondidas_dia > 0:
-            accuracy = (daily_stats.acertos_dia /
-                        daily_stats.perguntas_respondidas_dia) * 100
-            accuracy_percentage_str = f"{accuracy:.0f}%"
-        elif daily_stats:
-            accuracy_percentage_str = "0%"
+    user = request.user
+    daily_stats = get_or_create_daily_stats(user)
+
+    accuracy_percentage_value = 0.0
+    if daily_stats.perguntas_respondidas_dia > 0:
+        accuracy_percentage_value = (
+            daily_stats.acertos_dia / daily_stats.perguntas_respondidas_dia
+        ) * 100
+    accuracy_percentage_str = f"{accuracy_percentage_value:.0f}%" if accuracy_percentage_value else "0%"
+
+    today_stat_cards = [
+        {
+            'icon': 'checklist',
+            'label': 'Respondidas hoje',
+            'value': daily_stats.perguntas_respondidas_dia,
+        },
+        {
+            'icon': 'target',
+            'label': 'Taxa de acerto',
+            'value': accuracy_percentage_str,
+        },
+        {
+            'icon': 'stars',
+            'label': 'XP no dia',
+            'value': daily_stats.xp_ganho_dia,
+        },
+        {
+            'icon': 'local_fire_department',
+            'label': 'Sequência ativa',
+            'value': daily_stats.sequencia_dias_quiz,
+        },
+    ]
+
+    daily_goal_questions = 20
+    answered_today = daily_stats.perguntas_respondidas_dia
+    remaining_questions = max(daily_goal_questions - answered_today, 0)
+    daily_progress_percentage = 0
+    if daily_goal_questions > 0:
+        daily_progress_percentage = min(
+            100, round((answered_today / daily_goal_questions) * 100)
+        )
+    if remaining_questions:
+        daily_goal_message = (
+            f"Faltam {remaining_questions} questão"
+            f"{'s' if remaining_questions != 1 else ''} para bater a meta."
+        )
+    else:
+        daily_goal_message = "Meta diária concluída! Excelente ritmo."
+
+    weekly_stats_qs = _filter_queryset_by_period(
+        EstatisticasDiariasUsuario.objects.filter(id_usuario=user),
+        "7d",
+    )
+    weekly_totals = weekly_stats_qs.aggregate(
+        total_questions=Sum('perguntas_respondidas_dia'),
+        total_correct=Sum('acertos_dia'),
+        total_points=Sum('pontos_dia'),
+        total_xp=Sum('xp_ganho_dia'),
+        total_time=Sum('tempo_estudo_segundos_dia'),
+    )
+    weekly_total_questions = weekly_totals.get('total_questions') or 0
+    weekly_total_correct = weekly_totals.get('total_correct') or 0
+    weekly_accuracy_value = 0.0
+    if weekly_total_questions:
+        weekly_accuracy_value = (
+            weekly_total_correct / weekly_total_questions
+        ) * 100
+
+    if weekly_total_questions == 0:
+        weekly_insight = (
+            "Comece um novo quiz para gerar seus indicadores desta semana."
+        )
+    elif weekly_accuracy_value >= 85:
+        weekly_insight = "Excelente consistência! Continue acumulando vitórias."
+    elif weekly_accuracy_value >= 60:
+        weekly_insight = "Bom ritmo. Revise os tópicos que ficaram abaixo da média para evoluir ainda mais."
+    else:
+        weekly_insight = "Hora de revisar as anotações e reforçar os pontos desafiadores."
+
+    weekly_summary = {
+        'total_questions': weekly_total_questions,
+        'total_points': weekly_totals.get('total_points') or 0,
+        'total_xp': weekly_totals.get('total_xp') or 0,
+        'study_time': _format_duration_from_seconds(weekly_totals.get('total_time') or 0),
+        'accuracy_value': weekly_accuracy_value,
+        'accuracy': f"{weekly_accuracy_value:.0f}%" if weekly_total_questions else "--",
+        'insight': weekly_insight,
+        'has_activity': weekly_total_questions > 0,
+    }
+
+    monthly_stats_qs = _filter_queryset_by_period(
+        EstatisticasDiariasUsuario.objects.filter(id_usuario=user),
+        "30d",
+    )
+    key_metrics = _get_key_metrics(user, monthly_stats_qs)
+    lifetime_overview = {
+        'total_score': key_metrics.get('total_score_all_time', 0),
+        'total_xp': key_metrics.get('total_xp_all_time', 0),
+        'max_streak': key_metrics.get('max_streak', 0),
+        'total_questions': key_metrics.get('total_questions_answered', 0),
+        'study_time': _format_duration_from_seconds(key_metrics.get('total_study_time_seconds', 0)),
+    }
+
+    top_categories = _get_top_categories_for_user(user)
+    focus_areas = _get_focus_areas_for_user(user)
+
+    ongoing_session_data = None
+    ongoing_session = (
+        SessoesQuizUsuario.objects.filter(
+            id_usuario=user,
+            status_sessao=SessoesQuizUsuario.StatusSessao.EM_ANDAMENTO,
+        )
+        .order_by('-data_inicio')
+        .first()
+    )
+    if ongoing_session:
+        total_questions_session = ongoing_session.total_perguntas_sessao
+        if not total_questions_session and isinstance(ongoing_session.ids_perguntas_json, list):
+            total_questions_session = len(ongoing_session.ids_perguntas_json)
+        answered_session = (ongoing_session.total_acertos or 0) + (ongoing_session.total_erros or 0)
+        session_progress = 0
+        if total_questions_session:
+            session_progress = min(
+                100,
+                int((answered_session / total_questions_session) * 100),
+            )
+        ongoing_session_data = {
+            'mode': getattr(ongoing_session, 'get_modo_quiz_display', lambda: ongoing_session.modo_quiz)(),
+            'answered': answered_session,
+            'total': total_questions_session,
+            'progress': session_progress,
+        }
+
+    recent_sessions = []
+    recent_sessions_qs = (
+        SessoesQuizUsuario.objects.filter(
+            id_usuario=user,
+            status_sessao=SessoesQuizUsuario.StatusSessao.COMPLETA,
+        )
+        .order_by('-data_inicio')[:3]
+    )
+    for session in recent_sessions_qs:
+        recent_sessions.append({
+            'id': session.pk,
+            'mode': getattr(session, 'get_modo_quiz_display', lambda: session.modo_quiz)(),
+            'score': session.pontuacao_final,
+            'accuracy': f"{session.percentual_acertos:.0f}%" if session.percentual_acertos else "0%",
+            'questions': session.total_perguntas_sessao,
+            'date': session.data_inicio,
+        })
+
+    favorite_questions_count = QuestaoFavorita.objects.filter(usuario=user).count()
+
+    questions_url = reverse('quiz:questions')
+    favorites_url = f"{reverse('quiz:account')}#favorite-questions"
+    preferences_url = reverse('quiz:update_preferences')
+    progression_url = f"{reverse('quiz:account')}#progression"
+
+    daily_goal_context = {
+        'target': daily_goal_questions,
+        'answered': answered_today,
+        'progress': daily_progress_percentage,
+        'message': daily_goal_message,
+        'study_time': daily_stats.tempo_estudo_formatado,
+    }
+
+    daily_plan = _build_daily_plan(
+        daily_goal_context,
+        ongoing_session_data,
+        focus_areas,
+        favorite_questions_count,
+        questions_url=questions_url,
+        favorites_url=favorites_url,
+    )
+
+    today_momentum = []
+    for stat in today_stat_cards:
+        hint = ''
+        if stat['label'] == 'Respondidas hoje':
+            hint = daily_goal_message
+        elif stat['label'] == 'Taxa de acerto':
+            hint = 'Busque manter acima de 75% para evoluir com consistência.'
+        elif stat['label'] == 'XP no dia':
+            hint = 'Somatório considerando bônus aplicados hoje.'
+        elif stat['label'] == 'Sequência ativa':
+            hint = 'Tente alcançar uma sequência de 7 dias ou mais.'
+
+        today_momentum.append({
+            'icon': stat['icon'],
+            'label': stat['label'],
+            'value': stat['value'],
+            'hint': hint,
+        })
+
+    weekly_metrics = [
+        {
+            'icon': 'quiz',
+            'label': 'Questões na semana',
+            'value': weekly_summary['total_questions'],
+        },
+        {
+            'icon': 'military_tech',
+            'label': 'Pontos conquistados',
+            'value': weekly_summary['total_points'],
+        },
+        {
+            'icon': 'workspace_premium',
+            'label': 'XP acumulado',
+            'value': weekly_summary['total_xp'],
+        },
+        {
+            'icon': 'schedule',
+            'label': 'Tempo de estudo',
+            'value': weekly_summary['study_time'],
+        },
+    ]
+
+    lifetime_overview_items = [
+        {
+            'icon': 'scoreboard',
+            'label': 'Pontuação acumulada',
+            'value': lifetime_overview['total_score'],
+        },
+        {
+            'icon': 'workspace_premium',
+            'label': 'XP total',
+            'value': lifetime_overview['total_xp'],
+        },
+        {
+            'icon': 'local_fire_department',
+            'label': 'Maior sequência',
+            'value': f"{lifetime_overview['max_streak']} dia{'s' if lifetime_overview['max_streak'] != 1 else ''}",
+        },
+        {
+            'icon': 'task',
+            'label': 'Questões respondidas',
+            'value': lifetime_overview['total_questions'],
+        },
+        {
+            'icon': 'hourglass_bottom',
+            'label': 'Tempo dedicado (30 dias)',
+            'value': lifetime_overview['study_time'],
+        },
+    ]
+
+    strengths = [
+        {
+            'name': category['name'],
+            'accuracy': category['accuracy'],
+            'total': category['total'],
+        }
+        for category in top_categories
+    ]
+
+    if favorite_questions_count == 0:
+        favorites_action_description = 'Comece a favoritar questões para montar uma lista de revisão personalizada.'
+    elif favorite_questions_count == 1:
+        favorites_action_description = 'Você tem 1 questão favorita pronta para revisar.'
+    else:
+        favorites_action_description = (
+            f"Você possui {favorite_questions_count} questões favoritas aguardando revisão."
+        )
+
+    quick_actions = [
+        {
+            'icon': 'rocket_launch',
+            'title': 'Montar novo desafio',
+            'description': 'Personalize tempo e dificuldade para um treino objetivo.',
+            'url': questions_url,
+            'cta_label': 'Configurar',
+        },
+        {
+            'icon': 'star',
+            'title': 'Revisar favoritos',
+            'description': favorites_action_description,
+            'url': favorites_url,
+            'cta_label': 'Abrir',
+        },
+        {
+            'icon': 'tune',
+            'title': 'Ajustar preferências',
+            'description': 'Defina notificações, temas e ritmo de estudo ideais.',
+            'url': preferences_url,
+            'cta_label': 'Personalizar',
+        },
+        {
+            'icon': 'insights',
+            'title': 'Painel completo',
+            'description': 'Visualize gráficos e histórico detalhado da sua evolução.',
+            'url': progression_url,
+            'cta_label': 'Abrir painel',
+        },
+    ]
 
     context = {
         'page_title': 'MedQuiz - Início',
-        'daily_stats': daily_stats,
-        'accuracy_percentage': accuracy_percentage_str,
+        'daily_goal': daily_goal_context,
+        'weekly_summary': weekly_summary,
+        'weekly_metrics': weekly_metrics,
+        'weekly_insight': weekly_summary['insight'],
+        'weekly_accuracy': weekly_summary['accuracy'],
+        'lifetime_overview_items': lifetime_overview_items,
+        'strengths': strengths,
+        'focus_areas': focus_areas,
+        'ongoing_session': ongoing_session_data,
+        'recent_sessions': recent_sessions,
+        'quick_actions': quick_actions,
+        'daily_plan': daily_plan,
+        'today_momentum': today_momentum,
     }
     return render(request, 'quiz/home.html', context)
 


### PR DESCRIPTION
## Summary
- restructure the home view logic to compute daily plans, focus areas, refreshed quick actions, and consolidated lifetime indicators for the landing dashboard
- rebuild the home template into a strategic hero, daily agenda, focus insights, strengths, weekly metrics, session timeline, and action shortcuts for a richer first impression
- replace the home styles with a new responsive layout covering progress widgets, cards, and timeline components to support the updated structure

## Testing
- python manage.py check *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d94587a8b88333a2ba83bbd9f0068f