### PR TITLE
Add adaptive study engine with spaced repetition support

### DIFF
--- a/quiz/admin.py
+++ b/quiz/admin.py
@@ -19,6 +19,7 @@ from .models import (
     NivelGamificacao, Conquista, PerfilGamificacaoUsuario, ConquistaUsuario,
     DesafioDinamico, ProgressoDesafioUsuario, RecompensaNivelResgatada,
     SystemMessageBroadcast,
+    UserQuestionStudyState,
 )
 from .models import (
     DEFAULT_SCORE_PANEL_SETTINGS,
@@ -328,12 +329,12 @@ class RespostasUsuarioPorSessaoInline(admin.TabularInline):
 class SessoesQuizUsuarioAdmin(admin.ModelAdmin):
     list_display = (
         'id', 'link_usuario', 'data_inicio_formatada', 'duracao_sessao_formatada',
-        'modo_quiz', 'status_sessao', 'pontuacao_final', 'xp_total_sessao',
+        'modo_quiz', 'metodo_estudo', 'status_sessao', 'pontuacao_final', 'xp_total_sessao',
         'total_acertos', 'percentual_acertos', 'total_erros',
         'sequencia_acertos_atual', 'melhor_sequencia_acertos',
         'total_perguntas_sessao', 'link_quiz_definicao'
     )
-    list_filter = ('modo_quiz', 'status_sessao', 'data_inicio', 'id_usuario__username', 'id_quiz_definicao')
+    list_filter = ('modo_quiz', 'metodo_estudo', 'status_sessao', 'data_inicio', 'id_usuario__username', 'id_quiz_definicao')
     search_fields = ('id_usuario__username', 'id_usuario__email', 'id', 'id_quiz_definicao__nome_quiz')
     readonly_fields = (
         'data_inicio', 'data_fim', 'tempo_total_segundos', 'pontuacao_final', 'xp_total_sessao',
@@ -349,7 +350,7 @@ class SessoesQuizUsuarioAdmin(admin.ModelAdmin):
 
     fieldsets = (
         ('Informações da Sessão', {
-            'fields': ('id_usuario', 'modo_quiz', 'status_sessao', 'id_quiz_definicao', 'categorias_selecionadas',
+            'fields': ('id_usuario', 'modo_quiz', 'metodo_estudo', 'status_sessao', 'id_quiz_definicao', 'categorias_selecionadas',
                        'dificuldades_selecionadas_json', 'num_questoes_solicitadas')
         }),
         ('Progresso e Estado da Sessão', {
@@ -424,6 +425,17 @@ class RespostasUsuarioPorSessaoAdmin(admin.ModelAdmin):
     @admin.display(description='Data Resposta', ordering='data_resposta')
     def data_resposta_formatada(self, obj):
         return obj.data_resposta.strftime("%d/%m/%Y %H:%M:%S") if obj.data_resposta else "-"
+
+
+@admin.register(UserQuestionStudyState)
+class UserQuestionStudyStateAdmin(admin.ModelAdmin):
+    list_display = (
+        'user', 'pergunta', 'due_at', 'repetitions', 'interval_days', 'easiness_factor', 'last_outcome'
+    )
+    list_filter = ('last_outcome', 'user')
+    search_fields = ('user__username', 'pergunta__texto_pergunta')
+    autocomplete_fields = ['user', 'pergunta', 'last_session']
+    readonly_fields = ('created_at', 'updated_at')
 
 
 @admin.register(EstatisticasDiariasUsuario)

--- a/quiz/api/serializers.py
+++ b/quiz/api/serializers.py
@@ -3,6 +3,9 @@
 from rest_framework import serializers
 
 
+from quiz.services.study_methods import StudyMethodRegistry
+
+
 class QuizDataQuerySerializer(serializers.Serializer):
     category_ids = serializers.CharField(required=False, allow_blank=True)
     difficulty_levels = serializers.CharField(required=False, allow_blank=True)
@@ -11,6 +14,12 @@ class QuizDataQuerySerializer(serializers.Serializer):
     num_questions = serializers.CharField(required=False, allow_blank=True)
     quiz_definicao_id = serializers.IntegerField(required=False)
     search_query = serializers.CharField(required=False, allow_blank=True)
+    study_method = serializers.CharField(required=False, allow_blank=True)
+
+    def validate_study_method(self, value):
+        if not value:
+            return None
+        return StudyMethodRegistry.resolve_key(value)
 
 
 class FilteredQuestionCountSerializer(serializers.Serializer):
@@ -41,6 +50,7 @@ class StartQuizSessionSerializer(serializers.Serializer):
         allow_null=True,
     )
     num_questoes_solicitadas = serializers.IntegerField(required=False, allow_null=True)
+    study_method = serializers.CharField(required=False, allow_blank=True)
 
     def validate_categoria_ids(self, value):
         if value in (None, ''):
@@ -58,6 +68,11 @@ class StartQuizSessionSerializer(serializers.Serializer):
         if value in (None, ''):
             return None
         return value
+
+    def validate_study_method(self, value):
+        if not value:
+            return StudyMethodRegistry.get_default_key()
+        return StudyMethodRegistry.resolve_key(value)
 
 
 class RegisterAnswerSerializer(serializers.Serializer):

--- a/quiz/api/viewsets.py
+++ b/quiz/api/viewsets.py
@@ -31,6 +31,8 @@ from quiz.services.quiz_service import QuizDataService
 from quiz.services.statistics_service import StatisticsService
 from quiz.services.scoring_service import ScoringService
 from quiz.services.gamification_service import GamificationService
+from quiz.services.study_methods import StudyMethodRegistry
+from quiz.services.study_progress import StudyProgressService
 from quiz.views import (
     _get_category_performance_data,
     _get_difficulty_performance_data,
@@ -123,13 +125,19 @@ class QuizViewSet(viewsets.ViewSet):
         quiz_definicao_id = data.get('quiz_definicao_id')
         search_query = data.get('search_query')
 
+        study_method = data.get('study_method')
+
         if quiz_definicao_id:
             quiz_mode = SessoesQuizUsuario.ModoQuiz.DEFINIDO
 
         user_for_favorites = request.user if request.user.is_authenticated else None
 
         try:
-            service = QuizDataService(quiz_config=get_quiz_config(), user=user_for_favorites)
+            service = QuizDataService(
+                quiz_config=get_quiz_config(),
+                user=user_for_favorites,
+                study_method_key=study_method,
+            )
             quiz_data = service.get_quiz_data_dict(
                 category_ids_filter=category_ids_filter,
                 difficulty_levels_filter=difficulty_levels_filter,
@@ -138,6 +146,7 @@ class QuizViewSet(viewsets.ViewSet):
                 num_questions_custom_str=num_questions_custom_str,
                 quiz_definicao_id=quiz_definicao_id,
                 search_query=search_query,
+                study_method_key=study_method,
             )
             return Response(quiz_data)
         except Exception:
@@ -262,6 +271,7 @@ class QuizViewSet(viewsets.ViewSet):
         categoria_ids_str_list = data.get('categoria_ids', [])
         question_ids_in_session = data.get('question_ids_in_session')
         quiz_definicao_id = data.get('quiz_definicao_id')
+        study_method = data.get('study_method') or StudyMethodRegistry.get_default_key()
 
         total_perguntas_sessao = len(question_ids_in_session)
         if not modo_quiz_frontend or total_perguntas_sessao <= 0:
@@ -302,6 +312,7 @@ class QuizViewSet(viewsets.ViewSet):
             indice_ultima_pergunta_vista=0 if total_perguntas_sessao > 0 else None,
             dificuldades_selecionadas_json=data.get('dificuldades_selecionadas'),
             num_questoes_solicitadas=data.get('num_questoes_solicitadas'),
+            metodo_estudo=study_method,
         )
 
         if modo_quiz_frontend == SessoesQuizUsuario.ModoQuiz.POR_CATEGORIA and categoria_ids_str_list:
@@ -380,6 +391,13 @@ class QuizViewSet(viewsets.ViewSet):
                     'foi_correta': foi_correta_calculada,
                     'data_resposta': timezone.now(),
                 },
+            )
+
+            StudyProgressService.register_answer(
+                user=request.user,
+                pergunta=pergunta,
+                was_correct=foi_correta_calculada,
+                session=sessao_quiz,
             )
 
             score_result = self._recalculate_session_metrics(sessao_quiz, quiz_config)

--- a/quiz/migrations/0016_adaptive_study_methods.py
+++ b/quiz/migrations/0016_adaptive_study_methods.py
@@ -1,0 +1,94 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('quiz', '0015_quizdefinicao_score_panel_overrides'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sessoesquizusuario',
+            name='metodo_estudo',
+            field=models.CharField(
+                blank=True,
+                null=True,
+                default='random',
+                max_length=100,
+                verbose_name='Método de Estudo',
+                help_text='Identificador do algoritmo utilizado para selecionar as perguntas da sessão.',
+            ),
+            preserve_default=False,
+        ),
+        migrations.CreateModel(
+            name='UserQuestionStudyState',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('last_reviewed_at', models.DateTimeField(blank=True, null=True, verbose_name='Última Revisão')),
+                ('due_at', models.DateTimeField(blank=True, null=True, verbose_name='Próxima Revisão')),
+                ('repetitions', models.PositiveIntegerField(default=0, verbose_name='Repetições')),
+                ('interval_days', models.PositiveIntegerField(default=1, verbose_name='Intervalo (dias)')),
+                (
+                    'easiness_factor',
+                    models.FloatField(
+                        default=2.5,
+                        help_text='Parâmetro do algoritmo SM-2 usado para revisão espaçada.',
+                        verbose_name='Fator de Facilidade',
+                    ),
+                ),
+                ('correct_streak', models.PositiveIntegerField(default=0, verbose_name='Sequência de Acertos')),
+                ('incorrect_streak', models.PositiveIntegerField(default=0, verbose_name='Sequência de Erros')),
+                ('total_correct', models.PositiveIntegerField(default=0, verbose_name='Total de Acertos')),
+                ('total_incorrect', models.PositiveIntegerField(default=0, verbose_name='Total de Erros')),
+                (
+                    'last_outcome',
+                    models.BooleanField(
+                        blank=True,
+                        null=True,
+                        help_text='True para acerto, False para erro, None para não respondida.',
+                        verbose_name='Último Resultado',
+                    ),
+                ),
+                ('created_at', models.DateTimeField(auto_now_add=True, verbose_name='Criado em')),
+                ('updated_at', models.DateTimeField(auto_now=True, verbose_name='Atualizado em')),
+                (
+                    'last_session',
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=models.SET_NULL,
+                        related_name='study_state_entries',
+                        to='quiz.sessoesquizusuario',
+                        verbose_name='Última Sessão',
+                    ),
+                ),
+                (
+                    'pergunta',
+                    models.ForeignKey(
+                        on_delete=models.CASCADE,
+                        related_name='study_states',
+                        to='quiz.pergunta',
+                        verbose_name='Pergunta',
+                    ),
+                ),
+                (
+                    'user',
+                    models.ForeignKey(
+                        on_delete=models.CASCADE,
+                        related_name='question_study_states',
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name='Usuário',
+                    ),
+                ),
+            ],
+            options={
+                'verbose_name': 'Estado de Estudo da Pergunta',
+                'verbose_name_plural': 'Estados de Estudo das Perguntas',
+                'ordering': ['user', 'pergunta'],
+                'unique_together': {('user', 'pergunta')},
+            },
+        ),
+    ]

--- a/quiz/models.py
+++ b/quiz/models.py
@@ -674,6 +674,14 @@ class SessoesQuizUsuario(models.Model):
         choices=ModoQuiz.choices,
         verbose_name="Modo do Quiz"
     )
+    metodo_estudo = models.CharField(
+        max_length=100,
+        blank=True,
+        null=True,
+        default='random',
+        verbose_name="Método de Estudo",
+        help_text="Identificador do algoritmo utilizado para selecionar as perguntas da sessão.",
+    )
 
     class StatusSessao(models.TextChoices):
         EM_ANDAMENTO = 'Em Andamento', 'Em Andamento'
@@ -851,6 +859,88 @@ class RespostasUsuarioPorSessao(models.Model):
         verbose_name_plural = "Respostas dos Usuários por Sessão"
         unique_together = ('id_sessao_quiz', 'id_pergunta')
         ordering = ['id_sessao_quiz', 'data_resposta']
+
+
+class UserQuestionStudyState(models.Model):
+    """Rastreia o desempenho individual por pergunta para apoiar métodos adaptativos."""
+
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name='question_study_states',
+        verbose_name="Usuário",
+    )
+    pergunta = models.ForeignKey(
+        Pergunta,
+        on_delete=models.CASCADE,
+        related_name='study_states',
+        verbose_name="Pergunta",
+    )
+    last_reviewed_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        verbose_name="Última Revisão",
+    )
+    due_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        verbose_name="Próxima Revisão",
+    )
+    repetitions = models.PositiveIntegerField(
+        default=0,
+        verbose_name="Repetições",
+    )
+    interval_days = models.PositiveIntegerField(
+        default=1,
+        verbose_name="Intervalo (dias)",
+    )
+    easiness_factor = models.FloatField(
+        default=2.5,
+        verbose_name="Fator de Facilidade",
+        help_text="Parâmetro do algoritmo SM-2 usado para revisão espaçada.",
+    )
+    correct_streak = models.PositiveIntegerField(
+        default=0,
+        verbose_name="Sequência de Acertos",
+    )
+    incorrect_streak = models.PositiveIntegerField(
+        default=0,
+        verbose_name="Sequência de Erros",
+    )
+    total_correct = models.PositiveIntegerField(
+        default=0,
+        verbose_name="Total de Acertos",
+    )
+    total_incorrect = models.PositiveIntegerField(
+        default=0,
+        verbose_name="Total de Erros",
+    )
+    last_outcome = models.BooleanField(
+        null=True,
+        blank=True,
+        verbose_name="Último Resultado",
+        help_text="True para acerto, False para erro, None para não respondida.",
+    )
+    last_session = models.ForeignKey(
+        'SessoesQuizUsuario',
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name='study_state_entries',
+        verbose_name="Última Sessão",
+    )
+    created_at = models.DateTimeField(auto_now_add=True, verbose_name="Criado em")
+    updated_at = models.DateTimeField(auto_now=True, verbose_name="Atualizado em")
+
+    class Meta:
+        verbose_name = "Estado de Estudo da Pergunta"
+        verbose_name_plural = "Estados de Estudo das Perguntas"
+        unique_together = ('user', 'pergunta')
+        ordering = ['user', 'pergunta']
+
+    def __str__(self):
+        username = self.user.get_username()
+        return f"{username} • P{self.pergunta_id}"
 
 
 class EstatisticasDiariasUsuario(models.Model):

--- a/quiz/services/quiz_service.py
+++ b/quiz/services/quiz_service.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import random
 from collections import defaultdict
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Tuple
 
 from django.db.models import Case, Count, Prefetch, Q, When
 
@@ -18,6 +17,8 @@ from quiz.models import (
     QuizDefinicao,
     SessoesQuizUsuario,
 )
+
+from .study_methods import StudyMethodContext, StudyMethodRegistry
 
 
 def _normalize_int_list(values: Optional[Iterable[str]]) -> List[int]:
@@ -35,9 +36,10 @@ def _normalize_int_list(values: Optional[Iterable[str]]) -> List[int]:
 class QuizDataService:
     """Builds the payload consumed by the quiz front-end."""
 
-    def __init__(self, *, quiz_config, user=None) -> None:
+    def __init__(self, *, quiz_config, user=None, study_method_key: Optional[str] = None) -> None:
         self.quiz_config = quiz_config
         self.user = user
+        self._study_method_key = StudyMethodRegistry.resolve_key(study_method_key)
 
     def _build_perguntas_queryset(
         self,
@@ -48,26 +50,28 @@ class QuizDataService:
         num_questions_custom_str: Optional[str] = None,
         quiz_definicao_id: Optional[int] = None,
         search_query: Optional[str] = None,
-    ):
+        study_method_key: Optional[str] = None,
+    ) -> Tuple[Iterable[Pergunta], Optional[str], str]:
+        resolved_method = StudyMethodRegistry.resolve_key(study_method_key or self._study_method_key)
         perguntas_qs = Pergunta.objects.filter(ativa=True)
 
         if quiz_definicao_id:
             try:
                 quiz_def = QuizDefinicao.objects.get(pk=quiz_definicao_id, ativo=True)
             except QuizDefinicao.DoesNotExist:
-                return Pergunta.objects.none(), None
+                return Pergunta.objects.none(), None, resolved_method
 
             perguntas_ordenadas_ids = list(
                 quiz_def.quizdefinicaopergunta_set.order_by("ordem").values_list("pergunta_id", flat=True)
             )
             if not perguntas_ordenadas_ids:
-                return Pergunta.objects.none(), quiz_def.nome_quiz
+                return Pergunta.objects.none(), quiz_def.nome_quiz, resolved_method
 
             preserved_order = Case(
                 *[When(pk=pk, then=pos) for pos, pk in enumerate(perguntas_ordenadas_ids)]
             )
             perguntas_qs = Pergunta.objects.filter(pk__in=perguntas_ordenadas_ids, ativa=True).order_by(preserved_order)
-            return perguntas_qs, quiz_def.nome_quiz
+            return perguntas_qs, quiz_def.nome_quiz, resolved_method
 
         if search_query and str(search_query).strip():
             term = str(search_query).strip()
@@ -89,7 +93,7 @@ class QuizDataService:
             if q_difficulty_objects:
                 perguntas_qs = perguntas_qs.filter(q_difficulty_objects)
             else:
-                return Pergunta.objects.none(), None
+                return Pergunta.objects.none(), None, resolved_method
 
         if category_ids_filter:
             valid_category_ids = [cid for cid in category_ids_filter if str(cid).strip().isdigit()]
@@ -98,9 +102,9 @@ class QuizDataService:
                 if descendant_ids:
                     perguntas_qs = perguntas_qs.filter(categorias__pk__in=descendant_ids).distinct()
                 else:
-                    return Pergunta.objects.none(), None
+                    return Pergunta.objects.none(), None, resolved_method
             else:
-                return Pergunta.objects.none(), None
+                return Pergunta.objects.none(), None, resolved_method
 
         num_perguntas_a_selecionar = 0
         if quiz_mode == SessoesQuizUsuario.ModoQuiz.RAPIDO:
@@ -121,11 +125,29 @@ class QuizDataService:
 
         if num_perguntas_a_selecionar > 0:
             all_matching_question_ids = list(perguntas_qs.values_list("pk", flat=True))
-            if len(all_matching_question_ids) > num_perguntas_a_selecionar:
-                selected_ids = random.sample(all_matching_question_ids, num_perguntas_a_selecionar)
-                perguntas_qs = Pergunta.objects.filter(pk__in=selected_ids).order_by("?")
+            if all_matching_question_ids:
+                method = StudyMethodRegistry.get_strategy(resolved_method)
+                context = StudyMethodContext(
+                    quiz_mode=quiz_mode,
+                    category_ids=category_ids_filter,
+                    difficulty_levels=difficulty_levels_filter,
+                    search_query=search_query,
+                )
+                selected_ids = method.select_question_ids(
+                    user=self.user,
+                    base_queryset=Pergunta.objects.filter(pk__in=all_matching_question_ids),
+                    limit=num_perguntas_a_selecionar,
+                    context=context,
+                )
+                if selected_ids:
+                    preserved_order = Case(
+                        *[When(pk=pk, then=pos) for pos, pk in enumerate(selected_ids)]
+                    )
+                    perguntas_qs = Pergunta.objects.filter(pk__in=selected_ids, ativa=True).order_by(preserved_order)
+                else:
+                    perguntas_qs = Pergunta.objects.filter(pk__in=all_matching_question_ids)
 
-        return perguntas_qs, None
+        return perguntas_qs, None, resolved_method
 
     def get_quiz_data_dict(
         self,
@@ -137,8 +159,9 @@ class QuizDataService:
         num_questions_custom_str: Optional[str] = None,
         quiz_definicao_id: Optional[int] = None,
         search_query: Optional[str] = None,
+        study_method_key: Optional[str] = None,
     ):
-        perguntas_qs, quiz_definition_name = self._build_perguntas_queryset(
+        perguntas_qs, quiz_definition_name, resolved_method = self._build_perguntas_queryset(
             category_ids_filter=category_ids_filter,
             difficulty_levels_filter=difficulty_levels_filter,
             quiz_mode=quiz_mode,
@@ -146,6 +169,7 @@ class QuizDataService:
             num_questions_custom_str=num_questions_custom_str,
             quiz_definicao_id=quiz_definicao_id,
             search_query=search_query,
+            study_method_key=study_method_key,
         )
 
         todas_categorias_qs = Categoria.objects.all().order_by("nome_categoria")
@@ -219,6 +243,8 @@ class QuizDataService:
             "categorias": categorias_data_list,
             "opcoesResposta": [opt for opts_list in opcoes_dict_por_pergunta.values() for opt in opts_list],
             "quiz_definition_name": quiz_definition_name,
+            "study_methods": StudyMethodRegistry.list_metadata(),
+            "selected_study_method": resolved_method,
         }
 
     @staticmethod

--- a/quiz/services/study_methods.py
+++ b/quiz/services/study_methods.py
@@ -1,0 +1,209 @@
+"""Infrastructure for adaptive question selection strategies."""
+
+from __future__ import annotations
+
+import random
+from datetime import timedelta
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Type
+
+from django.contrib.auth.models import AbstractBaseUser
+from django.db.models import QuerySet
+from django.utils import timezone
+
+from quiz.models import UserQuestionStudyState
+
+
+@dataclass(frozen=True)
+class StudyMethodContext:
+    """Encapsula metadados relevantes para seleção das perguntas."""
+
+    quiz_mode: Optional[str] = None
+    category_ids: Optional[Iterable[str]] = None
+    difficulty_levels: Optional[Iterable[str]] = None
+    search_query: Optional[str] = None
+
+
+class StudyMethodStrategy:
+    """Contrato base para novos algoritmos de estudo adaptativo."""
+
+    key: str = 'base'
+    display_name: str = 'Base'
+    description: str = ''
+    supports_personalization: bool = False
+
+    def select_question_ids(
+        self,
+        *,
+        user: Optional[AbstractBaseUser],
+        base_queryset: QuerySet,
+        limit: int,
+        context: Optional[StudyMethodContext] = None,
+    ) -> List[int]:
+        raise NotImplementedError
+
+    def serialize_metadata(self) -> Dict[str, object]:
+        return {
+            'key': self.key,
+            'name': self.display_name,
+            'description': self.description,
+            'supports_personalization': bool(self.supports_personalization),
+        }
+
+    @staticmethod
+    def _coerce_limit(limit: Optional[int], max_available: int) -> int:
+        if not isinstance(limit, int) or limit <= 0:
+            return max_available
+        return min(limit, max_available)
+
+
+class RandomStudyMethod(StudyMethodStrategy):
+    """Mantém o comportamento tradicional de seleção aleatória de perguntas."""
+
+    key = 'random'
+    display_name = 'Aleatório Clássico'
+    description = 'Seleciona questões de forma uniforme sem considerar histórico prévio.'
+
+    def select_question_ids(
+        self,
+        *,
+        user: Optional[AbstractBaseUser],
+        base_queryset: QuerySet,
+        limit: int,
+        context: Optional[StudyMethodContext] = None,
+    ) -> List[int]:
+        question_ids = list(base_queryset.values_list('pk', flat=True))
+        if not question_ids:
+            return []
+
+        limit = self._coerce_limit(limit, len(question_ids))
+        if limit == len(question_ids):
+            return question_ids
+
+        return random.sample(question_ids, limit)
+
+
+class SpacedRepetitionStudyMethod(StudyMethodStrategy):
+    """Implementa um fluxo simplificado inspirado no algoritmo SM-2."""
+
+    key = 'spaced_repetition'
+    display_name = 'Revisão Espaçada (SM-2)'
+    description = (
+        'Prioriza cartões vencidos ou próximos do vencimento com base no fator de facilidade, '
+        'abrindo espaço para novas questões quando necessário.'
+    )
+    supports_personalization = True
+
+    def select_question_ids(
+        self,
+        *,
+        user: Optional[AbstractBaseUser],
+        base_queryset: QuerySet,
+        limit: int,
+        context: Optional[StudyMethodContext] = None,
+    ) -> List[int]:
+        if not user or not getattr(user, 'is_authenticated', False):
+            # Sem usuário autenticado, voltamos ao modo aleatório.
+            return RandomStudyMethod().select_question_ids(
+                user=user,
+                base_queryset=base_queryset,
+                limit=limit,
+                context=context,
+            )
+
+        question_ids = list(base_queryset.values_list('pk', flat=True))
+        if not question_ids:
+            return []
+
+        limit = self._coerce_limit(limit, len(question_ids))
+        if limit == 0:
+            return []
+
+        now = timezone.now()
+        states = list(
+            UserQuestionStudyState.objects.filter(
+                user=user,
+                pergunta_id__in=question_ids,
+            )
+        )
+        state_by_question = {state.pergunta_id: state for state in states}
+
+        def _due_weight(state: UserQuestionStudyState) -> float:
+            due = state.due_at or (now - timedelta(days=365))
+            # Prioriza itens atrasados (menor due_at) e com menor sequência de acertos.
+            return (due.timestamp(), -float(state.correct_streak))
+
+        due_states = [
+            state
+            for state in states
+            if state.due_at is None or state.due_at <= now
+        ]
+        due_states.sort(key=_due_weight)
+
+        selected_ids: List[int] = [state.pergunta_id for state in due_states[:limit]]
+
+        if len(selected_ids) < limit:
+            backlog = [state for state in states if state.pergunta_id not in selected_ids]
+            backlog.sort(
+                key=lambda state: (
+                    (state.due_at or (now + timedelta(days=365))).timestamp(),
+                    state.last_reviewed_at or (now - timedelta(days=365)),
+                )
+            )
+            for state in backlog:
+                if len(selected_ids) >= limit:
+                    break
+                selected_ids.append(state.pergunta_id)
+
+        if len(selected_ids) < limit:
+            unseen_ids = [qid for qid in question_ids if qid not in state_by_question]
+            random.shuffle(unseen_ids)
+            selected_ids.extend(unseen_ids[: limit - len(selected_ids)])
+
+        return selected_ids
+
+
+class StudyMethodRegistry:
+    """Registro simples para centralizar os métodos disponíveis."""
+
+    _strategies: Dict[str, StudyMethodStrategy] = {}
+    _default_key: str = 'random'
+
+    @classmethod
+    def register(cls, strategy_cls: Type[StudyMethodStrategy]) -> Type[StudyMethodStrategy]:
+        instance = strategy_cls()
+        if not instance.key:
+            raise ValueError('StudyMethodStrategy subclasses must define a non-empty key.')
+
+        cls._strategies[instance.key] = instance
+        if cls._default_key not in cls._strategies:
+            cls._default_key = instance.key
+        return strategy_cls
+
+    @classmethod
+    def get_default_key(cls) -> str:
+        return cls._default_key
+
+    @classmethod
+    def resolve_key(cls, key: Optional[str]) -> str:
+        if key and key in cls._strategies:
+            return key
+        return cls.get_default_key()
+
+    @classmethod
+    def get_strategy(cls, key: Optional[str]) -> StudyMethodStrategy:
+        resolved = cls.resolve_key(key)
+        strategy = cls._strategies.get(resolved)
+        if not strategy:
+            raise KeyError(f"Nenhuma estratégia registrada para a chave '{resolved}'.")
+        return strategy
+
+    @classmethod
+    def list_metadata(cls) -> List[Dict[str, object]]:
+        return [strategy.serialize_metadata() for strategy in cls._strategies.values()]
+
+
+# Registro padrão dos métodos disponíveis.
+StudyMethodRegistry.register(RandomStudyMethod)
+StudyMethodRegistry.register(SpacedRepetitionStudyMethod)
+

--- a/quiz/services/study_progress.py
+++ b/quiz/services/study_progress.py
@@ -1,0 +1,81 @@
+"""Utilities to keep user study states in sync with quiz interactions."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Optional
+
+from django.contrib.auth.models import AbstractBaseUser
+from django.utils import timezone
+
+from quiz.models import Pergunta, SessoesQuizUsuario, UserQuestionStudyState
+
+
+class StudyProgressService:
+    """Atualiza métricas de desempenho individual para algoritmos adaptativos."""
+
+    MIN_EASINESS = 1.3
+
+    @classmethod
+    def register_answer(
+        cls,
+        *,
+        user: Optional[AbstractBaseUser],
+        pergunta: Pergunta,
+        was_correct: Optional[bool],
+        session: Optional[SessoesQuizUsuario] = None,
+    ) -> Optional[UserQuestionStudyState]:
+        if not user or not getattr(user, 'is_authenticated', False):
+            return None
+
+        if was_correct is None:
+            # Pergunta pulada: não altera algoritmo de revisão.
+            return None
+
+        state, _ = UserQuestionStudyState.objects.get_or_create(
+            user=user,
+            pergunta=pergunta,
+        )
+
+        now = timezone.now()
+        state.last_reviewed_at = now
+        state.last_session = session
+        state.last_outcome = was_correct
+
+        if was_correct:
+            state.total_correct += 1
+            state.correct_streak += 1
+            state.incorrect_streak = 0
+            state.repetitions += 1
+            if state.repetitions == 1:
+                state.interval_days = 1
+            elif state.repetitions == 2:
+                state.interval_days = 6
+            else:
+                state.interval_days = max(1, int(round(state.interval_days * state.easiness_factor)))
+        else:
+            state.total_incorrect += 1
+            state.correct_streak = 0
+            state.incorrect_streak += 1
+            state.repetitions = 0
+            state.interval_days = 1
+
+        quality = 5 if was_correct else 2
+        state.easiness_factor = cls._updated_easiness_factor(state.easiness_factor, quality)
+
+        if was_correct:
+            delta = timedelta(days=state.interval_days)
+        else:
+            # Repetição rápida para erros recentes.
+            delta = timedelta(hours=12)
+
+        state.due_at = now + delta
+        state.save()
+        return state
+
+    @classmethod
+    def _updated_easiness_factor(cls, current: float, quality: int) -> float:
+        # Fórmula tradicional do SM-2.
+        easiness = current + 0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02)
+        return max(cls.MIN_EASINESS, round(easiness, 4))
+

--- a/quiz/tests/test_services.py
+++ b/quiz/tests/test_services.py
@@ -18,6 +18,7 @@ from quiz.models import (
     QuestaoFavorita,
     QuizDefinicao,
     SessoesQuizUsuario,
+    UserQuestionStudyState,
     DesafioDinamico,
     RecompensaNivelResgatada,
 )
@@ -25,6 +26,8 @@ from quiz.services.gamification_service import GamificationService
 from quiz.services.quiz_service import QuizDataService
 from quiz.services.scoring_service import ScoringService, SessionScoreResult
 from quiz.services.statistics_service import StatisticsService
+from quiz.services.study_methods import StudyMethodRegistry
+from quiz.services.study_progress import StudyProgressService
 from quiz.views import get_quiz_config, invalidate_quiz_config_cache
 
 
@@ -65,6 +68,10 @@ class QuizDataServiceTests(TestCase):
         self.assertTrue(question_payload['is_favorited'])
         self.assertEqual(question_payload['opcoes'][0]['texto_opcao'], 'Coração')
         self.assertEqual(data['categorias'][0]['nome_categoria'], 'Cardiologia')
+        self.assertIn('study_methods', data)
+        self.assertIn('selected_study_method', data)
+        self.assertTrue(any(method['key'] == StudyMethodRegistry.get_default_key() for method in data['study_methods']))
+        self.assertEqual(data['selected_study_method'], StudyMethodRegistry.get_default_key())
 
     def test_descendant_category_lookup_filters_questions(self):
         sub_category = Categoria.objects.create(nome_categoria='Pediatria', id_categoria_pai=self.category)
@@ -114,6 +121,76 @@ class QuizDataServiceTests(TestCase):
         self.assertEqual(summary['total_categories'], 1)
         self.assertIn('predefined_quizzes', summary)
         self.assertTrue(any(item['id'] == quiz_def.pk for item in summary['predefined_quizzes']))
+
+
+class StudyAdaptiveEngineTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user('adaptive', 'adaptive@example.com', 'secret')
+        invalidate_quiz_config_cache()
+        ConfiguracoesGeraisQuiz.objects.all().delete()
+        get_quiz_config()
+
+        self.question_due = Pergunta.objects.create(
+            texto_pergunta='Card marcapasso?',
+            nivel_dificuldade=Pergunta.NivelDificuldade.FACIL,
+        )
+        self.question_future = Pergunta.objects.create(
+            texto_pergunta='Anatomia venosa?',
+            nivel_dificuldade=Pergunta.NivelDificuldade.MEDIO,
+        )
+        self.question_new = Pergunta.objects.create(
+            texto_pergunta='Fisiologia renal?',
+            nivel_dificuldade=Pergunta.NivelDificuldade.DIFICIL,
+        )
+
+    def test_register_answer_updates_state(self):
+        StudyProgressService.register_answer(
+            user=self.user,
+            pergunta=self.question_future,
+            was_correct=True,
+            session=None,
+        )
+
+        state = UserQuestionStudyState.objects.get(user=self.user, pergunta=self.question_future)
+        self.assertEqual(state.total_correct, 1)
+        self.assertEqual(state.total_incorrect, 0)
+        self.assertIsNotNone(state.due_at)
+        self.assertGreater(state.due_at, timezone.now())
+
+    def test_spaced_repetition_prioritizes_due_questions(self):
+        StudyProgressService.register_answer(
+            user=self.user,
+            pergunta=self.question_due,
+            was_correct=False,
+            session=None,
+        )
+        due_state = UserQuestionStudyState.objects.get(user=self.user, pergunta=self.question_due)
+        due_state.due_at = timezone.now() - timedelta(hours=1)
+        due_state.save()
+
+        StudyProgressService.register_answer(
+            user=self.user,
+            pergunta=self.question_future,
+            was_correct=True,
+            session=None,
+        )
+
+        method = StudyMethodRegistry.get_strategy('spaced_repetition')
+        base_queryset = Pergunta.objects.filter(pk__in=[
+            self.question_due.pk,
+            self.question_future.pk,
+            self.question_new.pk,
+        ])
+        selected_ids = method.select_question_ids(
+            user=self.user,
+            base_queryset=base_queryset,
+            limit=3,
+            context=None,
+        )
+
+        self.assertEqual(selected_ids[0], self.question_due.pk)
+        self.assertEqual(len(selected_ids), 3)
+        self.assertIn(self.question_new.pk, selected_ids)
 
 
 class StatisticsServiceTests(TestCase):

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -40,6 +40,8 @@ from .services.quiz_service import QuizDataService
 from .services.statistics_service import StatisticsService
 from .services.scoring_service import ScoringService
 from .services.gamification_service import GamificationService
+from .services.study_methods import StudyMethodRegistry
+from .services.study_progress import StudyProgressService
 
 # region Lógica de Negócio e Utilitários de Dados
 
@@ -100,8 +102,13 @@ def get_quiz_data_dict(
     user: User = None,
     quiz_definicao_id=None,
     search_query=None,
+    study_method_key=None,
 ):
-    service = QuizDataService(quiz_config=get_quiz_config(), user=user)
+    service = QuizDataService(
+        quiz_config=get_quiz_config(),
+        user=user,
+        study_method_key=study_method_key,
+    )
     return service.get_quiz_data_dict(
         category_ids_filter=category_ids_filter,
         difficulty_levels_filter=difficulty_levels_filter,
@@ -110,6 +117,7 @@ def get_quiz_data_dict(
         num_questions_custom_str=num_questions_custom_str,
         quiz_definicao_id=quiz_definicao_id,
         search_query=search_query,
+        study_method_key=study_method_key,
     )
 
 # **** FUNÇÃO ADICIONADA AQUI ****
@@ -746,6 +754,7 @@ def api_get_quiz_data_view(request):
     num_questions_custom_str = request.GET.get('num_questions')
     quiz_definicao_id_str = request.GET.get('quiz_definicao_id')
     search_query = request.GET.get('search_query')
+    study_method = request.GET.get('study_method')
 
     category_ids_filter = [cid.strip() for cid in category_ids_str.split(
         ',') if cid.strip()] if category_ids_str else None
@@ -769,6 +778,7 @@ def api_get_quiz_data_view(request):
             user=user_for_favorites,
             quiz_definicao_id=quiz_definicao_id,
             search_query=search_query,
+            study_method_key=study_method,
         )
         return JsonResponse(quiz_data)
     except Exception as e:
@@ -834,6 +844,12 @@ def start_quiz_session_view(request):
         categoria_ids_str_list = data.get('categoria_ids', [])
         question_ids_in_session = data.get('question_ids_in_session', [])
         quiz_definicao_id = data.get('quiz_definicao_id')
+        study_method_raw = data.get('study_method')
+        study_method = (
+            StudyMethodRegistry.resolve_key(study_method_raw)
+            if study_method_raw
+            else StudyMethodRegistry.get_default_key()
+        )
 
         if not isinstance(question_ids_in_session, list) or not all(isinstance(qid, int) for qid in question_ids_in_session):
             return JsonResponse({'status': 'error', 'message': 'IDs de perguntas da sessão inválidos.'}, status=400)
@@ -866,7 +882,8 @@ def start_quiz_session_view(request):
             indice_ultima_pergunta_vista=0 if total_perguntas_sessao > 0 else None,
             dificuldades_selecionadas_json=data.get(
                 'dificuldades_selecionadas'),
-            num_questoes_solicitadas=data.get('num_questoes_solicitadas')
+            num_questoes_solicitadas=data.get('num_questoes_solicitadas'),
+            metodo_estudo=study_method,
         )
 
         if modo_quiz_frontend == SessoesQuizUsuario.ModoQuiz.POR_CATEGORIA and categoria_ids_str_list:
@@ -932,6 +949,13 @@ def register_answer_view(request):
                 'foi_correta': foi_correta_calculada,
                 'data_resposta': timezone.now()
             }
+        )
+
+        StudyProgressService.register_answer(
+            user=request.user,
+            pergunta=pergunta,
+            was_correct=foi_correta_calculada,
+            session=sessao_quiz,
         )
 
         respostas_da_sessao = list(


### PR DESCRIPTION
## Summary
- introduce a study method registry with classic random selection and a new spaced repetition strategy
- persist per-user question review state to drive adaptive scheduling and update quiz session metadata and admin tooling
- wire study method selection through the quiz APIs/UI helpers and extend tests to cover the adaptive pipeline

## Testing
- `python manage.py test quiz.tests.test_services.QuizDataServiceTests` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68d951f0a3608333bfd6e13170f51a79