### PR TITLE
Revamp Django admin styling for MedQuiz

### DIFF
--- a/assets/admin/css/custom-admin.css
+++ b/assets/admin/css/custom-admin.css
@@ -1,0 +1,396 @@
+:root {
+    color-scheme: light;
+    --admin-bg: #f5f7fb;
+    --admin-surface: #ffffff;
+    --admin-border: #e1e6ef;
+    --admin-primary: #0a7cff;
+    --admin-primary-dark: #0656b0;
+    --admin-accent: #0ec7a3;
+    --admin-text: #1d2433;
+    --admin-muted: #667084;
+    --admin-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+    --admin-radius-lg: 18px;
+    --admin-radius-md: 14px;
+    --admin-radius-sm: 10px;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body.login {
+    background: radial-gradient(circle at top left, rgba(10, 124, 255, 0.15), transparent 55%),
+                radial-gradient(circle at bottom right, rgba(14, 199, 163, 0.15), transparent 50%),
+                var(--admin-bg);
+}
+
+#header {
+    background: transparent;
+    border-bottom: none;
+    padding-block: 2.4rem 1.2rem;
+}
+
+.custom-admin__brand {
+    display: flex;
+    gap: 1.4rem;
+    align-items: center;
+}
+
+.custom-admin__brand-icon {
+    width: 58px;
+    height: 58px;
+    border-radius: 18px;
+    display: grid;
+    place-items: center;
+    font-size: 2.1rem;
+    background: linear-gradient(135deg, var(--admin-primary), var(--admin-accent));
+    color: #fff;
+    box-shadow: var(--admin-shadow);
+}
+
+.custom-admin__brand-title {
+    margin: 0;
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: var(--admin-text);
+}
+
+.custom-admin__brand-subtitle {
+    margin: 0.2rem 0 0;
+    color: var(--admin-muted);
+    font-size: 0.95rem;
+}
+
+.custom-admin__quick-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    margin: 1rem 0 0;
+}
+
+.custom-admin__quick-link {
+    background: var(--admin-surface);
+    color: var(--admin-primary);
+    border-radius: 999px;
+    padding: 0.45rem 1rem;
+    font-size: 0.88rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: 1px solid rgba(10, 124, 255, 0.2);
+    transition: background 0.2s ease, transform 0.2s ease;
+    box-shadow: 0 3px 10px rgba(10, 124, 255, 0.12);
+}
+
+.custom-admin__quick-link:hover,
+.custom-admin__quick-link:focus-visible {
+    background: rgba(10, 124, 255, 0.1);
+    transform: translateY(-1px);
+}
+
+.custom-admin__usertools {
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+    font-size: 0.9rem;
+}
+
+.custom-admin__greeting {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    background: var(--admin-surface);
+    padding: 0.45rem 0.85rem;
+    border-radius: 999px;
+    border: 1px solid rgba(102, 112, 132, 0.2);
+}
+
+.custom-admin__avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    background: linear-gradient(135deg, var(--admin-primary), var(--admin-accent));
+    color: #fff;
+    font-weight: 600;
+}
+
+.custom-admin__hello {
+    display: block;
+    font-size: 0.7rem;
+    color: var(--admin-muted);
+}
+
+.custom-admin__usertools-link {
+    color: var(--admin-muted);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.custom-admin__usertools-link:hover,
+.custom-admin__usertools-link:focus-visible {
+    color: var(--admin-primary-dark);
+}
+
+#content {
+    background: var(--admin-bg);
+    padding: 2.4rem;
+}
+
+.change-list #content,
+.change-form #content,
+.dashboard #content {
+    border-radius: var(--admin-radius-lg);
+    box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.04);
+}
+
+#content-main,
+#content-related {
+    background: transparent;
+}
+
+.breadcrumbs {
+    background: transparent;
+    padding: 0;
+    margin: 0 0 1.2rem;
+    font-size: 0.85rem;
+    color: var(--admin-muted);
+}
+
+.breadcrumbs a {
+    color: var(--admin-primary);
+}
+
+.module {
+    border-radius: var(--admin-radius-md);
+    border: 1px solid rgba(15, 23, 42, 0.05);
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.05);
+    background: var(--admin-surface);
+}
+
+.module caption,
+.module h2 {
+    background: transparent;
+    color: var(--admin-text);
+    font-weight: 600;
+}
+
+.custom-admin__messages .messagelist {
+    padding: 0;
+}
+
+.custom-admin__messages .messagelist li {
+    border-radius: var(--admin-radius-md);
+    border: 1px solid rgba(15, 23, 42, 0.07);
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+    padding: 0.8rem 1rem;
+    margin-bottom: 0.8rem;
+}
+
+.custom-admin__welcome {
+    background: var(--admin-surface);
+    border-radius: var(--admin-radius-lg);
+    padding: 2rem;
+    box-shadow: var(--admin-shadow);
+    border: 1px solid rgba(15, 23, 42, 0.06);
+    margin-bottom: 2rem;
+    display: grid;
+    gap: 1.6rem;
+}
+
+.custom-admin__welcome h2 {
+    margin: 0 0 0.45rem;
+    font-size: 1.6rem;
+}
+
+.custom-admin__welcome p {
+    margin: 0;
+    color: var(--admin-muted);
+    max-width: 620px;
+}
+
+.custom-admin__stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+}
+
+.custom-admin__stat-card {
+    background: linear-gradient(135deg, rgba(10, 124, 255, 0.12), rgba(14, 199, 163, 0.12));
+    padding: 1.1rem 1.3rem;
+    border-radius: var(--admin-radius-md);
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    border: 1px solid rgba(10, 124, 255, 0.2);
+}
+
+.custom-admin__stat-icon {
+    font-size: 1.9rem;
+}
+
+.custom-admin__stat-card strong {
+    display: block;
+    font-size: 1.1rem;
+}
+
+.custom-admin__app-list {
+    display: grid;
+    gap: 1.4rem;
+}
+
+.custom-admin__app-card {
+    background: var(--admin-surface);
+    border-radius: var(--admin-radius-lg);
+    padding: 1.5rem;
+    box-shadow: var(--admin-shadow);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.custom-admin__app-card header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.custom-admin__app-card h3 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.custom-admin__app-card-link {
+    font-size: 0.85rem;
+    color: var(--admin-primary);
+    text-decoration: none;
+}
+
+.custom-admin__app-card ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.8rem;
+}
+
+.custom-admin__model {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.8rem;
+    padding: 0.9rem 1rem;
+    border-radius: var(--admin-radius-md);
+    border: 1px solid rgba(15, 23, 42, 0.07);
+    background: rgba(245, 247, 251, 0.6);
+}
+
+.custom-admin__model strong {
+    display: block;
+    font-size: 1rem;
+    color: var(--admin-text);
+}
+
+.custom-admin__model-hint {
+    color: var(--admin-muted);
+    font-size: 0.75rem;
+}
+
+.custom-admin__model-actions {
+    display: flex;
+    gap: 0.6rem;
+}
+
+.custom-admin__model-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.4rem 0.85rem;
+    border-radius: 999px;
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    text-decoration: none;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--admin-muted);
+    transition: all 0.2s ease;
+}
+
+.custom-admin__model-link:hover,
+.custom-admin__model-link:focus-visible {
+    border-color: var(--admin-primary);
+    color: var(--admin-primary);
+}
+
+.custom-admin__model-link--primary {
+    background: var(--admin-primary);
+    color: #fff;
+    border-color: var(--admin-primary);
+}
+
+.custom-admin__model-link--primary:hover,
+.custom-admin__model-link--primary:focus-visible {
+    background: var(--admin-primary-dark);
+    border-color: var(--admin-primary-dark);
+}
+
+.module #changelist-filter {
+    background: rgba(245, 247, 251, 0.6);
+    border-radius: var(--admin-radius-md);
+    padding: 1rem;
+}
+
+#toolbar form input[type="text"] {
+    border-radius: 999px;
+    border: 1px solid rgba(102, 112, 132, 0.2);
+    padding: 0.5rem 1rem;
+}
+
+.submit-row {
+    padding: 1rem 1.2rem;
+    background: rgba(245, 247, 251, 0.6);
+    border-radius: var(--admin-radius-md);
+}
+
+.submit-row input {
+    border-radius: 999px;
+    border: none;
+    font-weight: 600;
+    padding: 0.55rem 1.4rem;
+    box-shadow: 0 10px 20px rgba(10, 124, 255, 0.25);
+}
+
+.custom-admin__footer {
+    margin: 3rem auto 1rem;
+    text-align: center;
+    color: var(--admin-muted);
+    font-size: 0.85rem;
+}
+
+.custom-admin__footer a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.custom-admin__footer-links {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+@media (max-width: 960px) {
+    #content {
+        padding: 1.5rem;
+    }
+
+    .custom-admin__app-card header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.6rem;
+    }
+
+    .custom-admin__model {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .custom-admin__model-actions {
+        align-self: stretch;
+    }
+}

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -1,0 +1,73 @@
+{% extends "admin/base.html" %}
+{% load i18n static %}
+
+{% block title %}Painel Administrativo | {{ site_title|default:_('MedQuiz Admin') }}{% endblock %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{% static 'admin/css/custom-admin.css' %}">
+{% endblock %}
+
+{% block branding %}
+<div class="custom-admin__brand">
+    <div class="custom-admin__brand-icon">🎯</div>
+    <div>
+        <h1 class="custom-admin__brand-title">MedQuiz • Área Administrativa</h1>
+        <p class="custom-admin__brand-subtitle">Gerencie perguntas, usuários e estatísticas com agilidade.</p>
+    </div>
+</div>
+{% endblock %}
+
+{% block nav-global %}
+<nav class="custom-admin__quick-actions" aria-label="Ações rápidas do painel">
+    <a href="{% url 'admin:index' %}" class="custom-admin__quick-link">🏠 Início</a>
+    <a href="{% url 'admin:quiz_pergunta_changelist' %}" class="custom-admin__quick-link">❓ Perguntas</a>
+    <a href="{% url 'admin:quiz_categoria_changelist' %}" class="custom-admin__quick-link">🗂️ Categorias</a>
+    <a href="{% url 'admin:quiz_estatisticasdiariasusuario_changelist' %}" class="custom-admin__quick-link">📊 Estatísticas</a>
+    <a href="{% url 'admin:quiz_userquestionstudystate_changelist' %}" class="custom-admin__quick-link">🎯 Revisão Inteligente</a>
+</nav>
+{% endblock %}
+
+{% block usertools %}
+<div class="custom-admin__usertools">
+    {% if user.is_anonymous %}
+        <a href="{% url 'admin:login' %}">{% translate 'Log in' %}</a>
+    {% else %}
+        <div class="custom-admin__greeting">
+            <span class="custom-admin__avatar" aria-hidden="true">{{ user.get_short_name|default:user.username|first|upper }}</span>
+            <div>
+                <span class="custom-admin__hello">Olá,</span>
+                <strong>{{ user.get_short_name|default:user.username }}</strong>
+            </div>
+        </div>
+        <a href="{% url 'admin:password_change' %}" class="custom-admin__usertools-link">{% translate 'Change password' %}</a>
+        <a href="{% url 'admin:logout' %}" class="custom-admin__usertools-link">{% translate 'Log out' %}</a>
+    {% endif %}
+</div>
+{% endblock %}
+
+{% block messages %}
+    <div class="custom-admin__messages">
+        {{ block.super }}
+    </div>
+{% endblock %}
+
+{% block breadcrumbs %}
+    <nav class="custom-admin__breadcrumb" aria-label="Caminho de navegação">
+        {{ block.super }}
+    </nav>
+{% endblock %}
+
+{% block footer %}
+<footer class="custom-admin__footer">
+    <p>MedQuiz Admin &bull; Sistema interno de gestão. {% now "Y" %}</p>
+    <p class="custom-admin__footer-links">
+        <a href="/" target="_blank" rel="noopener">Ir para o site público</a>
+        <span aria-hidden="true">•</span>
+        <a href="mailto:suporte@medquiz.com">Contato do suporte</a>
+    </p>
+</footer>
+{% endblock %}

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -1,0 +1,73 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+    <section class="custom-admin__welcome">
+        <header>
+            <h2>Bem-vindo(a) ao painel do MedQuiz</h2>
+            <p>Use os atalhos abaixo para acessar rapidamente as áreas mais utilizadas ou escolha uma seção da lista de aplicações.</p>
+        </header>
+        <div class="custom-admin__stats">
+            <div class="custom-admin__stat-card">
+                <span class="custom-admin__stat-icon">❓</span>
+                <div>
+                    <strong>{{ app_list|length }}</strong>
+                    <span>Aplicações registradas</span>
+                </div>
+            </div>
+            <div class="custom-admin__stat-card">
+                <span class="custom-admin__stat-icon">📝</span>
+                <div>
+                    <strong>{% blocktrans count counter=app_list|length %}{{ counter }} módulo{% plural %}{{ counter }} módulos{% endblocktrans %}</strong>
+                    <span>Prontos para gerenciar</span>
+                </div>
+            </div>
+            <div class="custom-admin__stat-card">
+                <span class="custom-admin__stat-icon">⚡</span>
+                <div>
+                    <strong>Produtividade</strong>
+                    <span>Dicas em cada página</span>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="custom-admin__app-list" aria-label="Lista de aplicações">
+        {% if app_list %}
+            {% for app in app_list %}
+                <article class="custom-admin__app-card">
+                    <header>
+                        <h3>{{ app.name }}</h3>
+                        {% if app.app_url %}
+                            <a href="{{ app.app_url }}" class="custom-admin__app-card-link">{% translate 'View site' %}</a>
+                        {% endif %}
+                    </header>
+                    <ul>
+                        {% for model in app.models %}
+                            <li>
+                                <div class="custom-admin__model">
+                                    <div>
+                                        <strong>{{ model.name }}</strong>
+                                        {% if model.perms.change %}
+                                            <span class="custom-admin__model-hint">Clique para editar registros</span>
+                                        {% endif %}
+                                    </div>
+                                    <div class="custom-admin__model-actions">
+                                        {% if model.admin_url %}
+                                            <a href="{{ model.admin_url }}" class="custom-admin__model-link">{% translate 'Open' %}</a>
+                                        {% endif %}
+                                        {% if model.add_url %}
+                                            <a href="{{ model.add_url }}" class="custom-admin__model-link custom-admin__model-link--primary">{% translate 'Add' %}</a>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </article>
+            {% endfor %}
+        {% else %}
+            <p>{% translate "You don't have permission to view or edit anything." %}</p>
+        {% endif %}
+    </section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- customize the Django admin base template with refreshed branding, quick navigation shortcuts, and contextual footer information
- redesign the admin index dashboard to highlight quick stats and model actions in card-based layouts
- add a dedicated CSS theme to deliver a modern, responsive visual style across admin pages

## Testing
- Not Run (Django package is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d961518c448333841b008228479442