### PR TITLE
Fix bottom navigation anchoring on mobile

### DIFF
--- a/assets/css/components/challenge-hub.css
+++ b/assets/css/components/challenge-hub.css
@@ -690,7 +690,7 @@
 @media (max-width: 768px) {
     /* Evita que a bottom-nav cubra os cards quando o Hub está visível na aba de questões */
     body[data-page-id="questions"] .challenge-hub {
-        margin-bottom: calc(var(--bottom-nav-height, 68px) + var(--spacing-sm, 12px));
+        margin-bottom: calc(var(--bottom-nav-height, 68px) + var(--spacing-sm, 12px) + env(safe-area-inset-bottom, 0px));
     }
 }
 

--- a/assets/css/components/navigation.css
+++ b/assets/css/components/navigation.css
@@ -73,17 +73,20 @@
 .bottom-nav {
   display: none; /* Regra padrão: a barra está OCULTA. */
   position: fixed;
-  bottom: calc(var(--spacing-sm, 12px) + env(safe-area-inset-bottom, 0px));
-  left: 50%;
-  transform: translateX(-50%);
-  width: calc(100% - var(--spacing-lg, 28px));
-  max-width: 420px;
-  height: var(--bottom-nav-height, 68px);
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  max-width: none;
+  min-height: calc(var(--bottom-nav-height, 68px) + env(safe-area-inset-bottom, 0px));
+  padding: 0 var(--spacing-lg, 28px);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  box-sizing: border-box;
   z-index: var(--z-index-bottom-nav, 100);
 }
 
 .bottom-nav__list {
-  height: 100%;
+  min-height: var(--bottom-nav-height, 68px);
   width: 100%;
   list-style: none;
   margin: 0;
@@ -185,7 +188,7 @@
 
   /* 3. Aplica o padding inferior SOMENTE na página 'home' para evitar que o conteúdo seja coberto */
   body[data-page-id="home"] {
-    padding-bottom: calc(var(--bottom-nav-height, 68px) + var(--spacing-sm, 12px));
+    padding-bottom: calc(var(--bottom-nav-height, 68px) + var(--spacing-sm, 12px) + env(safe-area-inset-bottom, 0px));
   }
 }
 

--- a/assets/css/layout/main-sections.css
+++ b/assets/css/layout/main-sections.css
@@ -85,7 +85,7 @@ body {
 
     body[data-page-id="home"],
     body[data-page-id="questions"] {
-        --layout-bottom-offset: calc(var(--bottom-nav-height, 68px) + var(--spacing-sm, 12px));
+        --layout-bottom-offset: calc(var(--bottom-nav-height, 68px) + var(--spacing-sm, 12px) + env(safe-area-inset-bottom, 0px));
     }
 
     #question-section.main-section {


### PR DESCRIPTION
## Summary
- pin the mobile bottom navigation bar to the viewport edge and include safe-area padding
- update dependent layout spacings to account for the navigation bar's new positioning

## Testing
- not run (Django is not installed in the container environment)

------
https://chatgpt.com/codex/tasks/task_e_68e4766128308333866399a03dcf5805