### PR TITLE
Limit navigation visibility to mobile hub views

### DIFF
--- a/assets/css/components/navigation.css
+++ b/assets/css/components/navigation.css
@@ -64,3 +64,23 @@
   text-decoration: none;
 }
 
+/* ===== Visibility Rules ===== */
+body[data-page-id="account"] .main-nav {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .main-nav {
+    display: none;
+  }
+
+  body[data-page-id="home"] .main-nav,
+  body[data-page-id="questions"].is-challenge-hub-active .main-nav {
+    display: flex;
+  }
+
+  body[data-page-id="questions"].is-quiz-active .main-nav {
+    display: none;
+  }
+}
+

--- a/assets/js/ui/ChallengeHub.js
+++ b/assets/js/ui/ChallengeHub.js
@@ -10,6 +10,8 @@ export default class ChallengeHub {
         // Atalho para os elementos DOM relevantes gerenciados por QuizUI
         this._cacheElements();
 
+        this._setHubActiveClass(this._isHubVisible());
+
         this.lastTotalQuestions = null;
         this.lastQuickQuizCount = null;
         this.predefinedQuizzesCache = [];
@@ -43,6 +45,28 @@ export default class ChallengeHub {
         };
     }
 
+    _isHubVisible() {
+        if (!this.elements.challengeHubContainer) {
+            return false;
+        }
+
+        const hiddenClass = this.quizUI?.hiddenClassName || 'u-is-hidden';
+        return !this.elements.challengeHubContainer.classList.contains(hiddenClass);
+    }
+
+    _setHubActiveClass(isActive) {
+        const bodyElement = document.body;
+        if (!bodyElement) {
+            return;
+        }
+
+        bodyElement.classList.toggle('is-challenge-hub-active', Boolean(isActive));
+
+        if (isActive) {
+            bodyElement.classList.remove('is-quiz-active');
+        }
+    }
+
     /**
      * Define a instância do ActionOrchestrator.
      * @param {ActionOrchestrator} orchestrator - A instância do orquestrador.
@@ -58,11 +82,13 @@ export default class ChallengeHub {
         if (this.elements.challengeHubContainer) {
             this.quizUI.showElement(this.elements.challengeHubContainer);
         }
-        
+
+        this._setHubActiveClass(true);
+
         this.quizUI.hideElement(this.elements.placeholderFiltrosContainer);
         this.quizUI.hideElement(this.quizUI.elements.quizSectionContent);
         this.quizUI.hideElement(this.quizUI.elements.resultadoCard);
-        
+
         if (this.quizUI.scorePanel) {
             this.quizUI.scorePanel.hide();
         } else {
@@ -83,6 +109,8 @@ export default class ChallengeHub {
         if (this.elements.challengeHubContainer) {
             this.quizUI.hideElement(this.elements.challengeHubContainer);
         }
+
+        this._setHubActiveClass(false);
     }
 
     /**

--- a/assets/js/ui/QuizUI.js
+++ b/assets/js/ui/QuizUI.js
@@ -388,6 +388,18 @@ export default class QuizUI {
         const { placeholderFiltrosContainer, quizSectionContent } = this.elements;
         const displayMode = this.store?.getState()?.quiz?.quizDisplayContext?.displayMode || 'challenge';
 
+        const bodyElement = document.body;
+
+        if (bodyElement) {
+            if (showQuizLayout) {
+                bodyElement.classList.add('is-quiz-active');
+                bodyElement.classList.remove('is-challenge-hub-active');
+            } else {
+                bodyElement.classList.remove('is-quiz-active');
+                bodyElement.classList.add('is-challenge-hub-active');
+            }
+        }
+
         if (showQuizLayout) {
             if (this.scorePanel) {
                 if (displayMode === 'review') this.scorePanel.hide();

--- a/quiz/templates/quiz/base.html
+++ b/quiz/templates/quiz/base.html
@@ -15,8 +15,9 @@
     <title>{% block title %}MedQuiz{% endblock title %}</title>
 </head>
 {# ===== MODIFICAÇÃO AQUI para adicionar data-page-id e os novos data attributes ===== #}
+{% with view_name=request.resolver_match.view_name|default:'' %}
 <body data-user-authenticated="{{ user.is_authenticated|yesno:'true,false' }}"
-      data-page-id="{% if request.resolver_match.view_name == 'quiz:home' %}home{% elif request.resolver_match.view_name == 'quiz:questions' %}questions{% elif request.resolver_match.view_name == 'quiz:account' %}account{% else %}unknown{% endif %}"
+      data-page-id="{% if view_name == 'quiz:home' %}home{% elif view_name == 'quiz:questions' %}questions{% elif view_name == 'quiz:account' %}account{% elif view_name == 'quiz:update_profile' %}account{% elif view_name == 'quiz:update_preferences' %}account{% elif view_name == 'quiz:delete_account' %}account{% else %}unknown{% endif %}"
       data-active-tab-on-error="{{ active_tab_on_error|default_if_none:'' }}"
       data-show-delete-modal-on-error="{{ show_delete_account_modal_on_error|yesno:'true,false' }}"
       data-user-theme="{{ user_theme_preference|default:'' }}"
@@ -78,4 +79,5 @@
         <script src="{% static 'js/main.js' %}" type="module" defer></script>
     {% endblock scripts %}
 </body>
+{% endwith %}
 </html>


### PR DESCRIPTION
## Summary
- map account-related views to the shared page id so layout rules apply consistently
- toggle body classes when the challenge hub or quiz is active and hide the navigation on account pages and during quizzes
- add mobile-specific CSS rules so the main navigation only appears on the home page and the challenge hub for small screens

## Testing
- python manage.py runserver 0.0.0.0:8000 *(fails: Django is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e48311f85c8333901fb2d25e0b7721