### PR TITLE
Fix mobile navigation visibility on questions page

### DIFF
--- a/assets/js/ui/ModalManager.js
+++ b/assets/js/ui/ModalManager.js
@@ -258,12 +258,29 @@ export default class ModalManager {
                 this.quizUI.showElement(this.elements.placeholderFiltrosContainer);
             }
         } else {
-            if (this.elements.quizSectionContent?.classList.contains(this.quizUI.hiddenClassName) &&
-                this.elements.resultadoCard?.classList.contains(this.quizUI.hiddenClassName) &&
-                !this.elements.placeholderFiltrosContainer?.classList.contains(this.quizUI.hiddenClassName)
-                ) {
-                this.quizUI.hideElement(this.elements.placeholderFiltrosContainer);
-                if(this.elements.challengeHubContainer) this.quizUI.showElement(this.elements.challengeHubContainer);
+            const {
+                quizSectionContent,
+                resultadoCard,
+                placeholderFiltrosContainer,
+                challengeHubContainer,
+            } = this.elements;
+
+            const shouldReturnToHub = quizSectionContent?.classList.contains(this.quizUI.hiddenClassName)
+                && resultadoCard?.classList.contains(this.quizUI.hiddenClassName)
+                && !placeholderFiltrosContainer?.classList.contains(this.quizUI.hiddenClassName);
+
+            if (shouldReturnToHub) {
+                this.quizUI.hideElement(placeholderFiltrosContainer);
+
+                if (this.quizUI.challengeHubInstance && typeof this.quizUI.challengeHubInstance.showHub === 'function') {
+                    this.quizUI.challengeHubInstance.showHub();
+                } else if (challengeHubContainer) {
+                    this.quizUI.showElement(challengeHubContainer);
+                    if (typeof document !== 'undefined' && document.body) {
+                        document.body.classList.add('is-challenge-hub-active');
+                        document.body.classList.remove('is-quiz-active');
+                    }
+                }
             }
         }
         this._toggleGenericModal(overlay, panel, show, panel);

--- a/quiz/templates/quiz/base.html
+++ b/quiz/templates/quiz/base.html
@@ -16,7 +16,9 @@
 </head>
 {# ===== MODIFICAÇÃO AQUI para adicionar data-page-id e os novos data attributes ===== #}
 {% with view_name=request.resolver_match.view_name|default:'' %}
-<body data-user-authenticated="{{ user.is_authenticated|yesno:'true,false' }}"
+<body
+      {% block body_attrs %}{% endblock body_attrs %}
+      data-user-authenticated="{{ user.is_authenticated|yesno:'true,false' }}"
       data-page-id="{% if view_name == 'quiz:home' %}home{% elif view_name == 'quiz:questions' %}questions{% elif view_name == 'quiz:account' %}account{% elif view_name == 'quiz:update_profile' %}account{% elif view_name == 'quiz:update_preferences' %}account{% elif view_name == 'quiz:delete_account' %}account{% else %}unknown{% endif %}"
       data-active-tab-on-error="{{ active_tab_on_error|default_if_none:'' }}"
       data-show-delete-modal-on-error="{{ show_delete_account_modal_on_error|yesno:'true,false' }}"

--- a/quiz/templates/quiz/questions_page.html
+++ b/quiz/templates/quiz/questions_page.html
@@ -1,6 +1,8 @@
 {% extends "quiz/base.html" %}
 {% load static %}
 
+{% block body_attrs %}class="is-challenge-hub-active"{% endblock %}
+
 {% block title %}MedQuiz - Questões{% endblock title %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- add an overridable block for body attributes in the base layout template
- default the questions page to render with the challenge hub class so the mobile navigation stays visible from the start
- ensure closing the filter panel restores the challenge hub and navigation state when returning from the customization flow

## Testing
- python manage.py check *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e48d4e81888333b704b24274df8dd5