### PR TITLE
Revamp curated and saved filter styling

### DIFF
--- a/assets/css/components/button.css
+++ b/assets/css/components/button.css
@@ -110,6 +110,28 @@
     opacity: 0.6;
 }
 
+/* --- BOTÃO SURFACE (SUBTLE GRADIENT) --- */
+.button--surface {
+    background: rgba(var(--color-white-rgb), 0.95);
+    color: var(--color-primary-dark);
+    border-color: rgba(var(--color-primary-medium-rgb), 0.35);
+    box-shadow: inset 0 0 0 1px rgba(var(--color-primary-light-rgb), 0.5);
+}
+
+.button--surface:not(:disabled):hover,
+.button--surface:not(:disabled):focus-visible {
+    background: rgba(var(--color-white-rgb), 1);
+    border-color: rgba(var(--color-primary-medium-rgb), 0.45);
+    box-shadow: 0 8px 18px -14px rgba(var(--color-primary-dark-rgb), 0.35);
+    filter: none;
+}
+
+.button--surface:not(:disabled):active {
+    transform: translateY(0);
+    box-shadow: inset 0 0 0 1px rgba(var(--color-primary-medium-rgb), 0.45);
+    filter: none;
+}
+
 /* --- BOTÃO APENAS COM ÍCONE --- */
 .button--icon-only {
     padding: var(--spacing-xs, 8px);

--- a/assets/css/components/filter-panel.css
+++ b/assets/css/components/filter-panel.css
@@ -233,44 +233,128 @@
 }
 
 .filter-predefined-card {
-    border: 1px solid var(--color-gray-200);
-    border-radius: var(--border-radius-lg, 12px);
-    padding: var(--spacing-md, 20px);
-    background: linear-gradient(135deg, rgba(var(--color-white-rgb), 0.98), rgba(var(--color-primary-light-rgb), 0.08));
-    box-shadow: 0 10px 28px -24px rgba(var(--color-primary-dark-rgb), 0.5);
+    position: relative;
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-sm, 12px);
+    gap: var(--spacing-md, 16px);
+    padding: var(--spacing-md, 20px) var(--spacing-lg, 24px);
+    border-radius: var(--border-radius-xl, 18px);
+    border: 1px solid rgba(var(--color-primary-medium-rgb), 0.18);
+    background:
+        linear-gradient(155deg, rgba(var(--color-white-rgb), 0.96), rgba(var(--color-primary-light-rgb), 0.12)),
+        rgba(var(--color-white-rgb), 0.94);
+    box-shadow:
+        0 18px 40px -28px rgba(var(--color-primary-dark-rgb), 0.6),
+        0 1px 0 rgba(var(--color-white-rgb), 0.9) inset;
+    overflow: hidden;
+    transition: transform var(--transition-medium), box-shadow var(--transition-medium), border-color var(--transition-fast);
+}
+
+.filter-predefined-card::before {
+    content: '';
+    position: absolute;
+    top: -45%;
+    right: -35%;
+    width: 220px;
+    height: 220px;
+    background: radial-gradient(circle at center, rgba(var(--color-primary-light-rgb), 0.35), rgba(255, 255, 255, 0));
+    opacity: 0.8;
+    pointer-events: none;
+    transform: rotate(15deg);
+}
+
+.filter-predefined-card:hover,
+.filter-predefined-card:focus-within {
+    transform: translateY(-2px);
+    border-color: rgba(var(--color-primary-medium-rgb), 0.3);
+    box-shadow:
+        0 24px 48px -26px rgba(var(--color-primary-dark-rgb), 0.65),
+        0 0 0 1px rgba(var(--color-primary-medium-rgb), 0.15) inset;
+}
+
+.filter-predefined-card__header {
+    position: relative;
+    display: flex;
+    align-items: flex-start;
+    gap: var(--spacing-md, 16px);
+    z-index: 1;
+}
+
+.filter-predefined-card__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border-radius: var(--border-radius-xl, 18px);
+    background: linear-gradient(135deg, rgba(var(--color-primary-medium-rgb), 0.18), rgba(var(--color-primary-dark-rgb), 0.14));
+    color: var(--color-primary-dark);
+    box-shadow: 0 10px 20px -18px rgba(var(--color-primary-dark-rgb), 0.65);
+    font-size: 1.4rem;
+    flex-shrink: 0;
+}
+
+.filter-predefined-card__content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xxs, 4px);
 }
 
 .filter-predefined-card__title {
-    font-size: 1rem;
+    margin: 0;
+    font-size: 1.05rem;
     font-weight: var(--font-weight-semibold, 600);
     color: var(--color-primary-dark);
-    margin: 0;
 }
 
 .filter-predefined-card__description {
     margin: 0;
-    font-size: 0.9rem;
     color: var(--color-gray-600);
+    font-size: 0.9rem;
+    line-height: 1.5;
+}
+
+.filter-predefined-card__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-md, 16px);
+    flex-wrap: wrap;
+    position: relative;
+    z-index: 1;
 }
 
 .filter-predefined-card__meta {
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: var(--spacing-xs, 8px);
+    gap: var(--spacing-xxs, 4px);
+    padding: 6px 12px;
+    border-radius: var(--border-radius-pill);
+    background: rgba(var(--color-primary-light-rgb), 0.45);
+    color: var(--color-primary-dark);
     font-size: 0.85rem;
-    color: var(--color-gray-500);
+    font-weight: var(--font-weight-medium, 500);
+    letter-spacing: 0.2px;
+}
+
+.filter-predefined-card__meta .material-symbols-outlined {
+    font-size: 1rem;
+}
+
+.filter-predefined-card__meta-text {
+    white-space: nowrap;
 }
 
 .filter-predefined-card__actions {
     display: flex;
-    justify-content: flex-start;
+    align-items: center;
+    gap: var(--spacing-xs, 8px);
+    flex-shrink: 0;
 }
 
 .filter-predefined-card__actions .button {
     width: auto;
+    box-shadow: none;
 }
 
 .filter-saved__form {
@@ -304,54 +388,124 @@
 }
 
 .saved-collections-list__item {
-    border: 1px solid var(--color-gray-200);
-    border-radius: var(--border-radius-lg, 12px);
-    padding: var(--spacing-sm, 12px) var(--spacing-md, 20px);
-    background-color: var(--color-white);
+    position: relative;
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-xs, 8px);
-    box-shadow: 0 6px 18px -16px rgba(var(--color-primary-dark-rgb), 0.4);
+    gap: var(--spacing-sm, 12px);
+    padding: var(--spacing-md, 20px) var(--spacing-lg, 24px);
+    border-radius: var(--border-radius-xl, 18px);
+    border: 1px solid rgba(var(--color-gray-300-rgb), 0.45);
+    background:
+        linear-gradient(165deg, rgba(var(--color-white-rgb), 0.98), rgba(var(--color-primary-light-rgb), 0.05));
+    box-shadow:
+        0 16px 32px -26px rgba(var(--color-primary-dark-rgb), 0.55),
+        0 1px 0 rgba(var(--color-white-rgb), 0.85) inset;
+    transition: transform var(--transition-medium), box-shadow var(--transition-medium), border-color var(--transition-fast);
+    overflow: hidden;
 }
 
-.saved-collections-list__header {
+.saved-collections-list__item::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(var(--color-primary-light-rgb), 0.12), transparent 60%);
+    opacity: 0;
+    transition: opacity var(--transition-medium);
+    pointer-events: none;
+}
+
+.saved-collections-list__item:hover,
+.saved-collections-list__item:focus-within {
+    transform: translateY(-2px);
+    border-color: rgba(var(--color-primary-medium-rgb), 0.25);
+    box-shadow:
+        0 24px 44px -28px rgba(var(--color-primary-dark-rgb), 0.6),
+        0 0 0 1px rgba(var(--color-primary-medium-rgb), 0.08) inset;
+}
+
+.saved-collections-list__item:hover::before,
+.saved-collections-list__item:focus-within::before {
+    opacity: 1;
+}
+
+.saved-collection-card__header {
+    position: relative;
     display: flex;
-    justify-content: space-between;
+    align-items: center;
+    gap: var(--spacing-md, 16px);
+    z-index: 1;
+}
+
+.saved-collection-card__badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: var(--border-radius-xl, 18px);
+    background: rgba(var(--color-primary-medium-rgb), 0.15);
+    color: var(--color-primary-dark);
+    box-shadow: 0 10px 22px -18px rgba(var(--color-primary-dark-rgb), 0.6);
+    flex-shrink: 0;
+}
+
+.saved-collection-card__info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+    min-width: 0;
+}
+
+.saved-collections-list__title.saved-collection-card__title {
+    margin: 0;
+    color: var(--color-primary-dark);
+    font-size: 1rem;
+    font-weight: var(--font-weight-semibold, 600);
+    letter-spacing: 0.2px;
+}
+
+.saved-collection-card__timestamp {
+    font-size: 0.8rem;
+    color: var(--color-gray-600);
+    letter-spacing: 0.3px;
+}
+
+.saved-collection-card__actions {
+    display: flex;
     align-items: center;
     gap: var(--spacing-xs, 8px);
 }
 
-.saved-collections-list__title {
-    margin: 0;
-    font-size: 0.95rem;
-    font-weight: var(--font-weight-semibold, 600);
-    color: var(--color-primary-dark);
-}
-
-.saved-collections-list__meta {
-    margin: 0;
-    font-size: 0.85rem;
-    color: var(--color-gray-600);
-    line-height: 1.4;
-}
-
-.saved-collections-list__actions {
-    display: flex;
-    gap: var(--spacing-xs, 8px);
-}
-
-.saved-collections-list__actions .button {
+.saved-collection-card__actions .button {
     flex: none;
 }
 
-.saved-collections-list__remove {
-    color: var(--color-gray-500);
+.saved-collection-card__summary {
+    margin: 0;
+    font-size: 0.88rem;
+    color: var(--color-gray-600);
+    line-height: 1.5;
+    position: relative;
+    z-index: 1;
 }
 
-.saved-collections-list__remove:hover,
-.saved-collections-list__remove:focus-visible {
+.saved-collection-card__apply .material-symbols-outlined {
+    color: var(--color-primary-dark);
+}
+
+.saved-collections-list__remove.saved-collection-card__remove {
+    color: var(--color-gray-500);
+    background-color: rgba(var(--color-white-rgb), 0.7);
+    border: 1px solid rgba(var(--color-gray-300-rgb), 0.6);
+    box-shadow: none;
+}
+
+.saved-collections-list__remove.saved-collection-card__remove:hover,
+.saved-collections-list__remove.saved-collection-card__remove:focus-visible {
     color: var(--color-accent-red);
-    background-color: rgba(var(--color-accent-red-rgb), 0.1);
+    background-color: rgba(var(--color-accent-red-rgb), 0.12);
+    border-color: rgba(var(--color-accent-red-rgb), 0.35);
 }
 
 .form-control--filter-panel.has-error {
@@ -368,12 +522,23 @@
         padding: var(--spacing-sm, 12px) var(--spacing-md, 20px);
     }
 
-    .saved-collections-list__item {
-        padding: var(--spacing-sm, 12px);
+    .filter-predefined-card__footer {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--spacing-sm, 12px);
     }
 
-    .saved-collections-list__actions {
+    .saved-collections-list__item {
+        padding: var(--spacing-sm, 12px) var(--spacing-md, 20px);
+    }
+
+    .saved-collection-card__header {
+        align-items: flex-start;
+    }
+
+    .saved-collection-card__actions {
         flex-wrap: wrap;
+        justify-content: flex-end;
     }
 }
 

--- a/assets/js/ui/FilterPanel.js
+++ b/assets/js/ui/FilterPanel.js
@@ -603,23 +603,39 @@ export default class FilterPanel {
 
     _buildSavedCollectionItem(collection) {
         const listItem = document.createElement('li');
-        listItem.className = 'saved-collections-list__item';
+        listItem.className = 'saved-collections-list__item saved-collection-card';
         listItem.dataset.collectionId = collection.id;
 
         const header = document.createElement('div');
-        header.className = 'saved-collections-list__header';
+        header.className = 'saved-collection-card__header';
+
+        const badge = document.createElement('span');
+        badge.className = 'saved-collection-card__badge';
+        const badgeIcon = document.createElement('span');
+        badgeIcon.className = 'material-symbols-outlined';
+        badgeIcon.setAttribute('aria-hidden', 'true');
+        badgeIcon.textContent = 'bookmark';
+        badge.appendChild(badgeIcon);
+
+        const info = document.createElement('div');
+        info.className = 'saved-collection-card__info';
 
         const title = document.createElement('h4');
-        title.className = 'saved-collections-list__title';
+        title.className = 'saved-collections-list__title saved-collection-card__title';
         title.textContent = collection.name;
-        header.appendChild(title);
+
+        const timestamp = document.createElement('span');
+        timestamp.className = 'saved-collection-card__timestamp';
+        timestamp.textContent = this._formatSavedCollectionTimestamp(collection);
+
+        info.append(title, timestamp);
 
         const actions = document.createElement('div');
-        actions.className = 'saved-collections-list__actions';
+        actions.className = 'saved-collections-list__actions saved-collection-card__actions';
 
         const applyButton = document.createElement('button');
         applyButton.type = 'button';
-        applyButton.className = 'button button--primary button--small';
+        applyButton.className = 'button button--surface button--small saved-collection-card__apply';
         applyButton.dataset.role = 'apply-collection';
 
         const applyIcon = document.createElement('span');
@@ -633,7 +649,7 @@ export default class FilterPanel {
 
         const removeButton = document.createElement('button');
         removeButton.type = 'button';
-        removeButton.className = 'button button--icon-only saved-collections-list__remove';
+        removeButton.className = 'button button--icon-only saved-collections-list__remove saved-collection-card__remove';
         removeButton.dataset.role = 'remove-collection';
         removeButton.setAttribute('aria-label', `Remover coleção ${collection.name}`);
         const removeIcon = document.createElement('span');
@@ -643,15 +659,66 @@ export default class FilterPanel {
         removeButton.appendChild(removeIcon);
 
         actions.append(applyButton, removeButton);
-        header.appendChild(actions);
+        header.append(badge, info, actions);
 
         const meta = document.createElement('p');
-        meta.className = 'saved-collections-list__meta';
+        meta.className = 'saved-collections-list__meta saved-collection-card__summary';
         meta.textContent = this._describeFilters(collection.filters);
 
         listItem.append(header, meta);
 
         return listItem;
+    }
+
+    _formatSavedCollectionTimestamp(collection) {
+        const rawTimestamp = Number.isFinite(Number(collection?.updatedAt))
+            ? Number(collection.updatedAt)
+            : Number(collection?.createdAt);
+
+        if (!Number.isFinite(rawTimestamp) || rawTimestamp <= 0) {
+            return 'Coleção personalizada';
+        }
+
+        const now = Date.now();
+        const delta = Math.max(0, now - rawTimestamp);
+
+        const minute = 60 * 1000;
+        const hour = 60 * minute;
+        const day = 24 * hour;
+        const week = 7 * day;
+
+        if (delta < minute) {
+            return 'Atualizado agora';
+        }
+
+        if (delta < hour) {
+            const minutes = Math.round(delta / minute);
+            return `Atualizado há ${minutes} min`;
+        }
+
+        if (delta < day) {
+            const hours = Math.round(delta / hour);
+            return `Atualizado há ${hours} h`;
+        }
+
+        if (delta < week) {
+            const days = Math.round(delta / day);
+            return `Atualizado há ${days} ${days === 1 ? 'dia' : 'dias'}`;
+        }
+
+        try {
+            const date = new Date(rawTimestamp);
+            if (!Number.isFinite(date.getTime())) {
+                throw new Error('Invalid date');
+            }
+
+            return `Atualizado em ${date.toLocaleDateString('pt-BR', {
+                day: '2-digit',
+                month: 'short',
+            })}`;
+        } catch (_error) {
+            return 'Atualizado recentemente';
+        }
     }
 
     _handleSaveCurrentFilters() {
@@ -852,35 +919,55 @@ export default class FilterPanel {
         card.className = 'filter-predefined-card';
         card.dataset.predefinedId = item.id;
 
+        const header = document.createElement('div');
+        header.className = 'filter-predefined-card__header';
+
+        const iconWrapper = document.createElement('span');
+        iconWrapper.className = 'filter-predefined-card__icon material-symbols-outlined';
+        iconWrapper.setAttribute('aria-hidden', 'true');
+        iconWrapper.textContent = 'auto_awesome';
+
+        const content = document.createElement('div');
+        content.className = 'filter-predefined-card__content';
+
         const title = document.createElement('h4');
         title.className = 'filter-predefined-card__title';
         title.textContent = item.nome;
-        card.appendChild(title);
+        content.appendChild(title);
 
         if (item.descricao) {
             const description = document.createElement('p');
             description.className = 'filter-predefined-card__description';
             description.textContent = item.descricao;
-            card.appendChild(description);
+            content.appendChild(description);
         }
+
+        header.append(iconWrapper, content);
+        card.appendChild(header);
+
+        const footer = document.createElement('div');
+        footer.className = 'filter-predefined-card__footer';
 
         const meta = document.createElement('div');
         meta.className = 'filter-predefined-card__meta';
-        const icon = document.createElement('span');
-        icon.className = 'material-symbols-outlined';
-        icon.setAttribute('aria-hidden', 'true');
-        icon.textContent = 'quiz';
+
+        const metaIcon = document.createElement('span');
+        metaIcon.className = 'material-symbols-outlined';
+        metaIcon.setAttribute('aria-hidden', 'true');
+        metaIcon.textContent = 'quiz';
+
         const metaText = document.createElement('span');
+        metaText.className = 'filter-predefined-card__meta-text';
         metaText.textContent = `${this._formatNumber(item.total_perguntas)} questões`;
-        meta.append(icon, metaText);
-        card.appendChild(meta);
+
+        meta.append(metaIcon, metaText);
 
         const actions = document.createElement('div');
         actions.className = 'filter-predefined-card__actions';
 
         const startButton = document.createElement('button');
         startButton.type = 'button';
-        startButton.className = 'button button--primary button--small';
+        startButton.className = 'button button--surface button--small';
         startButton.dataset.role = 'start-predefined';
 
         const startIcon = document.createElement('span');
@@ -893,7 +980,8 @@ export default class FilterPanel {
         startButton.append(startIcon, startLabel);
 
         actions.appendChild(startButton);
-        card.appendChild(actions);
+        footer.append(meta, actions);
+        card.appendChild(footer);
 
         return card;
     }


### PR DESCRIPTION
## Summary
- restyle curated quiz cards with layered layout, icon treatment, and refined meta chip
- refresh saved filter collection cards with badges, timestamps, and cohesive spacing
- add reusable surface button variant to support the softer actions in the panel

## Testing
- not run (Django not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68e55b2f96348333964d37e844d0581f