### PR TITLE
Fix home progress section conditional to avoid TemplateSyntaxError

### DIFF
--- a/quiz/templates/quiz/home.html
+++ b/quiz/templates/quiz/home.html
@@ -65,7 +65,8 @@
         </div>
     </div>
 
-    {% if show_progress and (home_progress_cards or home_progress_section.show_when_empty) %}
+    {% if show_progress %}
+        {% if home_progress_cards or home_progress_section.show_when_empty %}
     <section class="home-overview" aria-label="{{ home_progress_section.title }}">
         <div class="home-section__header">
             <h2>{{ home_progress_section.title }}</h2>
@@ -191,6 +192,7 @@
         </div>
         {% endif %}
     </section>
+        {% endif %}
     {% endif %}
 
     {% if show_progress %}


### PR DESCRIPTION
## Summary
- wrap the progress section check in nested conditionals to avoid invalid Django template syntax
- ensure the progress overview section still renders when either cards exist or the empty state should be shown

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6b481d39883338f791b9fc4878049