### PR TITLE
Add slugged detail routes for hub questions and challenges

### DIFF
--- a/assets/js/app/App.js
+++ b/assets/js/app/App.js
@@ -52,7 +52,7 @@ export default class App {
         this._ensureActiveSection(initialSectionId);
 
         try {
-            if (initialSectionId === 'questions') {
+            if (initialSectionId === 'hub') {
                 await this.actionOrchestrator.initializeAppData();
             }
 
@@ -66,7 +66,7 @@ export default class App {
             const isQuizActive = this.store.getState().quiz.currentSessionId !== null;
             this.quizUI.displayQuizLayout(isQuizActive);
 
-            if (initialSectionId === 'questions') {
+            if (initialSectionId === 'hub') {
                 await this.actionOrchestrator.initializeQuizPage();
                 await this._handlePendingFavoriteReview();
             } else if (initialSectionId === 'account') {
@@ -171,8 +171,9 @@ export default class App {
         }
 
         const bodyPageId = document.body?.dataset?.pageId || 'home';
-        const validSections = ['home', 'questions', 'account'];
-        return validSections.includes(bodyPageId) ? bodyPageId : 'home';
+        const normalizedId = bodyPageId === 'questions' ? 'hub' : bodyPageId;
+        const validSections = ['home', 'hub', 'account'];
+        return validSections.includes(normalizedId) ? normalizedId : 'home';
     }
 
     _ensureActiveSection(targetSection) {

--- a/assets/js/app/flux/ActionOrchestrator.js
+++ b/assets/js/app/flux/ActionOrchestrator.js
@@ -435,7 +435,7 @@ export default class ActionOrchestrator {
                 return false;
             }
 
-            this.store.dispatch(quizActions.setActiveSection('questions'));
+            this.store.dispatch(quizActions.setActiveSection('hub'));
             this.store.dispatch(
                 quizActions.initializeQuiz(
                     normalizedQuestions,
@@ -772,7 +772,7 @@ export default class ActionOrchestrator {
                 questionPayload.is_favorited = true;
             }
 
-            this.store.dispatch(quizActions.setActiveSection('questions'));
+            this.store.dispatch(quizActions.setActiveSection('hub'));
             this.store.dispatch(
                 quizActions.initializeQuiz(
                     [questionPayload],

--- a/assets/js/ui/FavoriteManager.js
+++ b/assets/js/ui/FavoriteManager.js
@@ -404,6 +404,20 @@ export default class FavoriteManager {
                 actionsContainer.appendChild(explanationButton);
             }
 
+            if (fav.detail_url) {
+                const detailLink = document.createElement('a');
+                detailLink.href = fav.detail_url;
+                detailLink.className = 'button button--text button--compact favorite-question-card__action';
+                detailLink.setAttribute('role', 'link');
+
+                const detailLabel = document.createElement('span');
+                detailLabel.className = 'button__label';
+                detailLabel.textContent = 'Abrir detalhes';
+                detailLink.appendChild(detailLabel);
+
+                actionsContainer.appendChild(detailLink);
+            }
+
             const unfavoriteButton = this._createUnfavoriteButton(fav);
             if (unfavoriteButton) {
                 actionsContainer.appendChild(unfavoriteButton);
@@ -563,7 +577,9 @@ export default class FavoriteManager {
         }
 
         const baseUrl = this._getQuestionsPageUrl();
-        const destinationUrl = this._buildQuestionReviewLink(baseUrl, favoriteQuestion.id_pergunta) || baseUrl;
+        const destinationUrl = favoriteQuestion?.detail_url
+            || this._buildQuestionReviewLink(baseUrl, favoriteQuestion.id_pergunta)
+            || baseUrl;
 
         if (typeof window !== 'undefined' && window.sessionStorage) {
             try {
@@ -637,6 +653,8 @@ export default class FavoriteManager {
 
         const sanitizedQuestion = {
             id_pergunta: favoriteQuestion.id_pergunta,
+            slug: favoriteQuestion.slug || null,
+            detail_url: favoriteQuestion.detail_url || null,
             texto_pergunta: favoriteQuestion.texto_pergunta || '',
             url_imagem: favoriteQuestion.url_imagem || null,
             referencia_bibliografica: favoriteQuestion.referencia_bibliografica || null,
@@ -807,16 +825,17 @@ export default class FavoriteManager {
 
     _getQuestionsPageUrl() {
         const bottomNav = this.quizUI?.elements?.bottomNavElement;
-        const questionsLink = bottomNav?.querySelector('[data-section-target-django="questions"]');
-        if (questionsLink && questionsLink.href) {
-            return questionsLink.href;
+        const hubLink = bottomNav?.querySelector('[data-section-target-django="hub"]')
+            || bottomNav?.querySelector('[data-section-target-django="questions"]');
+        if (hubLink && hubLink.href) {
+            return hubLink.href;
         }
 
         if (typeof window !== 'undefined' && window.location) {
-            return `${window.location.origin}/questions/`;
+            return `${window.location.origin}/hub/`;
         }
 
-        return '/questions/';
+        return '/hub/';
     }
 
     _formatFavoriteDate(isoDateString) {

--- a/assets/js/ui/GamificationDashboard.js
+++ b/assets/js/ui/GamificationDashboard.js
@@ -796,6 +796,7 @@ export default class GamificationDashboard {
                         </div>
                     </dl>
                 </div>
+                ${item?.detail_url ? `<footer class="challenge-card__footer"><a class="button button--text button--small" href="${item.detail_url}">Ver detalhes</a></footer>` : ''}
             </article>
         `;
     }

--- a/assets/js/ui/LayoutManager.js
+++ b/assets/js/ui/LayoutManager.js
@@ -8,6 +8,7 @@ export default class LayoutManager {
 
         this.sectionIds = {
             home: 'home-section',
+            hub: 'question-section',
             questions: 'question-section',
             account: 'account-section-page',
         };

--- a/quiz/api/viewsets.py
+++ b/quiz/api/viewsets.py
@@ -1040,6 +1040,8 @@ class QuestionViewSet(viewsets.ViewSet):
 
         question_payload = {
             'id_pergunta': pergunta.pk,
+            'slug': pergunta.slug,
+            'detail_url': pergunta.get_absolute_url(),
             'texto_pergunta': pergunta.texto_pergunta,
             'url_imagem': pergunta.url_imagem,
             'referencia_bibliografica': pergunta.referencia_bibliografica,

--- a/quiz/migrations/0023_pergunta_slug.py
+++ b/quiz/migrations/0023_pergunta_slug.py
@@ -1,0 +1,102 @@
+from django.db import migrations, models
+from django.utils.text import slugify
+
+
+def generate_question_slugs(apps, schema_editor):
+    Pergunta = apps.get_model('quiz', 'Pergunta')
+    for question in Pergunta.objects.all():
+        base_slug = slugify(question.texto_pergunta or '') or 'pergunta'
+        base_slug = base_slug[:200].strip('-') or 'pergunta'
+        slug_candidate = base_slug
+        suffix = 2
+        while Pergunta.objects.filter(slug=slug_candidate).exclude(pk=question.pk).exists():
+            suffix_fragment = f'-{suffix}'
+            available_length = 255 - len(suffix_fragment)
+            slug_candidate = f"{base_slug[:available_length]}{suffix_fragment}"
+            suffix += 1
+        question.slug = slug_candidate
+        question.save(update_fields=['slug'])
+
+
+def update_home_urls(apps, schema_editor):
+    HomePageSettings = apps.get_model('quiz', 'HomePageSettings')
+    HomeRecentSessionCardSettings = apps.get_model('quiz', 'HomeRecentSessionCardSettings')
+    HomeHeroCTA = apps.get_model('quiz', 'HomeHeroCTA')
+    HomeQuickLink = apps.get_model('quiz', 'HomeQuickLink')
+
+    hub_root = '/hub/'
+    legacy_root = '/questions/'
+
+    settings = HomePageSettings.objects.first()
+    if settings and settings.intro_secondary_cta_url in {legacy_root, f'{legacy_root}#hub-predefined-section'}:
+        new_value = hub_root if settings.intro_secondary_cta_url == legacy_root else f'{hub_root}#hub-predefined-section'
+        settings.intro_secondary_cta_url = new_value
+        settings.save(update_fields=['intro_secondary_cta_url'])
+
+    session_card = HomeRecentSessionCardSettings.objects.first()
+    if session_card and session_card.cta_url == legacy_root:
+        session_card.cta_url = hub_root
+        session_card.save(update_fields=['cta_url'])
+
+    for cta in HomeHeroCTA.objects.all():
+        if cta.url and cta.url.startswith(legacy_root):
+            cta.url = cta.url.replace(legacy_root, hub_root, 1)
+            cta.save(update_fields=['url'])
+
+    for quick_link in HomeQuickLink.objects.all():
+        if quick_link.url and quick_link.url.startswith(legacy_root):
+            quick_link.url = quick_link.url.replace(legacy_root, hub_root, 1)
+            quick_link.save(update_fields=['url'])
+
+
+def noop(apps, schema_editor):
+    """Migration reversal is intentionally left as a no-op."""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('quiz', '0022_populate_home_challenge_card_defaults'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='pergunta',
+            name='slug',
+            field=models.SlugField(
+                blank=True,
+                max_length=255,
+                null=True,
+                unique=True,
+                help_text='Identificador único e legível usado para construir URLs públicas da questão.',
+                verbose_name='Slug da Pergunta',
+            ),
+        ),
+        migrations.RunPython(generate_question_slugs, reverse_code=noop),
+        migrations.AlterField(
+            model_name='pergunta',
+            name='slug',
+            field=models.SlugField(
+                blank=True,
+                max_length=255,
+                unique=True,
+                help_text='Identificador único e legível usado para construir URLs públicas da questão.',
+                verbose_name='Slug da Pergunta',
+            ),
+        ),
+        migrations.AlterField(
+            model_name='homepagesettings',
+            name='intro_secondary_cta_url',
+            field=models.CharField(
+                default='/hub/',
+                help_text='URL relativa ou absoluta para o CTA secundário do card de passos.',
+                max_length=255,
+            ),
+        ),
+        migrations.AlterField(
+            model_name='homerecentsessioncardsettings',
+            name='cta_url',
+            field=models.CharField(default='/hub/', max_length=255),
+        ),
+        migrations.RunPython(update_home_urls, reverse_code=noop),
+    ]

--- a/quiz/models.py
+++ b/quiz/models.py
@@ -8,7 +8,9 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import models, transaction
+from django.urls import reverse
 from django.utils import timezone
+from django.utils.text import slugify
 
 
 def default_difficulty_rewards() -> Dict[str, Dict[str, int]]:
@@ -394,6 +396,13 @@ class Pergunta(models.Model):
         null=True,
         verbose_name="Referência Bibliográfica"
     )
+    slug = models.SlugField(
+        max_length=255,
+        unique=True,
+        blank=True,
+        verbose_name="Slug da Pergunta",
+        help_text="Identificador único e legível usado para construir URLs públicas da questão.",
+    )
     categorias = models.ManyToManyField(
         Categoria,
         related_name='perguntas_associadas',
@@ -436,6 +445,23 @@ class Pergunta(models.Model):
 
     def __str__(self):
         return f"P{self.pk}: {self.texto_pergunta[:70]}..."
+
+    def save(self, *args, **kwargs):  # type: ignore[override]
+        if not self.slug:
+            base_slug = slugify(self.texto_pergunta) or "pergunta"
+            base_slug = base_slug[:200].strip("-") or "pergunta"
+            slug_candidate = base_slug
+            suffix = 2
+            while Pergunta.objects.filter(slug=slug_candidate).exclude(pk=self.pk).exists():
+                suffix_fragment = f"-{suffix}"
+                available_length = 255 - len(suffix_fragment)
+                slug_candidate = f"{base_slug[:available_length]}{suffix_fragment}"
+                suffix += 1
+            self.slug = slug_candidate
+        super().save(*args, **kwargs)
+
+    def get_absolute_url(self) -> str:
+        return reverse('quiz:question_detail', kwargs={'slug': self.slug})
 
     class Meta:
         verbose_name = "Pergunta do Quiz"
@@ -1555,6 +1581,9 @@ class DesafioDinamico(models.Model):
         reference = reference_time or timezone.now()
         return DesafioDinamico.objects.ativos(reference).filter(pk=self.pk).exists()
 
+    def get_absolute_url(self) -> str:
+        return reverse('quiz:challenge_detail', kwargs={'slug': self.slug})
+
     def get_target_value(self) -> float:
         criterio = self.criterio_json or {}
         try:
@@ -1955,7 +1984,7 @@ class HomePageSettings(SingletonModel):
     )
     intro_secondary_cta_url = models.CharField(
         max_length=255,
-        default="/questions/",
+        default="/hub/",
         help_text="URL relativa ou absoluta para o CTA secundário do card de passos.",
     )
     collections_section_title = models.CharField(
@@ -2009,7 +2038,7 @@ class HomeHeroCTA(models.Model):
     audience = models.CharField(max_length=20, choices=HomeContentAudience.choices, default=HomeContentAudience.AUTHENTICATED)
     position = models.CharField(max_length=20, choices=Position.choices, default=Position.PRIMARY)
     label = models.CharField(max_length=120)
-    url = models.CharField(max_length=255, help_text="Use URLs relativas (ex: /questions/) ou absolutas.")
+    url = models.CharField(max_length=255, help_text="Use URLs relativas (ex: /hub/) ou absolutas.")
     icon = models.CharField(max_length=80, blank=True, help_text="Nome do ícone Material Symbols a exibir.")
     css_class = models.CharField(
         max_length=200,
@@ -2185,7 +2214,7 @@ class HomeRecentSessionCardSettings(models.Model):
     stat_accuracy_placeholder = models.CharField(max_length=80, default="0%")
     stat_duration_placeholder = models.CharField(max_length=80, default="0 min")
     cta_label = models.CharField(max_length=120, default="Retomar treino")
-    cta_url = models.CharField(max_length=255, default="/questions/")
+    cta_url = models.CharField(max_length=255, default="/hub/")
     cta_icon = models.CharField(max_length=80, blank=True, default="play_arrow")
     cta_css_class = models.CharField(max_length=200, default="button button--text")
     show_when_empty = models.BooleanField(

--- a/quiz/services/gamification_service.py
+++ b/quiz/services/gamification_service.py
@@ -849,12 +849,12 @@ class GamificationService:
         self,
         *,
         challenge: DesafioDinamico,
-        progress: ProgressoDesafioUsuario,
+        progress: Optional[ProgressoDesafioUsuario],
         reference_time: datetime,
     ) -> Dict[str, Any]:
         target_value = challenge.get_target_value()
-        current_value = float(progress.valor_atual or 0.0)
-        percent = progress.progress_percent(target_value) if target_value else 0.0
+        current_value = float(progress.valor_atual or 0.0) if progress else 0.0
+        percent = progress.progress_percent(target_value) if progress and target_value else 0.0
         remaining = None
         if target_value:
             remaining = max(int(round(target_value - current_value)), 0)
@@ -884,11 +884,42 @@ class GamificationService:
                 'remaining': remaining,
             },
             'reward': challenge.recompensa_json or {},
-            'is_completed': bool(progress.concluido),
-            'completed_at': progress.data_conclusao.isoformat() if progress.data_conclusao else None,
+            'is_completed': bool(progress.concluido) if progress else False,
+            'completed_at': progress.data_conclusao.isoformat() if progress and progress.data_conclusao else None,
             'time_remaining_seconds': time_remaining_seconds,
-            'metadata': progress.metadata or {},
+            'metadata': progress.metadata or {} if progress else {},
+            'detail_url': challenge.get_absolute_url(),
         }
+
+    def serialize_challenge_for_user(
+        self,
+        challenge: DesafioDinamico,
+        *,
+        user=None,
+    ) -> Dict[str, Any]:
+        profile: Optional[PerfilGamificacaoUsuario] = None
+        progress: Optional[ProgressoDesafioUsuario] = None
+
+        if user and getattr(user, 'is_authenticated', False):
+            profile = getattr(user, 'gamification_profile', None)
+            if profile is None:
+                profile = (
+                    PerfilGamificacaoUsuario.objects.filter(user=user).first()
+                )
+            if profile:
+                progress = ProgressoDesafioUsuario.objects.filter(
+                    desafio=challenge,
+                    perfil=profile,
+                ).first()
+
+        reference_time = timezone.now()
+        payload = self._serialize_single_challenge(
+            challenge=challenge,
+            progress=progress,
+            reference_time=reference_time,
+        )
+        payload['is_active'] = challenge.is_active(reference_time)
+        return payload
 
     def _serialize_rewards(
         self,

--- a/quiz/services/quiz_service.py
+++ b/quiz/services/quiz_service.py
@@ -224,6 +224,8 @@ class QuizDataService:
             perguntas_data_list.append(
                 {
                     "id_pergunta": pergunta.pk,
+                    "slug": pergunta.slug,
+                    "detail_url": pergunta.get_absolute_url(),
                     "texto_pergunta": pergunta.texto_pergunta,
                     "url_imagem": pergunta.url_imagem,
                     "referencia_bibliografica": pergunta.referencia_bibliografica,

--- a/quiz/templates/quiz/base.html
+++ b/quiz/templates/quiz/base.html
@@ -13,17 +13,18 @@
         rel="stylesheet">
     <link rel="stylesheet" href="{% static 'css/style.bundle.css' %}">
     <title>{% block title %}MedQuiz{% endblock title %}</title>
+    {% block extra_head %}{% endblock extra_head %}
 </head>
 {# ===== MODIFICAÇÃO AQUI para adicionar data-page-id e os novos data attributes ===== #}
 {% with view_name=request.resolver_match.view_name|default:'' %}
-<body
-      {% block body_attrs %}{% endblock body_attrs %}
-      data-user-authenticated="{{ user.is_authenticated|yesno:'true,false' }}"
-      data-page-id="{% if view_name == 'quiz:home' %}home{% elif view_name == 'quiz:questions' %}questions{% elif view_name == 'quiz:account' %}account{% elif view_name == 'quiz:update_profile' %}account{% elif view_name == 'quiz:update_preferences' %}account{% elif view_name == 'quiz:delete_account' %}account{% else %}unknown{% endif %}"
-      data-active-tab-on-error="{{ active_tab_on_error|default_if_none:'' }}"
-      data-show-delete-modal-on-error="{{ show_delete_account_modal_on_error|yesno:'true,false' }}"
-      data-user-theme="{{ user_theme_preference|default:'' }}"
-      >
+    <body
+        {% block body_attrs %}{% endblock body_attrs %}
+        data-user-authenticated="{{ user.is_authenticated|yesno:'true,false' }}"
+        data-page-id="{% if view_name == 'quiz:home' %}home{% elif view_name == 'quiz:challenge_hub' or view_name == 'quiz:questions' or view_name == 'quiz:question_detail' or view_name == 'quiz:challenge_detail' %}hub{% elif view_name == 'quiz:account' %}account{% elif view_name == 'quiz:update_profile' %}account{% elif view_name == 'quiz:update_preferences' %}account{% elif view_name == 'quiz:delete_account' %}account{% else %}unknown{% endif %}"
+        data-active-tab-on-error="{{ active_tab_on_error|default_if_none:'' }}"
+        data-show-delete-modal-on-error="{{ show_delete_account_modal_on_error|yesno:'true,false' }}"
+        data-user-theme="{{ user_theme_preference|default:'' }}"
+        >
 {# ===== FIM DA MODIFICAÇÃO ===== #}
     
     <div id="global-toast-stack" class="toast-stack" role="region" aria-live="polite" aria-atomic="false"></div>

--- a/quiz/templates/quiz/challenge_detail.html
+++ b/quiz/templates/quiz/challenge_detail.html
@@ -1,0 +1,104 @@
+{% extends "quiz/base.html" %}
+{% load static %}
+
+{% block title %}{{ page_title }}{% endblock %}
+
+{% block extra_head %}
+    {% if meta_description %}<meta name="description" content="{{ meta_description }}">{% endif %}
+    <link rel="canonical" href="{{ canonical_url }}">
+{% endblock extra_head %}
+
+{% block body_attrs %}class="is-challenge-detail"{% endblock %}
+
+{% block content %}
+<section class="main-section main-section--narrow challenge-detail">
+    <div class="breadcrumb">
+        <a href="{{ hub_url }}" class="button button--text button--compact">
+            <span class="material-symbols-outlined" aria-hidden="true">arrow_back</span>
+            <span class="button__label">Voltar para o hub de desafios</span>
+        </a>
+    </div>
+
+    <article class="card challenge-detail__card">
+        <header class="card__header challenge-detail__header">
+            <div class="challenge-detail__heading">
+                <span class="challenge-detail__eyebrow">Desafio dinâmico</span>
+                <h1 class="challenge-detail__title">{{ challenge.nome }}</h1>
+                {% if challenge_payload.is_active %}
+                <span class="challenge-detail__status challenge-detail__status--active">Ativo</span>
+                {% else %}
+                <span class="challenge-detail__status">Encerrado</span>
+                {% endif %}
+            </div>
+            {% if challenge.descricao %}
+            <p class="challenge-detail__description">{{ challenge.descricao }}</p>
+            {% endif %}
+        </header>
+
+        <div class="card__body challenge-detail__body">
+            <section class="challenge-detail__summary" aria-label="Informações principais">
+                <ul class="challenge-detail__summary-list">
+                    <li>
+                        <span class="challenge-detail__meta-label">Tipo</span>
+                        <span class="challenge-detail__meta-value">{{ challenge.get_tipo_display }}</span>
+                    </li>
+                    <li>
+                        <span class="challenge-detail__meta-label">Período</span>
+                        <span class="challenge-detail__meta-value">
+                            {% if start_display %}{{ start_display|date:"d \d\e F" }}{% else %}Início flexível{% endif %}
+                            {% if end_display %} a {{ end_display|date:"d \d\e F" }}{% else %} • Sem data limite{% endif %}
+                        </span>
+                    </li>
+                    {% if time_remaining_text %}
+                    <li>
+                        <span class="challenge-detail__meta-label">Tempo restante</span>
+                        <span class="challenge-detail__meta-value">{{ time_remaining_text }}</span>
+                    </li>
+                    {% endif %}
+                </ul>
+            </section>
+
+            <section class="challenge-detail__progress" aria-label="Progresso atual">
+                <h2 class="challenge-detail__section-title">Progresso</h2>
+                <div class="challenge-detail__progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ progress_payload.percent|default:0|floatformat:'0' }}">
+                    <span style="width: {{ progress_payload.percent|default:0 }}%;"></span>
+                </div>
+                <div class="challenge-detail__progress-meta">
+                    <span>{{ progress_payload.label }}</span>
+                    {% if remaining_display is not None and challenge_payload.target %}
+                    <span>Faltam {{ remaining_display|floatformat:'0' }} de {{ challenge_payload.target|floatformat:'0' }}</span>
+                    {% endif %}
+                </div>
+                {% if challenge_payload.is_completed %}
+                <p class="challenge-detail__completion">Você concluiu este desafio {% if challenge_payload.completed_at %}em {{ challenge_payload.completed_at|date:"d/m/Y H:i" }}{% endif %}.</p>
+                {% endif %}
+            </section>
+
+            {% if reward_payload %}
+            <section class="challenge-detail__reward" aria-label="Recompensa">
+                <h2 class="challenge-detail__section-title">Recompensa</h2>
+                <div class="challenge-detail__reward-card">
+                    <span class="material-symbols-outlined" aria-hidden="true">redeem</span>
+                    <div>
+                        <p class="challenge-detail__reward-title">{{ reward_payload.nome|default:"Recompensa especial" }}</p>
+                        {% if reward_payload.descricao %}
+                        <p class="challenge-detail__reward-description">{{ reward_payload.descricao }}</p>
+                        {% endif %}
+                        {% if reward_payload.valor %}
+                        <p class="challenge-detail__reward-meta">Valor: {{ reward_payload.valor }}</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </section>
+            {% endif %}
+        </div>
+
+        <footer class="card__footer challenge-detail__footer">
+            <a href="{{ hub_url }}" class="button button--primary">
+                <span class="material-symbols-outlined button__icon" aria-hidden="true">flag</span>
+                <span class="button__label">Escolher outro desafio</span>
+            </a>
+        </footer>
+    </article>
+</section>
+{% endblock content %}

--- a/quiz/templates/quiz/home.html
+++ b/quiz/templates/quiz/home.html
@@ -141,9 +141,14 @@
                             <span class="home-card__progress-fill" style="width: {{ card.progress.percent|default:0 }}%;"></span>
                         </div>
                     </div>
-                    {% if card.reward %}
-                    <footer class="home-card__footer">
+                    {% if card.reward or card.detail_url %}
+                    <footer class="home-card__footer{% if card.detail_url %} home-card__footer--actions{% endif %}">
+                        {% if card.reward %}
                         <span class="home-card__chip">{{ card.reward }}</span>
+                        {% endif %}
+                        {% if card.detail_url %}
+                        <a href="{{ card.detail_url }}" class="button button--text button--compact">Ver detalhes</a>
+                        {% endif %}
                     </footer>
                     {% endif %}
                 </article>
@@ -282,7 +287,7 @@
                 </header>
                 <p class="home-card__description">{{ quiz.description|default:"Coleção com casos clínicos selecionados para acelerar sua revisão." }}</p>
                 <footer class="home-card__footer home-card__footer--actions">
-                    <a href="{% url 'quiz:questions' %}?predefined_id={{ quiz.id }}" class="button button--text">
+                    <a href="{% url 'quiz:challenge_hub' %}?predefined_id={{ quiz.id }}" class="button button--text">
                         <span class="material-symbols-outlined button__icon" aria-hidden="true">chevron_right</span>
                         Abrir coleção
                     </a>

--- a/quiz/templates/quiz/includes/_main_nav.html
+++ b/quiz/templates/quiz/includes/_main_nav.html
@@ -4,9 +4,9 @@
         <li class="main-nav__item"><a href="{% url 'quiz:home' %}"
                 class="main-nav__link {% if request.resolver_match.view_name == 'quiz:home' %}main-nav__link--active{% endif %}"
                 data-section-target-django="home">Início</a></li>
-        <li class="main-nav__item"><a href="{% url 'quiz:questions' %}"
-                class="main-nav__link {% if request.resolver_match.view_name == 'quiz:questions' %}main-nav__link--active{% endif %}"
-                data-section-target-django="questions">Questões</a></li>
+        <li class="main-nav__item"><a href="{% url 'quiz:challenge_hub' %}"
+                class="main-nav__link {% if request.resolver_match.view_name == 'quiz:challenge_hub' or request.resolver_match.view_name == 'quiz:question_detail' or request.resolver_match.view_name == 'quiz:challenge_detail' %}main-nav__link--active{% endif %}"
+                data-section-target-django="hub">Hub de desafios</a></li>
         {# Adicionar link para 'Minha Conta' se o usuário estiver logado, opcional aqui se já estiver no header #}
     </ul>
 </nav>

--- a/quiz/templates/quiz/includes/_site_footer.html
+++ b/quiz/templates/quiz/includes/_site_footer.html
@@ -12,7 +12,7 @@
                 <ul class="site-footer__nav-list">
                     <li><a href="#" class="site-footer__nav-link">Sobre Nós</a></li>
                     <li><a href="#" class="site-footer__nav-link">Contato</a></li>  
-                    <li><a href="{% url 'quiz:questions' %}" class="site-footer__nav-link">Questões</a></li>
+                    <li><a href="{% url 'quiz:challenge_hub' %}" class="site-footer__nav-link">Hub de desafios</a></li>
                 </ul>
             </nav>
         </div>

--- a/quiz/templates/quiz/question_detail.html
+++ b/quiz/templates/quiz/question_detail.html
@@ -1,0 +1,107 @@
+{% extends "quiz/base.html" %}
+{% load static %}
+
+{% block title %}{{ page_title }}{% endblock %}
+
+{% block extra_head %}
+    {% if meta_description %}<meta name="description" content="{{ meta_description }}">{% endif %}
+    <link rel="canonical" href="{{ canonical_url }}">
+{% endblock extra_head %}
+
+{% block body_attrs %}class="is-question-detail"{% endblock %}
+
+{% block content %}
+<section class="main-section main-section--narrow question-detail">
+    <div class="breadcrumb">
+        <a href="{{ hub_url }}" class="button button--text button--compact">
+            <span class="material-symbols-outlined" aria-hidden="true">arrow_back</span>
+            <span class="button__label">Voltar para o hub de desafios</span>
+        </a>
+    </div>
+
+    <article class="card card--question-wrap question-detail__card">
+        <header class="card__header question-detail__header">
+            <div class="question-detail__heading">
+                <span class="question-detail__eyebrow">Questão do banco MedQuiz</span>
+                <h1 class="question-detail__title">{{ question.texto_pergunta }}</h1>
+            </div>
+            {% if not question.ativa %}
+            <span class="question-detail__badge">Indisponível no treino automático</span>
+            {% endif %}
+        </header>
+
+        <div class="card__body question-detail__body">
+            <section class="question-detail__meta" aria-label="Resumo da questão">
+                <ul class="question-detail__meta-list">
+                    <li>
+                        <span class="question-detail__meta-label">ID interno</span>
+                        <span class="question-detail__meta-value">#{{ question.id }}</span>
+                    </li>
+                    <li>
+                        <span class="question-detail__meta-label">Dificuldade</span>
+                        <span class="question-detail__meta-value">{{ question.get_nivel_dificuldade_display }}</span>
+                    </li>
+                    {% if question_categories %}
+                    <li>
+                        <span class="question-detail__meta-label">Categorias</span>
+                        <span class="question-detail__meta-value">
+                            {% for category in question_categories %}
+                                <span class="question-detail__tag">{{ category.nome_categoria }}</span>{% if not forloop.last %} {% endif %}
+                            {% endfor %}
+                        </span>
+                    </li>
+                    {% endif %}
+                </ul>
+            </section>
+
+            {% if question.url_imagem %}
+            <figure class="question-detail__media">
+                <img src="{{ question.url_imagem }}" alt="Ilustração complementar da questão" loading="lazy">
+            </figure>
+            {% endif %}
+
+            <section class="question-detail__statement" aria-label="Enunciado">
+                <h2 class="question-detail__section-title">Enunciado</h2>
+                <p class="question-detail__text">{{ question.texto_pergunta|linebreaksbr }}</p>
+            </section>
+
+            {% if question_options %}
+            <section class="question-detail__options" aria-label="Alternativas">
+                <h2 class="question-detail__section-title">Alternativas</h2>
+                <ol class="question-detail__option-list">
+                    {% for option in question_options %}
+                    <li class="question-detail__option{% if option.eh_correta %} question-detail__option--correct{% endif %}">
+                        <span class="question-detail__option-text">{{ option.texto_opcao|linebreaksbr }}</span>
+                        {% if option.feedback_opcao %}
+                        <p class="question-detail__option-feedback">{{ option.feedback_opcao|linebreaksbr }}</p>
+                        {% endif %}
+                    </li>
+                    {% endfor %}
+                </ol>
+            </section>
+            {% endif %}
+
+            {% if question.explicacao_resposta %}
+            <section class="question-detail__explanation" aria-label="Comentário da resposta">
+                <h2 class="question-detail__section-title">Comentário da resposta</h2>
+                <p>{{ question.explicacao_resposta|linebreaksbr }}</p>
+            </section>
+            {% endif %}
+
+            {% if question.referencia_bibliografica %}
+            <section class="question-detail__reference" aria-label="Referência bibliográfica">
+                <h2 class="question-detail__section-title">Referência</h2>
+                <p>{{ question.referencia_bibliografica|linebreaksbr }}</p>
+            </section>
+            {% endif %}
+        </div>
+
+        <footer class="card__footer question-detail__footer">
+            <a href="{{ hub_url }}" class="button button--primary">
+                <span class="material-symbols-outlined button__icon" aria-hidden="true">play_circle</span>
+                <span class="button__label">Explorar mais desafios</span>
+            </a>
+        </footer>
+    </article>
+</section>
+{% endblock content %}

--- a/quiz/urls.py
+++ b/quiz/urls.py
@@ -1,5 +1,6 @@
 # quiz/urls.py
 from django.urls import include, path
+from django.views.generic import RedirectView
 
 from rest_framework.routers import DefaultRouter
 
@@ -23,7 +24,10 @@ router.register('api/question-history', UserQuestionHistoryViewSet, basename='us
 
 urlpatterns = [
     path('', views.home_view, name='home'),
-    path('questions/', views.questions_view, name='questions'),
+    path('hub/', views.challenge_hub_view, name='challenge_hub'),
+    path('hub/perguntas/<slug:slug>/', views.question_detail_view, name='question_detail'),
+    path('hub/desafios/<slug:slug>/', views.challenge_detail_view, name='challenge_detail'),
+    path('questions/', RedirectView.as_view(pattern_name='quiz:challenge_hub', permanent=True)),
     path('account/', views.account_view, name='account'),
     path('register/', views.register_view, name='register'),
 

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -31,6 +31,7 @@ from .models import (
     ValueSourceType,
     ChallengeHubSettings,
     ChallengeHubValueSource,
+    DesafioDinamico,
     default_difficulty_rewards,
     default_streak_bonus_rules,
     default_score_panel_config,
@@ -653,6 +654,7 @@ def home_view(request):
     predefined_quizzes = QuizDataService.get_active_predefined_quizzes_summary()[:3]
     study_methods_metadata = StudyMethodRegistry.list_metadata()[:3]
     home_settings = _get_home_page_settings()
+    challenge_hub_url = reverse('quiz:challenge_hub')
 
     home_quick_links = []
     home_intro_highlights = []
@@ -728,6 +730,7 @@ def home_view(request):
                 'progress_label': progress.get('label'),
                 'reward': reward_payload.get('nome') or reward_payload.get('descricao'),
                 'time_remaining': humanize_time_remaining(primary.get('time_remaining_seconds')),
+                'detail_url': primary.get('detail_url'),
             }
 
         last_session = (
@@ -861,7 +864,7 @@ def home_view(request):
         if cta_label:
             cta = {
                 'label': cta_label,
-                'url': getattr(config, 'cta_url', '/questions/'),
+                'url': getattr(config, 'cta_url', challenge_hub_url),
                 'icon': getattr(config, 'cta_icon', ''),
                 'css_class': getattr(config, 'cta_css_class', 'button button--text'),
             }
@@ -916,6 +919,7 @@ def home_view(request):
             reward_value = reward_placeholder
 
         progress_percent = payload.get('progress_percent') if payload else 0
+        detail_url = payload.get('detail_url') if payload else None
 
         return {
             'key': 'active_challenge',
@@ -930,6 +934,7 @@ def home_view(request):
                 'percent': progress_percent or 0,
             },
             'reward': reward_value,
+            'detail_url': detail_url,
             'is_empty': is_empty,
         }
 
@@ -1176,7 +1181,7 @@ def home_view(request):
             home_hero_ctas = [
                 {
                     'label': 'Iniciar novo quiz',
-                    'url': '/questions/',
+                    'url': challenge_hub_url,
                     'icon': 'rocket_launch',
                     'css_class': 'button button--fancy button--fancy-primary',
                     'anchor_id': 'go-to-challenges-hub-link',
@@ -1203,7 +1208,7 @@ def home_view(request):
                 },
                 {
                     'label': 'Explorar banco de questões',
-                    'url': '/questions/',
+                    'url': challenge_hub_url,
                     'icon': 'quiz',
                     'css_class': 'button button--fancy button--fancy-secondary',
                     'anchor_id': '',
@@ -1244,14 +1249,14 @@ def home_view(request):
         }
         home_intro_ctas = {
             'primary': {'label': 'Criar conta', 'url': '/register/'},
-            'secondary': {'label': 'Experimentar um quiz', 'url': '/questions/'},
+            'secondary': {'label': 'Experimentar um quiz', 'url': challenge_hub_url},
         }
         home_quick_links = [
             {
                 'title': 'Iniciar desafio rápido',
                 'description': 'Abra o hub de desafios configurado para você.',
                 'icon': 'rocket_launch',
-                'url': '/questions/',
+                'url': challenge_hub_url,
                 'extra_css_class': '',
                 'anchor_id': 'quick-link-start',
                 'open_in_new_tab': False,
@@ -1269,7 +1274,7 @@ def home_view(request):
                 'title': 'Explorar coleções prontas',
                 'description': 'Seleções temáticas com tempo estimado e foco claro.',
                 'icon': 'playlist_add_check',
-                'url': '/questions/#hub-predefined-section',
+                'url': f"{challenge_hub_url}#hub-predefined-section",
                 'extra_css_class': '',
                 'anchor_id': '',
                 'open_in_new_tab': False,
@@ -1350,7 +1355,7 @@ def home_view(request):
     return render(request, 'quiz/home.html', context)
 
 @login_required
-def questions_view(request):
+def challenge_hub_view(request):
     def format_count(value):
         try:
             return f"{int(value):,}".replace(',', '.')
@@ -1522,6 +1527,106 @@ def questions_view(request):
         'challenge_placeholders': challenge_placeholders,
     }
     return render(request, 'quiz/questions_page.html', context)
+
+
+def question_detail_view(request, slug):
+    question_queryset = Pergunta.objects.prefetch_related(
+        Prefetch(
+            'categorias',
+            queryset=Categoria.objects.all().only('pk', 'nome_categoria').order_by('nome_categoria'),
+        ),
+        Prefetch(
+            'opcoes',
+            queryset=OpcaoResposta.objects.all().order_by('ordem_exibicao', 'pk'),
+        ),
+    )
+
+    pergunta = get_object_or_404(question_queryset, slug=slug)
+
+    categorias_relacionadas = list(pergunta.categorias.all())
+    opcoes_ordenadas = list(pergunta.opcoes.all())
+
+    canonical_url = request.build_absolute_uri(pergunta.get_absolute_url())
+    meta_description_raw = (pergunta.texto_pergunta or '').strip()
+    meta_description = ' '.join(meta_description_raw.split())
+    if not meta_description:
+        meta_description = f"Questão do MedQuiz disponível no hub de desafios."
+    if len(meta_description) > 155:
+        meta_description = f"{meta_description[:152].rstrip()}..."
+
+    context = {
+        'page_title': f"Questão: {pergunta.texto_pergunta[:60]} - MedQuiz",
+        'question': pergunta,
+        'question_categories': categorias_relacionadas,
+        'question_options': opcoes_ordenadas,
+        'canonical_url': canonical_url,
+        'meta_description': meta_description,
+        'hub_url': reverse('quiz:challenge_hub'),
+    }
+
+    return render(request, 'quiz/question_detail.html', context)
+
+
+def challenge_detail_view(request, slug):
+    challenge = get_object_or_404(DesafioDinamico.objects.all(), slug=slug)
+    gamification_service = GamificationService()
+    challenge_payload = gamification_service.serialize_challenge_for_user(
+        challenge,
+        user=request.user,
+    )
+
+    reward_payload = challenge_payload.get('reward') or {}
+    progress_payload = challenge_payload.get('progress') or {}
+
+    def format_time_remaining(seconds: Optional[int]) -> Optional[str]:
+        if seconds is None:
+            return None
+        try:
+            total_seconds = int(seconds)
+        except (TypeError, ValueError):
+            return None
+        if total_seconds <= 0:
+            return 'Encerrado'
+        minutes, sec = divmod(total_seconds, 60)
+        hours, minutes = divmod(minutes, 60)
+        days, hours = divmod(hours, 24)
+        if days:
+            return f"{days}d {hours}h"
+        if hours:
+            return f"{hours}h {minutes}min"
+        if minutes:
+            return f"{minutes}min"
+        return f"{sec}s"
+
+    time_remaining_text = format_time_remaining(challenge_payload.get('time_remaining_seconds'))
+    canonical_url = request.build_absolute_uri(challenge.get_absolute_url())
+    start_display = timezone.localtime(challenge.data_inicio) if challenge.data_inicio else None
+    end_display = timezone.localtime(challenge.data_fim) if challenge.data_fim else None
+    remaining_display = None
+    try:
+        remaining_display = int(progress_payload.get('remaining')) if progress_payload.get('remaining') is not None else None
+    except (TypeError, ValueError):
+        remaining_display = progress_payload.get('remaining')
+    meta_description = challenge.descricao or f"Detalhes do desafio {challenge.nome} no MedQuiz."
+    if len(meta_description) > 155:
+        meta_description = f"{meta_description[:152].rstrip()}..."
+
+    context = {
+        'page_title': f"Desafio: {challenge.nome} - MedQuiz",
+        'challenge': challenge,
+        'challenge_payload': challenge_payload,
+        'reward_payload': reward_payload,
+        'progress_payload': progress_payload,
+        'time_remaining_text': time_remaining_text,
+        'canonical_url': canonical_url,
+        'hub_url': reverse('quiz:challenge_hub'),
+        'start_display': start_display,
+        'end_display': end_display,
+        'remaining_display': remaining_display,
+        'meta_description': meta_description,
+    }
+
+    return render(request, 'quiz/challenge_detail.html', context)
 
 
 def register_view(request):
@@ -2240,6 +2345,8 @@ def get_favorite_questions_view(request):
 
         perguntas_favoritas_data.append({
             'id_pergunta': p.pk,
+            'slug': p.slug,
+            'detail_url': p.get_absolute_url(),
             'texto_pergunta': p.texto_pergunta,
             'url_imagem': p.url_imagem,
             'referencia_bibliografica': p.referencia_bibliografica,
@@ -2254,7 +2361,8 @@ def get_favorite_questions_view(request):
             'nivel_dificuldade': p.nivel_dificuldade,
             'explicacao_resposta': p.explicacao_resposta,
             'opcoes': opcoes_data,
-            'data_favoritada': fav.data_favoritada.isoformat()
+            'data_favoritada': fav.data_favoritada.isoformat(),
+            'esta_ativa': p.ativa,
         })
 
     all_categories_list_for_mapping = [


### PR DESCRIPTION
## Summary
- add a slug field and canonical URLs for questions/challenges plus a data migration that backfills slugs and updates legacy /questions links
- create dedicated detail templates and views for questions and challenges, wiring them to new /hub/ routes and updating navigation
- surface detail links across services and UI layers so hub cards, favorites, and dashboards link to the new pages

## Testing
- python manage.py migrate
- python manage.py test


------
https://chatgpt.com/codex/tasks/task_e_68e6b8f6f6988333986b151eb7272a3b