### PR TITLE
Streamline admin base with smart automation

### DIFF
--- a/assets/admin/enhancements.js
+++ b/assets/admin/enhancements.js
@@ -1,0 +1,55 @@
+(function () {
+    const focusFirstField = () => {
+        const content = document.getElementById('content-main');
+        if (!content) {
+            return;
+        }
+        const selector = 'form input:not([type="hidden"]):not([disabled]), form textarea, form select';
+        const firstField = content.querySelector(selector);
+        if (firstField && typeof firstField.focus === 'function') {
+            firstField.focus({ preventScroll: true });
+        }
+    };
+
+    const focusSearchInput = () => {
+        const searchBox = document.querySelector('#changelist-search input[name="q"]');
+        if (!searchBox) {
+            return;
+        }
+        if (!searchBox.placeholder) {
+            searchBox.placeholder = 'Buscar registros…';
+        }
+        if (document.activeElement === document.body && typeof searchBox.focus === 'function') {
+            searchBox.focus({ preventScroll: true });
+        }
+    };
+
+    const registerSaveShortcut = () => {
+        const handler = (event) => {
+            if (!(event.ctrlKey || event.metaKey) || event.key !== 'Enter') {
+                return;
+            }
+            const primarySave = document.querySelector(
+                'form input[name="_save"], form button[name="_save"]'
+            );
+            if (primarySave) {
+                event.preventDefault();
+                primarySave.click();
+            }
+        };
+
+        document.addEventListener('keydown', handler);
+    };
+
+    const init = () => {
+        focusFirstField();
+        focusSearchInput();
+        registerSaveShortcut();
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/quiz/admin/__init__.py
+++ b/quiz/admin/__init__.py
@@ -2,9 +2,12 @@
 
 from django.contrib import admin
 
-admin.site.site_header = "MedQuiz Admin"
-admin.site.site_title = "MedQuiz Administração"
-admin.site.index_title = "Gestão de Conteúdo"
+admin.site.site_header = "MedQuiz • Painel Administrativo"
+admin.site.site_title = "MedQuiz | Administração"
+admin.site.index_title = "Central de Gestão do MedQuiz"
+admin.site.site_url = "/"
+admin.site.enable_nav_sidebar = False
+admin.site.empty_value_display = "—"
 
 # Load registrations grouped by domain to keep the admin tidy.
 from . import analytics, configuration, content, gamification, sessions, system  # noqa: E402,F401

--- a/quiz/admin/analytics.py
+++ b/quiz/admin/analytics.py
@@ -9,9 +9,11 @@ from quiz.models import (
     UserQuestionStudyState,
 )
 
+from .base import EnhancedModelAdmin
+
 
 @admin.register(UserQuestionStudyState)
-class UserQuestionStudyStateAdmin(admin.ModelAdmin):
+class UserQuestionStudyStateAdmin(EnhancedModelAdmin):
     list_display = (
         "user",
         "pergunta",
@@ -25,10 +27,11 @@ class UserQuestionStudyStateAdmin(admin.ModelAdmin):
     search_fields = ("user__username", "pergunta__texto_pergunta")
     autocomplete_fields = ["user", "pergunta", "last_session"]
     readonly_fields = ("created_at", "updated_at")
+    select_related_fields = ("user", "pergunta", "last_session")
 
 
 @admin.register(EstatisticasDiariasUsuario)
-class EstatisticasDiariasUsuarioAdmin(admin.ModelAdmin):
+class EstatisticasDiariasUsuarioAdmin(EnhancedModelAdmin):
     list_display = (
         "id",
         "link_usuario_stats",
@@ -59,7 +62,7 @@ class EstatisticasDiariasUsuarioAdmin(admin.ModelAdmin):
     )
     autocomplete_fields = ["id_usuario"]
     date_hierarchy = "data_estatistica"
-    list_select_related = ("id_usuario",)
+    select_related_fields = ("id_usuario",)
 
     fieldsets = (
         (None, {"fields": ("id_usuario", "data_estatistica")}),

--- a/quiz/admin/base.py
+++ b/quiz/admin/base.py
@@ -1,0 +1,325 @@
+"""Shared admin base classes focused on a fast, polished authoring experience."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, Sequence
+
+from django import forms
+from django.contrib import admin
+from django.core import serializers
+from django.core.exceptions import FieldDoesNotExist
+from django.db import models
+from django.http import HttpResponse
+from django.utils import timezone
+
+from .mixins import AuditFieldsReadonlyMixin
+
+
+def _apply_widget_enhancements(
+    widget: forms.Widget,
+    label: str | None = None,
+    help_text: str | None = None,
+) -> None:
+    """Normalize widget appearance and hints for a better authoring flow."""
+
+    if not hasattr(widget, "attrs"):
+        return
+
+    if label:
+        widget.attrs.setdefault("aria-label", str(label))
+
+    if help_text:
+        widget.attrs.setdefault("title", str(help_text))
+
+    placeholder = widget.attrs.get("placeholder")
+    if not placeholder:
+        label_placeholder = (label or "").strip()
+        if label_placeholder:
+            widget.attrs["placeholder"] = label_placeholder
+
+    if isinstance(widget, forms.TextInput):
+        widget.attrs.setdefault("style", "width: 72%;")
+        widget.attrs.setdefault("autocomplete", "off")
+
+    if isinstance(widget, forms.Textarea):
+        current_style = widget.attrs.get("style", "")
+        additions = ["resize: vertical", "min-height: 120px"]
+        if current_style:
+            additions.insert(0, current_style.rstrip(";"))
+        widget.attrs["style"] = "; ".join(additions)
+        widget.attrs.setdefault("rows", 4)
+
+    if isinstance(widget, forms.URLInput):
+        widget.attrs.setdefault("style", "width: 80%;")
+        widget.attrs.setdefault("placeholder", (label or "https://exemplo.com"))
+        widget.attrs.setdefault("autocomplete", "url")
+
+    if isinstance(widget, forms.EmailInput):
+        widget.attrs.setdefault("placeholder", (label or "email@exemplo.com"))
+        widget.attrs.setdefault("autocomplete", "email")
+
+    if isinstance(widget, forms.NumberInput):
+        widget.attrs.setdefault("style", "width: 40%;")
+        widget.attrs.setdefault("step", "any")
+        widget.attrs.setdefault("inputmode", "decimal")
+
+
+class _EnhancedAdminBase:
+    """Mixin shared between our enhanced admin classes."""
+
+    save_on_top = True
+    save_as = True
+    actions_on_top = True
+    actions_on_bottom = True
+    list_per_page = 40
+    list_max_show_all = 200
+    preserve_filters = True
+
+    class Media:
+        js = ("admin/enhancements.js",)
+
+    export_datetime_format = "%Y%m%d-%H%M%S"
+
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        if "export_as_json_action" not in actions:
+            actions["export_as_json_action"] = (
+                self.export_as_json_action,
+                "export_as_json_action",
+                "Exportar selecionados como JSON",
+            )
+        return actions
+
+    def export_as_json_action(self, request, queryset):
+        if not queryset.exists():
+            self.message_user(request, "Nenhum registro selecionado para exportação.")
+            return None
+
+        opts = self.model._meta
+        timestamp = timezone.now().strftime(self.export_datetime_format)
+        filename = f"{opts.app_label}-{opts.model_name}-{timestamp}.json"
+        response = HttpResponse(content_type="application/json")
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
+        serializers.serialize("json", queryset, stream=response)
+        return response
+
+    export_as_json_action.short_description = "Exportar selecionados como JSON"
+
+
+class EnhancedModelAdmin(AuditFieldsReadonlyMixin, _EnhancedAdminBase, admin.ModelAdmin):
+    """Opinionated admin base with sensible defaults for content-heavy models."""
+
+    show_full_result_count = False
+    search_by_pk: bool = True
+    default_ordering: Sequence[str] = ("-pk",)
+    select_related_fields: Iterable[str] = ()
+    prefetch_related_fields: Iterable[str] = ()
+    auto_detect_search_fields: bool = True
+    auto_search_field_names: Sequence[str] = (
+        "nome",
+        "name",
+        "titulo",
+        "title",
+        "descricao",
+        "description",
+        "texto",
+        "texto_pergunta",
+        "slug",
+        "email",
+    )
+    auto_detect_list_filter: bool = True
+    auto_list_filter_cap: int = 4
+    auto_date_hierarchy: bool = True
+    auto_date_hierarchy_fields: Sequence[str] = (
+        "data_atualizacao",
+        "data_criacao",
+        "updated_at",
+        "created_at",
+        "modified",
+        "created",
+    )
+    formfield_overrides = {
+        models.CharField: {
+            "widget": forms.TextInput(attrs={"style": "width: 72%;", "autocomplete": "off"})
+        },
+        models.SlugField: {
+            "widget": forms.TextInput(
+                attrs={"style": "width: 72%;", "placeholder": "slug-gerado-automaticamente"}
+            )
+        },
+        models.TextField: {
+            "widget": forms.Textarea(
+                attrs={
+                    "rows": 4,
+                    "style": "min-height: 120px; resize: vertical;",
+                }
+            )
+        },
+        models.URLField: {
+            "widget": forms.URLInput(attrs={"style": "width: 80%;", "placeholder": "https://exemplo.com"})
+        },
+        models.JSONField: {
+            "widget": forms.Textarea(
+                attrs={
+                    "rows": 10,
+                    "style": "font-family: var(--font-family-monospace, monospace); resize: vertical;",
+                    "placeholder": "{\n    \"chave\": \"valor\"\n}",
+                }
+            )
+        },
+    }
+
+    def __init__(self, model, admin_site):
+        super().__init__(model, admin_site)
+        self._auto_configure_date_hierarchy()
+        self._auto_configure_search_fields()
+        self._auto_configure_list_filter()
+
+    def get_ordering(self, request):
+        ordering = super().get_ordering(request)
+        if ordering:
+            return ordering
+        return self.default_ordering
+
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        if self.select_related_fields:
+            queryset = queryset.select_related(*self.select_related_fields)
+        if self.prefetch_related_fields:
+            queryset = queryset.prefetch_related(*self.prefetch_related_fields)
+        return queryset
+
+    def get_search_results(self, request, queryset, search_term):
+        queryset, use_distinct = super().get_search_results(request, queryset, search_term)
+        if self.search_by_pk and search_term:
+            raw_term = search_term.strip()
+            candidate = re.sub(r"[^\d]", "", raw_term)
+            if candidate.isdigit():
+                queryset |= self.model._default_manager.filter(pk=int(candidate))
+        return queryset, use_distinct
+
+    def get_form(self, request, obj=None, change=False, **kwargs):
+        form = super().get_form(request, obj, change, **kwargs)
+        for name, field in form.base_fields.items():
+            _apply_widget_enhancements(field.widget, field.label, field.help_text)
+        return form
+
+    def formfield_for_dbfield(self, db_field, request, **kwargs):
+        formfield = super().formfield_for_dbfield(db_field, request, **kwargs)
+        if formfield and formfield.widget:
+            _apply_widget_enhancements(
+                formfield.widget,
+                getattr(formfield, "label", None),
+                getattr(formfield, "help_text", None),
+            )
+        return formfield
+
+    # ------------------------------------------------------------------
+    # Auto-configuration helpers
+    # ------------------------------------------------------------------
+
+    def _auto_configure_search_fields(self) -> None:
+        if not self.auto_detect_search_fields or self.search_fields:
+            return
+
+        detected: list[str] = []
+        for field_name in self.auto_search_field_names:
+            field = self._get_concrete_field(field_name)
+            if isinstance(
+                field,
+                (
+                    models.CharField,
+                    models.TextField,
+                    models.EmailField,
+                    models.SlugField,
+                ),
+            ):
+                detected.append(field_name)
+
+        if not detected:
+            for field in self.model._meta.get_fields():
+                if not getattr(field, "concrete", False):
+                    continue
+                if isinstance(field, (models.CharField, models.TextField)) and not getattr(
+                    field, "choices", None
+                ):
+                    detected.append(field.name)
+                if len(detected) >= 3:
+                    break
+
+        if detected:
+            self.search_fields = tuple(dict.fromkeys(detected))
+
+    def _auto_configure_list_filter(self) -> None:
+        if not self.auto_detect_list_filter or self.list_filter:
+            return
+
+        detected: list[str] = []
+        for field in self.model._meta.get_fields():
+            if not getattr(field, "concrete", False) or getattr(field, "many_to_many", False):
+                continue
+            if getattr(field, "choices", None):
+                detected.append(field.name)
+            elif isinstance(field, models.BooleanField):
+                detected.append(field.name)
+
+        if detected:
+            limited = detected[: self.auto_list_filter_cap]
+            self.list_filter = tuple(dict.fromkeys(limited))
+
+    def _auto_configure_date_hierarchy(self) -> None:
+        if not self.auto_date_hierarchy or self.date_hierarchy:
+            return
+
+        for field_name in self.auto_date_hierarchy_fields:
+            field = self._get_concrete_field(field_name)
+            if isinstance(field, (models.DateField, models.DateTimeField)):
+                self.date_hierarchy = field_name
+                return
+
+        for field in self.model._meta.get_fields():
+            if not getattr(field, "concrete", False):
+                continue
+            if isinstance(field, (models.DateField, models.DateTimeField)):
+                self.date_hierarchy = field.name
+                return
+
+    def _get_concrete_field(self, field_name: str):
+        try:
+            field = self.model._meta.get_field(field_name)
+        except FieldDoesNotExist:
+            return None
+        return field if getattr(field, "concrete", False) else None
+
+
+class EnhancedTabularInline(_EnhancedAdminBase, admin.TabularInline):
+    """Inline version of :class:`EnhancedModelAdmin` defaults."""
+
+    extra = 1
+    show_change_link = True
+
+    formfield_overrides = EnhancedModelAdmin.formfield_overrides
+
+    def get_formset(self, request, obj=None, **kwargs):
+        formset = super().get_formset(request, obj, **kwargs)
+        base_form = formset.form
+        for field in base_form.base_fields.values():
+            _apply_widget_enhancements(field.widget, field.label, field.help_text)
+        return formset
+
+
+class EnhancedStackedInline(_EnhancedAdminBase, admin.StackedInline):
+    """Stacked inline variant offering the same enhancements."""
+
+    extra = 0
+    show_change_link = True
+
+    formfield_overrides = EnhancedModelAdmin.formfield_overrides
+
+    def get_formset(self, request, obj=None, **kwargs):
+        formset = super().get_formset(request, obj, **kwargs)
+        base_form = formset.form
+        for field in base_form.base_fields.values():
+            _apply_widget_enhancements(field.widget, field.label, field.help_text)
+        return formset

--- a/quiz/admin/configuration.py
+++ b/quiz/admin/configuration.py
@@ -25,12 +25,13 @@ from quiz.models import (
     TrainingMode,
 )
 
+from .base import EnhancedModelAdmin, EnhancedStackedInline, EnhancedTabularInline
 from .inlines import QuizDefinicaoPerguntaInline
 from .score_panel import ConfiguracoesGeraisQuizForm, QuizDefinicaoAdminForm
 
 
 @admin.register(QuizDefinicao)
-class QuizDefinicaoAdmin(admin.ModelAdmin):
+class QuizDefinicaoAdmin(EnhancedModelAdmin):
     form = QuizDefinicaoAdminForm
     inlines = [QuizDefinicaoPerguntaInline]
     list_display = (
@@ -177,7 +178,7 @@ class QuizDefinicaoAdmin(admin.ModelAdmin):
 
 
 @admin.register(ConfiguracoesGeraisQuiz)
-class ConfiguracoesGeraisQuizAdmin(admin.ModelAdmin):
+class ConfiguracoesGeraisQuizAdmin(EnhancedModelAdmin):
     form = ConfiguracoesGeraisQuizForm
     list_display = (
         "__str__",
@@ -267,7 +268,7 @@ class ConfiguracoesGeraisQuizAdmin(admin.ModelAdmin):
         return obj.data_modificacao.strftime("%d/%m/%Y %H:%M") if obj.data_modificacao else "-"
 
 
-class HomeProgressSectionInline(admin.StackedInline):
+class HomeProgressSectionInline(EnhancedStackedInline):
     model = HomeProgressSectionSettings
     extra = 0
     max_num = 1
@@ -289,7 +290,7 @@ class HomeProgressSectionInline(admin.StackedInline):
     )
 
 
-class HomeRecentSessionCardInline(admin.StackedInline):
+class HomeRecentSessionCardInline(EnhancedStackedInline):
     model = HomeRecentSessionCardSettings
     extra = 0
     max_num = 1
@@ -341,7 +342,7 @@ class HomeRecentSessionCardInline(admin.StackedInline):
     )
 
 
-class HomeActiveChallengeCardInline(admin.StackedInline):
+class HomeActiveChallengeCardInline(EnhancedStackedInline):
     model = HomeActiveChallengeCardSettings
     extra = 0
     max_num = 1
@@ -375,7 +376,7 @@ class HomeActiveChallengeCardInline(admin.StackedInline):
     )
 
 
-class HomeAchievementCardInline(admin.StackedInline):
+class HomeAchievementCardInline(EnhancedStackedInline):
     model = HomeAchievementCardSettings
     extra = 0
     max_num = 1
@@ -398,14 +399,14 @@ class HomeAchievementCardInline(admin.StackedInline):
     )
 
 
-class HomeHeroCTAInline(admin.TabularInline):
+class HomeHeroCTAInline(EnhancedTabularInline):
     model = HomeHeroCTA
     extra = 0
     ordering = ("audience", "position")
     fields = ("audience", "position", "label", "url", "icon", "css_class", "anchor_id", "open_in_new_tab", "is_enabled")
 
 
-class HomeHeroStatInline(admin.TabularInline):
+class HomeHeroStatInline(EnhancedTabularInline):
     model = HomeHeroStatTemplate
     extra = 0
     ordering = ("audience", "order")
@@ -423,7 +424,7 @@ class HomeHeroStatInline(admin.TabularInline):
     )
 
 
-class HomeQuickLinkInline(admin.TabularInline):
+class HomeQuickLinkInline(EnhancedTabularInline):
     model = HomeQuickLink
     extra = 0
     ordering = ("order",)
@@ -440,7 +441,7 @@ class HomeQuickLinkInline(admin.TabularInline):
     )
 
 
-class HomeIntroHighlightInline(admin.TabularInline):
+class HomeIntroHighlightInline(EnhancedTabularInline):
     model = HomeIntroHighlight
     extra = 0
     ordering = ("order",)
@@ -457,7 +458,7 @@ class HomeIntroHighlightInline(admin.TabularInline):
     )
 
 
-class HomeIntroStepInline(admin.TabularInline):
+class HomeIntroStepInline(EnhancedTabularInline):
     model = HomeIntroStep
     extra = 0
     ordering = ("order",)
@@ -465,13 +466,14 @@ class HomeIntroStepInline(admin.TabularInline):
 
 
 @admin.register(TrainingMode)
-class TrainingModeAdmin(admin.ModelAdmin):
+class TrainingModeAdmin(EnhancedModelAdmin):
     list_display = ("name", "quiz_definition", "is_active", "order", "updated_at")
     list_filter = ("is_active",)
     search_fields = ("name", "slug", "description", "meta", "quiz_definition__nome_quiz")
     prepopulated_fields = {"slug": ("name",)}
     ordering = ("order", "name")
     readonly_fields = ("created_at", "updated_at")
+    select_related_fields = ("quiz_definition",)
 
     fieldsets = (
         (
@@ -513,7 +515,7 @@ class TrainingModeAdmin(admin.ModelAdmin):
 
 
 @admin.register(HomePageSettings)
-class HomePageSettingsAdmin(admin.ModelAdmin):
+class HomePageSettingsAdmin(EnhancedModelAdmin):
     inlines = [
         HomeProgressSectionInline,
         HomeRecentSessionCardInline,
@@ -588,21 +590,21 @@ class HomePageSettingsAdmin(admin.ModelAdmin):
         return False
 
 
-class ChallengeHubHeroActionInline(admin.TabularInline):
+class ChallengeHubHeroActionInline(EnhancedTabularInline):
     model = ChallengeHubHeroAction
     extra = 0
     fields = ("key", "label", "icon", "css_class", "dom_id", "is_enabled")
     ordering = ("key",)
 
 
-class ChallengeHubHeroStatInline(admin.TabularInline):
+class ChallengeHubHeroStatInline(EnhancedTabularInline):
     model = ChallengeHubHeroStat
     extra = 0
     fields = ("order", "label", "data_source", "prefix", "suffix", "dom_id", "is_enabled")
     ordering = ("order",)
 
 
-class ChallengeHubActionCardInline(admin.TabularInline):
+class ChallengeHubActionCardInline(EnhancedTabularInline):
     model = ChallengeHubActionCard
     extra = 0
     fields = (
@@ -619,7 +621,7 @@ class ChallengeHubActionCardInline(admin.TabularInline):
     ordering = ("key",)
 
 
-class ChallengeHubResumeCardInline(admin.StackedInline):
+class ChallengeHubResumeCardInline(EnhancedStackedInline):
     model = ChallengeHubResumeCardSettings
     extra = 0
     max_num = 1
@@ -627,7 +629,7 @@ class ChallengeHubResumeCardInline(admin.StackedInline):
     fields = ("title", "description_template", "icon", "discard_label", "continue_label")
 
 
-class ChallengeHubPredefinedSectionInline(admin.StackedInline):
+class ChallengeHubPredefinedSectionInline(EnhancedStackedInline):
     model = ChallengeHubPredefinedSection
     extra = 0
     max_num = 1
@@ -635,7 +637,7 @@ class ChallengeHubPredefinedSectionInline(admin.StackedInline):
     fields = ("title", "subtitle")
 
 
-class ChallengeHubPlaceholderInline(admin.StackedInline):
+class ChallengeHubPlaceholderInline(EnhancedStackedInline):
     model = ChallengeHubPlaceholderSettings
     extra = 0
     max_num = 1
@@ -667,7 +669,7 @@ class ChallengeHubPlaceholderInline(admin.StackedInline):
 
 
 @admin.register(ChallengeHubSettings)
-class ChallengeHubSettingsAdmin(admin.ModelAdmin):
+class ChallengeHubSettingsAdmin(EnhancedModelAdmin):
     inlines = [
         ChallengeHubHeroActionInline,
         ChallengeHubHeroStatInline,

--- a/quiz/admin/content.py
+++ b/quiz/admin/content.py
@@ -10,10 +10,11 @@ from quiz.models import Categoria, OpcaoResposta, Pergunta, QuestaoFavorita
 from .filters import TopLevelCategoriaFilter
 from .inlines import OpcaoRespostaInline
 from .mixins import AdminAutoImportCodeMixin, assign_auto_import_code
+from .base import EnhancedModelAdmin
 
 
 @admin.register(Categoria)
-class CategoriaAdmin(AdminAutoImportCodeMixin, admin.ModelAdmin):
+class CategoriaAdmin(AdminAutoImportCodeMixin, EnhancedModelAdmin):
     import_code_prefix = "cat"
     import_code_source_fields = ("nome_categoria",)
 
@@ -86,7 +87,7 @@ class CategoriaAdmin(AdminAutoImportCodeMixin, admin.ModelAdmin):
 
 
 @admin.register(Pergunta)
-class PerguntaAdmin(AdminAutoImportCodeMixin, admin.ModelAdmin):
+class PerguntaAdmin(AdminAutoImportCodeMixin, EnhancedModelAdmin):
     import_code_prefix = "pergunta"
     import_code_source_fields = ("texto_pergunta",)
 
@@ -123,7 +124,7 @@ class PerguntaAdmin(AdminAutoImportCodeMixin, admin.ModelAdmin):
     inlines = [OpcaoRespostaInline]
     readonly_fields = ("data_criacao", "data_atualizacao")
     autocomplete_fields = ["id_usuario_criador"]
-    list_select_related = ("id_usuario_criador",)
+    select_related_fields = ("id_usuario_criador",)
     date_hierarchy = "data_criacao"
     list_per_page = 30
     save_as = True
@@ -295,7 +296,7 @@ class PerguntaAdmin(AdminAutoImportCodeMixin, admin.ModelAdmin):
 
 
 @admin.register(OpcaoResposta)
-class OpcaoRespostaAdmin(AdminAutoImportCodeMixin, admin.ModelAdmin):
+class OpcaoRespostaAdmin(AdminAutoImportCodeMixin, EnhancedModelAdmin):
     import_code_prefix = "opcao"
     import_code_source_fields = ("texto_opcao",)
 
@@ -322,7 +323,7 @@ class OpcaoRespostaAdmin(AdminAutoImportCodeMixin, admin.ModelAdmin):
     )
     autocomplete_fields = ["pergunta"]
     readonly_fields = ("data_criacao", "data_atualizacao")
-    list_select_related = ("pergunta",)
+    select_related_fields = ("pergunta",)
 
     @admin.display(description="Texto da Opção")
     def texto_opcao_curto(self, obj):
@@ -353,7 +354,7 @@ class OpcaoRespostaAdmin(AdminAutoImportCodeMixin, admin.ModelAdmin):
 
 
 @admin.register(QuestaoFavorita)
-class QuestaoFavoritaAdmin(admin.ModelAdmin):
+class QuestaoFavoritaAdmin(EnhancedModelAdmin):
     list_display = (
         "id",
         "link_usuario_favorito",
@@ -364,7 +365,7 @@ class QuestaoFavoritaAdmin(admin.ModelAdmin):
     search_fields = ("usuario__username", "pergunta__texto_pergunta")
     autocomplete_fields = ["usuario", "pergunta"]
     readonly_fields = ("data_favoritada",)
-    list_select_related = ("usuario", "pergunta")
+    select_related_fields = ("usuario", "pergunta")
     date_hierarchy = "data_favoritada"
 
     @admin.display(description="Usuário", ordering="usuario__username")

--- a/quiz/admin/gamification.py
+++ b/quiz/admin/gamification.py
@@ -12,9 +12,10 @@ from quiz.models import (
     RecompensaNivelResgatada,
 )
 
+from .base import EnhancedModelAdmin
 
 @admin.register(NivelGamificacao)
-class NivelGamificacaoAdmin(admin.ModelAdmin):
+class NivelGamificacaoAdmin(EnhancedModelAdmin):
     list_display = ("nome", "ordem", "xp_minimo", "xp_maximo")
     search_fields = ("nome", "identificador")
     list_editable = ("ordem",)
@@ -22,7 +23,7 @@ class NivelGamificacaoAdmin(admin.ModelAdmin):
 
 
 @admin.register(Conquista)
-class ConquistaAdmin(admin.ModelAdmin):
+class ConquistaAdmin(EnhancedModelAdmin):
     list_display = ("nome", "slug", "ordem_exibicao")
     search_fields = ("nome", "slug")
     list_editable = ("ordem_exibicao",)
@@ -30,7 +31,7 @@ class ConquistaAdmin(admin.ModelAdmin):
 
 
 @admin.register(PerfilGamificacaoUsuario)
-class PerfilGamificacaoUsuarioAdmin(admin.ModelAdmin):
+class PerfilGamificacaoUsuarioAdmin(EnhancedModelAdmin):
     list_display = (
         "user",
         "xp_total",
@@ -40,21 +41,22 @@ class PerfilGamificacaoUsuarioAdmin(admin.ModelAdmin):
         "ultima_atualizacao",
     )
     search_fields = ("user__username", "user__email")
-    list_select_related = ("user", "nivel_atual")
+    select_related_fields = ("user", "nivel_atual")
     readonly_fields = ("ultima_atualizacao",)
     autocomplete_fields = ("user", "nivel_atual", "conquistas")
 
 
 @admin.register(ConquistaUsuario)
-class ConquistaUsuarioAdmin(admin.ModelAdmin):
+class ConquistaUsuarioAdmin(EnhancedModelAdmin):
     list_display = ("perfil", "conquista", "data_conquista")
     search_fields = ("perfil__user__username", "conquista__nome")
     list_filter = ("conquista", "data_conquista")
     autocomplete_fields = ("perfil", "conquista")
+    select_related_fields = ("perfil", "perfil__user", "conquista")
 
 
 @admin.register(DesafioDinamico)
-class DesafioDinamicoAdmin(admin.ModelAdmin):
+class DesafioDinamicoAdmin(EnhancedModelAdmin):
     list_display = (
         "nome",
         "slug",
@@ -106,7 +108,7 @@ class DesafioDinamicoAdmin(admin.ModelAdmin):
 
 
 @admin.register(ProgressoDesafioUsuario)
-class ProgressoDesafioUsuarioAdmin(admin.ModelAdmin):
+class ProgressoDesafioUsuarioAdmin(EnhancedModelAdmin):
     list_display = (
         "perfil",
         "desafio",
@@ -123,10 +125,11 @@ class ProgressoDesafioUsuarioAdmin(admin.ModelAdmin):
     )
     autocomplete_fields = ("perfil", "desafio")
     readonly_fields = ("criado_em", "atualizado_em")
+    select_related_fields = ("perfil", "perfil__user", "desafio")
 
 
 @admin.register(RecompensaNivelResgatada)
-class RecompensaNivelResgatadaAdmin(admin.ModelAdmin):
+class RecompensaNivelResgatadaAdmin(EnhancedModelAdmin):
     list_display = ("perfil", "nivel", "recompensa_id", "data_resgate")
     list_filter = ("nivel",)
     search_fields = (
@@ -137,3 +140,4 @@ class RecompensaNivelResgatadaAdmin(admin.ModelAdmin):
     )
     autocomplete_fields = ("perfil", "nivel")
     readonly_fields = ("data_resgate",)
+    select_related_fields = ("perfil", "perfil__user", "nivel")

--- a/quiz/admin/inlines.py
+++ b/quiz/admin/inlines.py
@@ -12,6 +12,8 @@ from quiz.models import (
     RespostasUsuarioPorSessao,
 )
 
+from .base import EnhancedTabularInline
+
 class OpcaoRespostaInlineFormSet(BaseInlineFormSet):
     """Ensure at least two options and one correct answer are provided."""
 
@@ -35,7 +37,7 @@ class OpcaoRespostaInlineFormSet(BaseInlineFormSet):
             raise ValidationError("Defina ao menos uma opcao como correta.")
 
 
-class OpcaoRespostaInline(admin.TabularInline):
+class OpcaoRespostaInline(EnhancedTabularInline):
     model = OpcaoResposta
     extra = 0
     min_num = 2
@@ -51,7 +53,7 @@ class OpcaoRespostaInline(admin.TabularInline):
     ]
 
 
-class RespostasUsuarioPorSessaoInline(admin.TabularInline):
+class RespostasUsuarioPorSessaoInline(EnhancedTabularInline):
     model = RespostasUsuarioPorSessao
     extra = 0
     fields = (
@@ -97,7 +99,7 @@ class RespostasUsuarioPorSessaoInline(admin.TabularInline):
         )
 
 
-class QuizDefinicaoPerguntaInline(admin.TabularInline):
+class QuizDefinicaoPerguntaInline(EnhancedTabularInline):
     model = QuizDefinicaoPergunta
     extra = 1
     autocomplete_fields = ["pergunta"]

--- a/quiz/admin/sessions.py
+++ b/quiz/admin/sessions.py
@@ -7,10 +7,11 @@ from django.utils.html import format_html
 from quiz.models import RespostasUsuarioPorSessao, SessoesQuizUsuario
 
 from .inlines import RespostasUsuarioPorSessaoInline
+from .base import EnhancedModelAdmin
 
 
 @admin.register(SessoesQuizUsuario)
-class SessoesQuizUsuarioAdmin(admin.ModelAdmin):
+class SessoesQuizUsuarioAdmin(EnhancedModelAdmin):
     list_display = (
         "id",
         "link_usuario",
@@ -62,7 +63,7 @@ class SessoesQuizUsuarioAdmin(admin.ModelAdmin):
     autocomplete_fields = ["id_usuario", "id_quiz_definicao"]
     filter_horizontal = ("categorias_selecionadas",)
     inlines = [RespostasUsuarioPorSessaoInline]
-    list_select_related = ("id_usuario", "id_quiz_definicao")
+    select_related_fields = ("id_usuario", "id_quiz_definicao")
     date_hierarchy = "data_inicio"
 
     fieldsets = (
@@ -141,7 +142,7 @@ class SessoesQuizUsuarioAdmin(admin.ModelAdmin):
 
 
 @admin.register(RespostasUsuarioPorSessao)
-class RespostasUsuarioPorSessaoAdmin(admin.ModelAdmin):
+class RespostasUsuarioPorSessaoAdmin(EnhancedModelAdmin):
     list_display = (
         "id",
         "link_sessao_quiz_formatado",
@@ -177,7 +178,8 @@ class RespostasUsuarioPorSessaoAdmin(admin.ModelAdmin):
         "id_pergunta",
         "id_opcao_resposta_selecionada",
     ]
-    list_select_related = (
+    select_related_fields = (
+        "id_sessao_quiz",
         "id_sessao_quiz__id_usuario",
         "id_pergunta",
         "id_opcao_resposta_selecionada",

--- a/quiz/admin/system.py
+++ b/quiz/admin/system.py
@@ -7,9 +7,11 @@ from django.utils.html import format_html
 
 from quiz.models import SupportRequest, SystemMessageBroadcast, UserPreferences
 
+from .base import EnhancedModelAdmin
+
 
 @admin.register(SystemMessageBroadcast)
-class SystemMessageBroadcastAdmin(admin.ModelAdmin):
+class SystemMessageBroadcastAdmin(EnhancedModelAdmin):
     list_display = (
         "admin_title",
         "message_type",
@@ -86,7 +88,7 @@ class SystemMessageBroadcastAdmin(admin.ModelAdmin):
 
 
 @admin.register(UserPreferences)
-class UserPreferencesAdmin(admin.ModelAdmin):
+class UserPreferencesAdmin(EnhancedModelAdmin):
     list_display = (
         "user",
         "theme_preference",
@@ -106,10 +108,11 @@ class UserPreferencesAdmin(admin.ModelAdmin):
         "user__last_name",
     )
     readonly_fields = ("created_at", "updated_at")
+    select_related_fields = ("user",)
 
 
 @admin.register(SupportRequest)
-class SupportRequestAdmin(admin.ModelAdmin):
+class SupportRequestAdmin(EnhancedModelAdmin):
     list_display = (
         "criado_em",
         "status_badge",
@@ -129,6 +132,7 @@ class SupportRequestAdmin(admin.ModelAdmin):
     )
     readonly_fields = ("mensagem", "contexto_pretty", "criado_em", "atualizado_em")
     ordering = ("-criado_em",)
+    select_related_fields = ("usuario",)
     fieldsets = (
         (
             "Identificação",


### PR DESCRIPTION
## Summary
- remove the bespoke admin stylesheet and rely on the enhanced widget helpers without custom CSS
- extend the reusable EnhancedModelAdmin with automatic search/list filter/date hierarchy detection and a JSON export bulk action
- add keyboard shortcuts and smarter focus behaviour for the admin UI while refreshing the global admin site copy

## Testing
- python manage.py check *(fails: Django not installed in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eec381f2f08333aa59b7ed78d97f5c