### PR TITLE
Recria painel analítico de progresso

### DIFF
--- a/assets/css/sections/conta-section.css
+++ b/assets/css/sections/conta-section.css
@@ -1131,745 +1131,588 @@
     flex: 1 1 100%;
 }
 
-/* --- Painel de Progresso Integrado --- */
-.account-progress {
+/* --- Central de Progresso Analítico --- */
+.progress-analytics {
     display: flex;
     flex-direction: column;
-    gap: clamp(var(--spacing-lg, 28px), 4vw, var(--spacing-xl, 36px));
+    gap: clamp(var(--spacing-lg, 28px), 4vw, var(--spacing-xl, 40px));
 }
 
-.account-progress__card {
-    --card-padding: clamp(var(--spacing-lg, 28px), 4vw, var(--spacing-xl, 36px));
+.progress-analytics__card {
+    --card-padding: clamp(var(--spacing-lg, 28px), 4vw, var(--spacing-xl, 40px));
     display: flex;
     flex-direction: column;
-    gap: clamp(var(--spacing-lg, 28px), 3vw, var(--spacing-xl, 40px));
+    gap: clamp(var(--spacing-lg, 28px), 3vw, var(--spacing-xl, 36px));
 }
 
-.account-progress__header {
+.progress-analytics__header {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: var(--spacing-md, 20px);
     padding-bottom: var(--spacing-md, 20px);
-    border-bottom: 1px solid rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.8);
+    border-bottom: 1px solid rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.85);
 }
 
-.account-progress__header-text {
+.progress-analytics__headline {
     display: flex;
     flex-direction: column;
     gap: var(--spacing-xxs, 6px);
 }
 
-.account-progress__icon {
+.progress-analytics__icon {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     width: 48px;
     height: 48px;
     border-radius: var(--border-radius-pill);
-    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.14);
     color: var(--color-primary-medium);
-    font-size: 1.75rem;
+    font-size: 1.8rem;
 }
 
-.account-progress__body {
+.progress-analytics__body {
     display: flex;
     flex-direction: column;
     gap: clamp(var(--spacing-lg, 28px), 3vw, var(--spacing-xl, 40px));
 }
 
-.account-progress__summary {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    gap: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-lg, 28px));
+.progress-analytics__label {
+    font-size: var(--font-size-xxs, 0.75rem);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
 }
 
-.account-progress__summary-item {
+.progress-analytics__level {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-xxs, 6px);
+    gap: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
+    padding: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
+    border-radius: var(--border-radius-xl);
+    background: linear-gradient(135deg, rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.9), rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.15));
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18);
+    box-shadow: var(--shadow-xs);
+}
+
+.progress-analytics__level-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--spacing-lg, 28px);
+}
+
+.progress-analytics__level-title {
+    margin: 4px 0 0;
+    font-size: clamp(1.4rem, 3vw, 1.8rem);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
+}
+
+.progress-analytics__level-status {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    text-align: right;
+}
+
+.progress-analytics__level-status strong {
+    font-size: clamp(1.4rem, 3vw, 1.9rem);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
+}
+
+.progress-analytics__level-status span {
+    font-size: var(--font-size-xs, 0.82rem);
+    color: var(--color-text-secondary);
+}
+
+.progress-analytics__level-status small {
+    font-size: var(--font-size-xxs, 0.75rem);
+    color: var(--color-text-muted);
+}
+
+.progress-analytics__bar {
+    position: relative;
+    width: 100%;
+    height: 12px;
+    border-radius: 999px;
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.14);
+    overflow: hidden;
+}
+
+.progress-analytics__bar-fill {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.9), rgba(var(--color-primary-dark-rgb, 8, 35, 64), 0.95));
+    transition: width 0.4s ease;
+}
+
+.progress-analytics__level-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: clamp(var(--spacing-sm, 16px), 2.6vw, var(--spacing-lg, 28px));
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.progress-analytics__level-stats li {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-md, 24px));
+    border-radius: var(--border-radius-lg);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.15);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.92);
+}
+
+.progress-analytics__level-stats strong {
+    font-size: clamp(1.05rem, 2.2vw, 1.45rem);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
+}
+
+.progress-analytics__summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-xl, 36px));
+    margin: 0;
+    padding: 0;
+}
+
+.progress-analytics__summary-item {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs, 10px);
+    padding: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
+    border-radius: var(--border-radius-xl);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.96);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
+    box-shadow: var(--shadow-xs);
+}
+
+.progress-analytics__summary-item dt {
+    margin: 0;
+    font-size: var(--font-size-xs, 0.82rem);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.progress-analytics__summary-item dd {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: clamp(1.3rem, 3vw, 1.7rem);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
+}
+
+.progress-analytics__summary-item small {
+    font-size: var(--font-size-xxs, 0.75rem);
+    color: var(--color-text-secondary);
+}
+
+.progress-analytics__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-xl, 36px));
+}
+
+.progress-analytics__panel {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(var(--spacing-sm, 16px), 2.4vw, var(--spacing-lg, 28px));
+    padding: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
+    border-radius: var(--border-radius-xl);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.97);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.14);
+    box-shadow: var(--shadow-xs);
+}
+
+.progress-analytics__panel-header {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--spacing-sm, 16px);
+}
+
+.progress-analytics__panel-header .material-symbols-outlined {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: var(--border-radius-pill);
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
+    color: var(--color-primary-medium);
+    font-size: 1.6rem;
+    flex-shrink: 0;
+}
+
+.progress-analytics__panel-header h3 {
+    margin: 0;
+    font-size: clamp(1.1rem, 2.4vw, 1.4rem);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-primary);
+}
+
+.progress-analytics__panel-header p {
+    margin: 4px 0 0;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm, 0.95rem);
+}
+
+.progress-analytics__metrics {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(var(--spacing-sm, 16px), 2.4vw, var(--spacing-md, 24px));
+}
+
+.progress-analytics__metrics li {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-md, 24px));
+    border-radius: var(--border-radius-lg);
+    border: 1px solid rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.9);
+    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.45);
+}
+
+.progress-analytics__metrics-label {
+    font-size: var(--font-size-xs, 0.8rem);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.progress-analytics__metrics-value {
+    font-size: clamp(1.2rem, 2.6vw, 1.6rem);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
+}
+
+.progress-analytics__metrics small {
+    font-size: var(--font-size-xxs, 0.75rem);
+    color: var(--color-text-secondary);
+}
+
+.progress-analytics__daily-status {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(var(--spacing-sm, 16px), 2.4vw, var(--spacing-md, 24px));
+}
+
+.progress-analytics__daily-indicator {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--spacing-sm, 16px);
     padding: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-md, 24px));
     border-radius: var(--border-radius-lg);
     background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.5);
     border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
 }
 
-.account-progress__label {
-    font-size: var(--font-size-xs, 0.8rem);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--color-text-muted);
-}
-
-.account-progress__value {
-    font-size: clamp(1.1rem, 2.4vw, 1.6rem);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-primary-dark);
-}
-
-
-.account-progress__level-overview {
-    display: flex;
-    flex-direction: column;
-    gap: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
-    padding: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
-    border-radius: var(--border-radius-xl);
-    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.65);
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.14);
-}
-
-.account-progress__level-headline {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--spacing-sm, 16px);
-}
-
-.account-progress__level-headline h3 {
-    margin: 0;
-    font-size: clamp(1.1rem, 2.2vw, 1.35rem);
-}
-
-.account-progress__level-headline p {
-    margin: 4px 0 0;
-    color: var(--color-text-secondary);
-    font-size: var(--font-size-sm, 0.9rem);
-}
-
-.account-progress__level-percentage {
+.progress-analytics__daily-indicator .material-symbols-outlined {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-width: 64px;
-    padding: 6px 14px;
+    width: 40px;
+    height: 40px;
     border-radius: var(--border-radius-pill);
-    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.1);
-    color: var(--color-primary-dark);
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
+    color: var(--color-primary-medium);
+    font-size: 1.6rem;
+    flex-shrink: 0;
+}
+
+.progress-analytics__daily-indicator strong {
+    display: block;
+    font-size: clamp(1.05rem, 2.2vw, 1.35rem);
     font-weight: var(--font-weight-semibold);
-    font-size: clamp(1rem, 2vw, 1.25rem);
+    color: var(--color-text-primary);
 }
 
-.account-progress__progress-bar {
-    position: relative;
-    width: 100%;
-    height: 10px;
-    border-radius: var(--border-radius-pill);
-    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
-    overflow: hidden;
+.progress-analytics__daily-indicator p {
+    margin: 6px 0 0;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm, 0.95rem);
 }
 
-.account-progress__progress-fill {
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(90deg, var(--color-primary-medium), var(--color-secondary-green));
-    border-radius: inherit;
-    transition: width 0.4s ease;
-}
-
-.account-progress__level-path {
-    --account-progress-connector-gap: clamp(var(--spacing-sm, 16px), 2.8vw, var(--spacing-lg, 28px));
+.progress-analytics__daily-metrics {
     display: grid;
-    grid-auto-flow: column;
-    grid-auto-columns: minmax(220px, 1fr);
-    gap: var(--account-progress-connector-gap);
-    margin-top: clamp(var(--spacing-sm, 16px), 2vw, var(--spacing-md, 24px));
-    padding-bottom: var(--spacing-sm, 16px);
-    overflow-x: auto;
-    position: relative;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: clamp(var(--spacing-sm, 16px), 2.4vw, var(--spacing-md, 24px));
+    list-style: none;
+    margin: 0;
+    padding: 0;
 }
 
-.account-progress__level-node {
-    position: relative;
+.progress-analytics__daily-metrics li {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-xs, 12px);
-    padding: clamp(var(--spacing-sm, 16px), 2.4vw, var(--spacing-md, 24px));
+    gap: 6px;
+    padding: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-md, 24px));
     border-radius: var(--border-radius-lg);
-    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.55);
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18);
-    box-shadow: var(--shadow-sm, 0 8px 16px rgba(15, 42, 81, 0.08));
-    min-height: 180px;
+    border: 1px dashed rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.25);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.92);
+    text-align: center;
 }
 
-.account-progress__level-node::before {
-    content: "";
-    position: absolute;
-    top: 36px;
-    left: calc(-0.5 * var(--account-progress-connector-gap));
-    width: calc(100% + var(--account-progress-connector-gap));
-    height: 2px;
-    background: linear-gradient(90deg, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.22), rgba(var(--color-secondary-green-rgb, 33, 150, 83), 0.22));
-    z-index: 0;
+.progress-analytics__daily-metrics span {
+    font-size: var(--font-size-xs, 0.8rem);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
 }
 
-.account-progress__level-node:first-child::before {
-    display: none;
+.progress-analytics__daily-metrics strong {
+    font-size: clamp(1.1rem, 2.4vw, 1.5rem);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
 }
 
-.account-progress__level-marker {
+.progress-analytics__timeline {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(var(--spacing-sm, 16px), 2.4vw, var(--spacing-lg, 28px));
+}
+
+.progress-analytics__timeline-header h3 {
+    margin: 0;
+    font-size: clamp(1.1rem, 2.4vw, 1.45rem);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-primary);
+}
+
+.progress-analytics__timeline-header p {
+    margin: 4px 0 0;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm, 0.95rem);
+}
+
+.progress-analytics__timeline-track {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-xl, 36px));
+}
+
+.progress-analytics__timeline-node {
     position: relative;
-    z-index: 1;
-    align-self: flex-start;
+    display: flex;
+    gap: var(--spacing-sm, 16px);
+    align-items: flex-start;
+    padding: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-lg, 28px));
+    border-radius: var(--border-radius-xl);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.96);
+    box-shadow: var(--shadow-xs);
+}
+
+.progress-analytics__timeline-order {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     width: 48px;
     height: 48px;
-    border-radius: 50%;
+    border-radius: var(--border-radius-pill);
     background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
     color: var(--color-primary-dark);
     font-weight: var(--font-weight-semibold);
+    font-size: 1.1rem;
+    flex-shrink: 0;
+}
+
+.progress-analytics__timeline-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs, 10px);
+}
+
+.progress-analytics__timeline-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--spacing-sm, 16px);
+}
+
+.progress-analytics__timeline-head strong {
     font-size: 1rem;
-    box-shadow: inset 0 0 0 2px rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.28);
+    color: var(--color-text-primary);
+    font-weight: var(--font-weight-semibold);
 }
 
-.account-progress__level-content {
-    position: relative;
-    z-index: 1;
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xs, 12px);
-}
-
-.account-progress__level-info {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xxs, 6px);
-}
-
-.account-progress__level-step {
-    font-size: var(--font-size-xxs, 0.75rem);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--color-text-muted);
-}
-
-.account-progress__level-name {
-    font-size: clamp(1rem, 2vw, 1.25rem);
-    color: var(--color-primary-dark);
-}
-
-.account-progress__level-xp {
-    margin: 0;
-    font-size: var(--font-size-sm, 0.9rem);
+.progress-analytics__timeline-head span {
+    font-size: var(--font-size-sm, 0.95rem);
     color: var(--color-text-secondary);
 }
 
-.account-progress__level-node-progress {
+.progress-analytics__timeline-range {
+    margin: 0;
+    font-size: var(--font-size-xs, 0.82rem);
+    color: var(--color-text-muted);
+}
+
+.progress-analytics__timeline-progress {
     position: relative;
     width: 100%;
-    height: 6px;
-    border-radius: var(--border-radius-pill);
-    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
+    height: 8px;
+    border-radius: 999px;
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
     overflow: hidden;
 }
 
-.account-progress__level-node-fill {
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(90deg, var(--color-primary-medium), var(--color-secondary-green));
+.progress-analytics__timeline-progress span {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.8);
     transition: width 0.4s ease;
 }
 
-.account-progress__level-status {
+.progress-analytics__timeline-status {
     font-size: var(--font-size-xs, 0.82rem);
-    font-weight: var(--font-weight-medium, 500);
+    color: var(--color-text-muted);
+    font-weight: var(--font-weight-medium);
+}
+
+.progress-analytics__timeline-node--completed .progress-analytics__timeline-order,
+.progress-analytics__timeline-node--completed .progress-analytics__timeline-progress span {
+    background: rgba(var(--color-success-medium-rgb, 35, 170, 105), 0.18);
+    color: var(--color-success-dark);
+}
+
+.progress-analytics__timeline-node--completed .progress-analytics__timeline-progress span {
+    background: rgba(var(--color-success-medium-rgb, 35, 170, 105), 0.6);
+}
+
+.progress-analytics__timeline-node--completed .progress-analytics__timeline-status {
+    color: var(--color-success-dark);
+}
+
+.progress-analytics__timeline-node--locked {
+    border-color: rgba(var(--color-text-muted-rgb, 125, 138, 152), 0.2);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.9);
+}
+
+.progress-analytics__timeline-node--locked .progress-analytics__timeline-order {
+    background: rgba(var(--color-text-muted-rgb, 125, 138, 152), 0.16);
+    color: var(--color-text-muted);
+}
+
+.progress-analytics__timeline-node--locked .progress-analytics__timeline-progress span {
+    background: rgba(var(--color-text-muted-rgb, 125, 138, 152), 0.4);
+}
+
+.progress-analytics__timeline-node.is-current {
+    border-color: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.32);
+    box-shadow: 0 18px 32px rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
+}
+
+.progress-analytics__timeline-node.is-current .progress-analytics__timeline-order {
+    background: linear-gradient(135deg, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.9), rgba(var(--color-primary-dark-rgb, 8, 35, 64), 0.95));
+    color: var(--color-white);
+}
+
+.progress-analytics__timeline-node.is-current .progress-analytics__timeline-progress span {
+    background: linear-gradient(135deg, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.85), rgba(var(--color-primary-dark-rgb, 8, 35, 64), 0.9));
+}
+
+.progress-analytics__timeline-node.is-current .progress-analytics__timeline-status {
     color: var(--color-primary-dark);
 }
 
-.account-progress__level-node--completed .account-progress__level-marker,
-.account-progress__level-node--completed .account-progress__level-node-fill {
-    background: rgba(var(--color-secondary-green-rgb, 33, 150, 83), 0.18);
-    color: var(--color-secondary-green, #219653);
-}
-
-.account-progress__level-node--completed .account-progress__level-node-fill {
-    background: linear-gradient(90deg, var(--color-secondary-green), var(--color-secondary-green));
-}
-
-.account-progress__level-node--locked {
-    opacity: 0.85;
-}
-
-.account-progress__level-node--locked .account-progress__level-marker {
-    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.08);
-    color: var(--color-text-secondary);
-    box-shadow: inset 0 0 0 2px rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18);
-}
-
-.account-progress__level-node--locked .account-progress__level-node-fill {
-    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18);
-}
-
-.account-progress__level-node.is-current {
-    border-color: rgba(var(--color-secondary-green-rgb, 33, 150, 83), 0.45);
-    background: rgba(var(--color-secondary-green-rgb, 33, 150, 83), 0.12);
-}
-
-.account-progress__level-node.is-current .account-progress__level-marker {
-    background: var(--color-secondary-green, #219653);
-    color: #fff;
-    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.3);
-}
-
-.account-progress__level-node.is-current .account-progress__level-status {
-    color: var(--color-secondary-green, #219653);
-}
-
-.account-progress__level-node.is-current .account-progress__level-node-fill {
-    background: linear-gradient(90deg, var(--color-secondary-green), var(--color-secondary-green));
-}
-
-.account-progress__level-node.is-current .account-progress__level-marker span {
-    font-weight: var(--font-weight-bold, 700);
-}
-
-.account-progress__level-node--completed .account-progress__level-status {
-    color: var(--color-secondary-green, #219653);
-}
-
-.account-progress__level-node--locked .account-progress__level-status {
-    color: var(--color-text-muted);
-}
-
-.account-progress__level-details {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    gap: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-md, 24px));
-    list-style: none;
-    margin: 0;
-    padding: 0;
-}
-
-.account-progress__level-details li {
+.progress-analytics__empty {
     display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xxs, 6px);
-}
-
-.account-progress__level-details span {
-    font-size: var(--font-size-xxs, 0.75rem);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--color-text-muted);
-}
-
-.account-progress__level-details strong {
-    font-size: clamp(1rem, 2vw, 1.3rem);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-text-primary);
-}
-
-.account-progress__insights-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-lg, 28px));
-}
-
-.account-progress__insight-card {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-sm, 16px);
-    padding: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
-    border-radius: var(--border-radius-xl);
-    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.92);
-    border: 1px solid rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.9);
-    box-shadow: var(--shadow-xs);
-}
-
-.account-progress__insight-header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: var(--spacing-sm, 16px);
-}
-
-.account-progress__insight-header h3 {
-    margin: 0;
-    font-size: clamp(1.05rem, 2vw, 1.3rem);
-}
-
-.account-progress__insight-count {
-    font-size: var(--font-size-xs, 0.8rem);
-    font-weight: var(--font-weight-medium);
-    color: var(--color-primary-medium);
-    text-align: right;
-}
-
-.account-progress__insight-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-sm, 16px);
-}
-
-.account-progress__insight-item {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xs, 12px);
-    padding: clamp(var(--spacing-sm, 16px), 2.5vw, var(--spacing-md, 24px));
-    border-radius: var(--border-radius-lg);
-    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.6);
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
-}
-
-.account-progress__metric-list {
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: var(--spacing-sm, 16px);
-}
-
-.account-progress__metric {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: var(--spacing-sm, 16px);
-    padding: clamp(var(--spacing-sm, 16px), 2.3vw, var(--spacing-md, 24px));
-    border-radius: var(--border-radius-lg);
-    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.55);
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
-}
-
-.account-progress__metric dt {
-    margin: 0;
-    font-size: var(--font-size-xxs, 0.75rem);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--color-text-muted);
-}
-
-.account-progress__metric dd {
-    margin: 0;
-    font-size: clamp(1rem, 2.1vw, 1.25rem);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-text-primary);
-    text-align: right;
-}
-
-.account-progress__stat-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: var(--spacing-sm, 16px);
-}
-
-.account-progress__stat {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xs, 12px);
-    padding: clamp(var(--spacing-sm, 16px), 2.6vw, var(--spacing-md, 24px));
-    border-radius: var(--border-radius-lg);
-    background: linear-gradient(135deg, rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.85), rgba(var(--color-white-rgb, 255, 255, 255), 0.95));
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18);
-    box-shadow: 0 8px 24px rgba(var(--color-primary-dark-rgb, 15, 58, 105), 0.06);
-}
-
-.account-progress__stat-label {
-    font-size: var(--font-size-xs, 0.8rem);
-    font-weight: var(--font-weight-medium);
-    color: var(--color-text-secondary);
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-}
-
-.account-progress__stat-value {
-    font-size: clamp(1.4rem, 2.6vw, 1.8rem);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-text-primary);
-}
-
-.account-progress__stat-hint {
-    font-size: var(--font-size-xxs, 0.75rem);
-    color: var(--color-text-muted);
-}
-
-.account-progress__trend-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: var(--spacing-sm, 16px);
-}
-
-.account-progress__trend {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xs, 12px);
-    padding: clamp(var(--spacing-sm, 16px), 2.5vw, var(--spacing-md, 24px));
-    border-radius: var(--border-radius-lg);
-    background: linear-gradient(140deg, rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.14), rgba(var(--color-white-rgb, 255, 255, 255), 0.92));
-    border: 1px solid rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.18);
-}
-
-.account-progress__trend-label {
-    font-size: var(--font-size-xs, 0.8rem);
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    color: var(--color-secondary-green-dark, #217667);
-}
-
-.account-progress__trend-value {
-    font-size: clamp(1.25rem, 2.4vw, 1.6rem);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-text-primary);
-}
-
-.account-progress__trend-hint {
-    font-size: var(--font-size-xxs, 0.75rem);
-    color: var(--color-text-muted);
-}
-
-.account-progress__insight-info strong {
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-text-primary);
-}
-
-.account-progress__insight-info p {
-    margin: 0;
-    color: var(--color-text-secondary);
-    font-size: var(--font-size-sm, 0.9rem);
-}
-
-.account-progress__insight-progress {
-    font-size: var(--font-size-xs, 0.8rem);
-    font-weight: var(--font-weight-medium);
-    color: var(--color-secondary-green-dark, #217667);
-}
-
-.account-progress__insight-remaining {
-    font-size: var(--font-size-xxs, 0.75rem);
-    color: var(--color-text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-}
-
-.account-progress__insight-tag {
-    align-self: flex-start;
-    padding: 6px 12px;
-    border-radius: var(--border-radius-pill);
-    background: rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.18);
-    color: var(--color-secondary-green);
-    font-size: var(--font-size-xxs, 0.75rem);
-    font-weight: var(--font-weight-semibold);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-}
-
-.account-progress__daily {
-    display: flex;
-    align-items: flex-start;
-    gap: var(--spacing-md, 20px);
-    padding: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
-    border-radius: var(--border-radius-xl);
-    background: rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.12);
-    border: 1px solid rgba(var(--color-secondary-green-rgb, 42, 157, 143), 0.18);
-}
-
-.account-progress__daily-icon {
-    display: inline-flex;
     align-items: center;
-    justify-content: center;
-    width: 44px;
-    height: 44px;
-    border-radius: var(--border-radius-pill);
-    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.9);
-    color: var(--color-secondary-green);
-    font-size: 1.6rem;
-    flex-shrink: 0;
-    box-shadow: var(--shadow-sm);
-}
-
-.account-progress__daily-content {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-sm, 16px);
-}
-
-.account-progress__daily-title {
-    font-size: clamp(1.05rem, 2vw, 1.25rem);
-    font-weight: var(--font-weight-semibold);
-    margin: 0;
-}
-
-.account-progress__daily-text {
-    margin: 0;
-    color: var(--color-text-secondary);
-    line-height: 1.6;
-}
-
-.account-progress__daily-list {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: var(--spacing-sm, 16px);
-    list-style: none;
-    margin: 0;
-    padding: 0;
-}
-
-.account-progress__daily-list li {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xxs, 6px);
-    padding: var(--spacing-sm, 16px);
-    border-radius: var(--border-radius-lg);
-    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.9);
-    border: 1px solid rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.8);
-    font-size: var(--font-size-sm, 0.94rem);
-    color: var(--color-text-secondary);
-}
-
-.account-progress__daily-list span {
-    font-size: var(--font-size-xs, 0.78rem);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--color-text-muted);
-}
-
-.account-progress__daily-list strong {
-    font-size: 1rem;
-    color: var(--color-primary-dark);
-}
-
-.account-progress__highlights {
-    display: flex;
-    flex-direction: column;
     gap: var(--spacing-md, 20px);
-}
-
-.account-progress__section-title {
-    margin: 0;
-    font-size: clamp(1.1rem, 2.1vw, 1.4rem);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-primary-dark);
-}
-
-.account-progress__list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-sm, 16px);
-}
-
-.account-progress__list li {
-    display: flex;
-    align-items: flex-start;
-    gap: var(--spacing-sm, 16px);
-    padding: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-md, 24px));
+    padding: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
     border-radius: var(--border-radius-xl);
-    border: 1px solid rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.9);
-    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.96);
-    box-shadow: var(--shadow-sm);
+    border: 1px dashed rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.24);
+    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.5);
 }
 
-.account-progress__list .material-symbols-outlined {
-    font-size: 1.8rem;
+.progress-analytics__empty .material-symbols-outlined {
+    font-size: 2rem;
     color: var(--color-primary-medium);
-    flex-shrink: 0;
 }
 
-.account-progress__list strong {
+.progress-analytics__empty strong {
     display: block;
-    font-size: 1rem;
-    font-weight: var(--font-weight-semibold);
+    font-size: clamp(1.05rem, 2.3vw, 1.35rem);
     color: var(--color-text-primary);
+    font-weight: var(--font-weight-semibold);
 }
 
-.account-progress__list p {
-    margin: 4px 0 0;
-    color: var(--color-text-secondary);
-    font-size: var(--font-size-sm, 0.94rem);
-}
-
-.account-progress__empty {
-    margin: 0;
-    padding: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-md, 24px));
-    border-radius: var(--border-radius-lg);
-    border: 1px dashed rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.3);
-    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.4);
+.progress-analytics__empty p {
+    margin: 6px 0 12px;
     color: var(--color-text-secondary);
     font-size: var(--font-size-sm, 0.95rem);
-    text-align: center;
+}
+
+@media (max-width: 1080px) {
+    .progress-analytics__timeline-track {
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    }
 }
 
 @media (max-width: 960px) {
-    .account-progress__header {
+    .progress-analytics__header {
         flex-direction: column;
         align-items: flex-start;
     }
 
-    .account-progress__icon {
-        width: 40px;
-        height: 40px;
-        font-size: 1.4rem;
-    }
-
-    .account-progress__level-path {
-        grid-auto-columns: minmax(200px, 1fr);
+    .progress-analytics__icon {
+        width: 42px;
+        height: 42px;
+        font-size: 1.5rem;
     }
 }
 
-@media (max-width: 720px) {
-    .account-progress__level-headline {
+@media (max-width: 780px) {
+    .progress-analytics__level-header {
         flex-direction: column;
         align-items: flex-start;
+        text-align: left;
     }
 
-    .account-progress__level-percentage {
-        width: 100%;
-        justify-content: flex-start;
+    .progress-analytics__level-status {
+        text-align: left;
+        align-items: flex-start;
     }
+}
 
-    .account-progress__level-node {
-        min-height: 160px;
-        padding: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-md, 20px));
-    }
-
-    .account-progress__level-marker {
-        width: 44px;
-        height: 44px;
-        font-size: 0.95rem;
-    }
-
-    .account-progress__level-path {
-        gap: clamp(var(--spacing-xs, 12px), 2.4vw, var(--spacing-sm, 18px));
-    }
-
-    .account-progress__insights-grid {
+@media (max-width: 640px) {
+    .progress-analytics__summary {
         grid-template-columns: 1fr;
     }
 
-    .account-progress__daily {
-        flex-direction: column;
+    .progress-analytics__grid {
+        grid-template-columns: 1fr;
     }
 
-    .account-progress__daily-icon {
-        width: 40px;
-        height: 40px;
+    .progress-analytics__timeline-track {
+        grid-template-columns: 1fr;
     }
 }
 
 @media (max-width: 520px) {
-    .account-progress__summary {
+    .progress-analytics__level-stats {
         grid-template-columns: 1fr;
     }
 
-    .account-progress__level-path {
-        grid-auto-columns: minmax(160px, 1fr);
-        padding-bottom: var(--spacing-xs, 10px);
+    .progress-analytics__daily-indicator {
+        flex-direction: column;
+        align-items: flex-start;
     }
 
-    .account-progress__level-node {
-        min-height: 150px;
-    }
-
-    .account-progress__level-xp {
-        font-size: var(--font-size-xs, 0.82rem);
-    }
-
-    .account-progress__daily-list {
+    .progress-analytics__daily-metrics {
         grid-template-columns: 1fr;
     }
 }

--- a/quiz/templates/quiz/account_page.html
+++ b/quiz/templates/quiz/account_page.html
@@ -388,286 +388,228 @@
             </div>
 
 
-            {# --- Seção: Progresso & Recompensas --- #}
+            {# --- Seção: Central de Progresso --- #}
             <div id="progression-content" class="account-content__section">
                 {% with metrics=profile_summary.metrics gamification=profile_summary.gamification %}
-                <div class="account-progress">
-                    <section class="card card--conta-perfil account-progress__card">
-                        <div class="card__header account-progress__header">
-                            <div class="account-progress__header-text">
-                                <h2 class="card__title">Painel de Progresso</h2>
-                                <p class="card__subtitle">Visão executiva da sua evolução, performance e ritmo de estudos.</p>
+                <div class="progress-analytics">
+                    <section class="card card--conta-perfil progress-analytics__card">
+                        <header class="progress-analytics__header">
+                            <div class="progress-analytics__headline">
+                                <h2 class="card__title">Central de Progresso</h2>
+                                <p class="card__subtitle">Acompanhe nível, desempenho e consistência de estudo em uma visão estratégica.</p>
                             </div>
-                            <span class="material-symbols-outlined account-progress__icon" aria-hidden="true">insights</span>
-                        </div>
-                        <div class="card__body account-progress__body">
-                            <div class="account-progress__summary">
-                                <div class="account-progress__summary-item">
-                                    <span class="account-progress__label">Nível atual</span>
-                                    <strong class="account-progress__value">
-                                        {% if gamification and gamification.level %}
-                                            {{ gamification.level.nome }}
-                                        {% else %}
-                                            Comece sua jornada
-                                        {% endif %}
-                                    </strong>
-                                </div>
-                                <div class="account-progress__summary-item">
-                                    <span class="account-progress__label">XP acumulado</span>
-                                    <strong class="account-progress__value">
-                                        {% if gamification %}
-                                            {{ gamification.xp_total|default:0 }}
-                                        {% else %}
-                                            0
-                                        {% endif %}
-                                    </strong>
-                                </div>
-                            </div>
+                            <span class="material-symbols-outlined progress-analytics__icon" aria-hidden="true">query_stats</span>
+                        </header>
 
+                        <div class="progress-analytics__body">
                             {% if gamification %}
-                            <div class="account-progress__level-overview">
-                                <div class="account-progress__level-headline">
+                            <section class="progress-analytics__level" aria-labelledby="progress-analytics-level-heading">
+                                <div class="progress-analytics__level-header">
                                     <div>
-                                        <h3>Progresso no nível</h3>
-                                        <p>Mantenha o ritmo para desbloquear novos benefícios.</p>
+                                        <span class="progress-analytics__label">Nível atual</span>
+                                        <h3 id="progress-analytics-level-heading" class="progress-analytics__level-title">
+                                            {% if gamification.level %}
+                                                {{ gamification.level.nome }}
+                                            {% else %}
+                                                Jornada em definição
+                                            {% endif %}
+                                        </h3>
                                     </div>
-                                    <span class="account-progress__level-percentage">
-                                        {{ gamification.progress.percent|default_if_none:0|floatformat:0 }}%
-                                    </span>
+                                    <div class="progress-analytics__level-status">
+                                        <strong>{{ gamification.progress.percent|default_if_none:0|floatformat:0 }}%</strong>
+                                        <span>concluído do nível atual</span>
+                                        {% if gamification.next_level %}
+                                            <small>Próximo nível: {{ gamification.next_level.nome }}</small>
+                                        {% else %}
+                                            <small>Nível máximo atingido</small>
+                                        {% endif %}
+                                    </div>
                                 </div>
-                                <div class="account-progress__progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ gamification.progress.percent|default_if_none:0 }}">
-                                    <span class="account-progress__progress-fill" style="width: {{ gamification.progress.percent|default_if_none:0 }}%;"></span>
+                                <div class="progress-analytics__bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ gamification.progress.percent|default_if_none:0 }}">
+                                    <span class="progress-analytics__bar-fill" style="width: {{ gamification.progress.percent|default_if_none:0 }}%;"></span>
                                 </div>
-                                {% if gamification.levels_path %}
-                                <div class="account-progress__level-path" role="list" aria-label="Linha do tempo de níveis">
-                                    {% for level in gamification.levels_path %}
-                                    <article class="account-progress__level-node account-progress__level-node--{{ level.status }}{% if level.is_current %} is-current{% endif %}" role="listitem"{% if level.is_current %} aria-current="step"{% endif %}>
-                                        <div class="account-progress__level-marker" aria-hidden="true">
-                                            <span>{{ level.order }}</span>
-                                        </div>
-                                        <div class="account-progress__level-content">
-                                            <div class="account-progress__level-info">
-                                                <span class="account-progress__level-step">Nível {{ level.order }}</span>
-                                                <strong class="account-progress__level-name">{{ level.name }}</strong>
-                                            </div>
-                                            <p class="account-progress__level-xp">A partir de {{ level.xp_required }} XP{% if level.xp_max %} · até {{ level.xp_max }} XP{% endif %}</p>
-                                            <div class="account-progress__level-node-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ level.progress_percent|default_if_none:0 }}">
-                                                <span class="account-progress__level-node-fill" style="width: {{ level.progress_percent|default_if_none:0 }}%;"></span>
-                                            </div>
-                                            <span class="account-progress__level-status">
-                                                {% if level.is_current %}
-                                                    Nível atual
-                                                {% elif level.is_completed %}
-                                                    Concluído
-                                                {% elif level.is_unlocked %}
-                                                    Desbloqueado
-                                                {% else %}
-                                                    Faltam {{ level.xp_to_unlock }} XP
-                                                {% endif %}
-                                            </span>
-                                        </div>
-                                    </article>
-                                    {% endfor %}
-                                </div>
-                                {% endif %}
-                                <ul class="account-progress__level-details">
+                                <ul class="progress-analytics__level-stats">
                                     <li>
-                                        <span>XP total</span>
+                                        <span class="progress-analytics__label">XP total</span>
                                         <strong>{{ gamification.xp_total|default:0 }}</strong>
                                     </li>
                                     <li>
-                                        <span>XP dentro do nível</span>
+                                        <span class="progress-analytics__label">XP no nível</span>
                                         <strong>{{ gamification.progress.xp_into_level|default:0 }}</strong>
                                     </li>
                                     <li>
-                                        <span>XP para o próximo nível</span>
+                                        <span class="progress-analytics__label">XP para avançar</span>
                                         <strong>
                                             {% if gamification.progress.xp_to_next_level is not None %}
                                                 {{ gamification.progress.xp_to_next_level }} XP
                                             {% else %}
-                                                Nível máximo alcançado
+                                                Objetivo concluído
                                             {% endif %}
                                         </strong>
                                     </li>
                                     <li>
-                                        <span>Próximo nível</span>
+                                        <span class="progress-analytics__label">Status da jornada</span>
                                         <strong>
                                             {% if gamification.next_level %}
-                                                {{ gamification.next_level.nome }}
+                                                Em direção a {{ gamification.next_level.nome }}
                                             {% else %}
                                                 Você está no topo
                                             {% endif %}
                                         </strong>
                                     </li>
                                 </ul>
-                            </div>
+                            </section>
+                            {% else %}
+                            <section class="progress-analytics__empty" aria-live="polite">
+                                <span class="material-symbols-outlined" aria-hidden="true">insights</span>
+                                <div>
+                                    <strong>Sem dados analíticos ainda</strong>
+                                    <p>Conclua seu primeiro quiz para gerar indicadores de nível, desempenho e frequência de estudo.</p>
+                                    <a class="button button--secondary button--small" href="{% url 'quiz:home' %}#home">Começar agora</a>
+                                </div>
+                            </section>
                             {% endif %}
 
-                            {% if gamification %}
-                            <div class="account-progress__insights-grid">
-                                <section class="account-progress__insight-card account-progress__insight-card--level">
-                                    <div class="account-progress__insight-header">
-                                        <h3>Momentum do nível</h3>
-                                        <span class="account-progress__insight-count">
-                                            {% if gamification.next_level %}
-                                                Próximo: {{ gamification.next_level.nome }}
-                                            {% else %}
-                                                Nível máximo alcançado
-                                            {% endif %}
-                                        </span>
-                                    </div>
-                                    <dl class="account-progress__metric-list">
-                                        <div class="account-progress__metric">
-                                            <dt>Conclusão do nível</dt>
-                                            <dd>{{ gamification.progress.percent|default_if_none:0|floatformat:0 }}%</dd>
-                                        </div>
-                                        <div class="account-progress__metric">
-                                            <dt>XP para avançar</dt>
-                                            <dd>
-                                                {% if gamification.progress.xp_to_next_level is not None %}
-                                                    {{ gamification.progress.xp_to_next_level }} XP
-                                                {% else %}
-                                                    Objetivo concluído
-                                                {% endif %}
-                                            </dd>
-                                        </div>
-                                        <div class="account-progress__metric">
-                                            <dt>XP dentro do nível</dt>
-                                            <dd>{{ gamification.progress.xp_into_level|default:0 }} XP</dd>
-                                        </div>
-                                        <div class="account-progress__metric">
-                                            <dt>XP ganho recentemente</dt>
-                                            <dd>{{ gamification.xp_ganho|default:0 }} XP</dd>
-                                        </div>
-                                    </dl>
-                                </section>
+                            <dl class="progress-analytics__summary">
+                                <div class="progress-analytics__summary-item">
+                                    <dt>Precisão geral</dt>
+                                    <dd>
+                                        {% if metrics.accuracy is not None %}
+                                            {{ metrics.accuracy|floatformat:1 }}%
+                                        {% else %}
+                                            —
+                                        {% endif %}
+                                        <small>{{ metrics.total_questions_answered|default:0 }} {{ metrics.total_questions_answered|default:0|pluralize:"questão analisada,questões analisadas" }}</small>
+                                    </dd>
+                                </div>
+                                <div class="progress-analytics__summary-item">
+                                    <dt>Sessões concluídas</dt>
+                                    <dd>
+                                        {{ metrics.total_sessions|default:0 }}
+                                        <small>Histórico completo disponível no painel ao lado</small>
+                                    </dd>
+                                </div>
+                                <div class="progress-analytics__summary-item">
+                                    <dt>Questões respondidas</dt>
+                                    <dd>
+                                        {{ metrics.total_questions_answered|default:0 }}
+                                        <small>Inclui todas as tentativas registradas</small>
+                                    </dd>
+                                </div>
+                                <div class="progress-analytics__summary-item">
+                                    <dt>Tempo de estudo (30 dias)</dt>
+                                    <dd>
+                                        {{ metrics.study_time_last_30_display|default:"0 min" }}
+                                        <small>{{ metrics.questions_last_30_days|default:0 }} {{ metrics.questions_last_30_days|default:0|pluralize:"questão revisada,questões revisadas" }}</small>
+                                    </dd>
+                                </div>
+                            </dl>
 
-                                <section class="account-progress__insight-card account-progress__insight-card--performance">
-                                    <div class="account-progress__insight-header">
-                                        <h3>Indicadores de desempenho</h3>
-                                        <span class="account-progress__insight-count">
-                                            {{ metrics.total_sessions|default:0 }} {{ metrics.total_sessions|default:0|pluralize:"sessão concluída,sessões concluídas" }}
-                                        </span>
-                                    </div>
-                                    <div class="account-progress__stat-grid">
-                                        <article class="account-progress__stat">
-                                            <span class="account-progress__stat-label">Taxa de acerto</span>
-                                            <strong class="account-progress__stat-value">
+                            <div class="progress-analytics__grid">
+                                <section class="progress-analytics__panel progress-analytics__panel--performance">
+                                    <header class="progress-analytics__panel-header">
+                                        <span class="material-symbols-outlined" aria-hidden="true">monitoring</span>
+                                        <div>
+                                            <h3>Desempenho consolidado</h3>
+                                            <p>Resultados acumulados das suas sessões finalizadas.</p>
+                                        </div>
+                                    </header>
+                                    <ul class="progress-analytics__metrics">
+                                        <li>
+                                            <span class="progress-analytics__metrics-label">Pontuação total</span>
+                                            <strong class="progress-analytics__metrics-value">{{ metrics.total_score|default:0 }}</strong>
+                                            <small>Melhor sessão: {{ metrics.best_score|default:0 }}</small>
+                                        </li>
+                                        <li>
+                                            <span class="progress-analytics__metrics-label">Taxa de acerto</span>
+                                            <strong class="progress-analytics__metrics-value">
                                                 {% if metrics.accuracy is not None %}
                                                     {{ metrics.accuracy|floatformat:1 }}%
                                                 {% else %}
                                                     —
                                                 {% endif %}
                                             </strong>
-                                            <small class="account-progress__stat-hint">{{ metrics.total_questions_answered|default:0 }} {{ metrics.total_questions_answered|default:0|pluralize:"questão respondida,questões respondidas" }}</small>
-                                        </article>
-                                        <article class="account-progress__stat">
-                                            <span class="account-progress__stat-label">Melhor pontuação</span>
-                                            <strong class="account-progress__stat-value">{{ metrics.best_score|default:0 }}</strong>
-                                            <small class="account-progress__stat-hint">Pontuação acumulada {{ metrics.total_score|default:0 }}</small>
-                                        </article>
-                                        <article class="account-progress__stat">
-                                            <span class="account-progress__stat-label">Sequência ativa</span>
-                                            <strong class="account-progress__stat-value">{{ metrics.current_streak|default:0 }} dia{{ metrics.current_streak|default:0|pluralize }}</strong>
-                                            <small class="account-progress__stat-hint">Recorde: {{ gamification.best_streak|default_if_none:0 }} dia{{ gamification.best_streak|default_if_none:0|pluralize }}</small>
-                                        </article>
-                                    </div>
-                                </section>
-
-                                <section class="account-progress__insight-card account-progress__insight-card--engagement">
-                                    <div class="account-progress__insight-header">
-                                        <h3>Ritmo de estudo</h3>
-                                        <span class="account-progress__insight-count">
-                                            {% if gamification.lifetime_stats and gamification.lifetime_stats.last_update_display %}
-                                                Atualizado em {{ gamification.lifetime_stats.last_update_display }}
-                                            {% else %}
-                                                Dados em tempo real
-                                            {% endif %}
-                                        </span>
-                                    </div>
-                                    <div class="account-progress__trend-grid">
-                                        <article class="account-progress__trend">
-                                            <span class="account-progress__trend-label">Últimos 30 dias</span>
-                                            <strong class="account-progress__trend-value">{{ metrics.questions_last_30_days|default:0 }} {{ metrics.questions_last_30_days|default:0|pluralize:"questão,questões" }}</strong>
-                                            <small class="account-progress__trend-hint">{{ metrics.study_time_last_30_display|default:"0 min" }} de estudo</small>
-                                        </article>
-                                        <article class="account-progress__trend">
-                                            <span class="account-progress__trend-label">Hoje</span>
-                                            {% if gamification.daily_engagement %}
-                                            <strong class="account-progress__trend-value">{{ gamification.daily_engagement.questions_today|default_if_none:0 }} {{ gamification.daily_engagement.questions_today|default_if_none:0|pluralize:"questão,questões" }}</strong>
-                                            <small class="account-progress__trend-hint">{{ gamification.daily_engagement.xp_today|default_if_none:0 }} XP conquistados</small>
-                                            {% else %}
-                                            <strong class="account-progress__trend-value">—</strong>
-                                            <small class="account-progress__trend-hint">Ainda sem atividade registrada</small>
-                                            {% endif %}
-                                        </article>
-                                        <article class="account-progress__trend">
-                                            <span class="account-progress__trend-label">Sessões concluídas</span>
-                                            <strong class="account-progress__trend-value">{{ metrics.total_sessions|default:0 }}</strong>
-                                            <small class="account-progress__trend-hint">{{ metrics.total_questions_answered|default:0 }} {{ metrics.total_questions_answered|default:0|pluralize:"questão respondida,questões respondidas" }}</small>
-                                        </article>
-                                    </div>
-                                </section>
-
-                                {% if gamification.achievements %}
-                                <section class="account-progress__insight-card account-progress__insight-card--achievements">
-                                    <div class="account-progress__insight-header">
-                                        <h3>Metas em foco</h3>
-                                        <span class="account-progress__insight-count">
-                                            {{ gamification.achievements.total_unlocked|default:0 }} de {{ gamification.achievements.total_available|default:0 }} conquistas
-                                        </span>
-                                    </div>
-                                    <ul class="account-progress__insight-list">
-                                        {% if gamification.achievements.upcoming %}
-                                            {% for item in gamification.achievements.upcoming %}
-                                            <li class="account-progress__insight-item">
-                                                <div class="account-progress__insight-info">
-                                                    <strong>{{ item.nome }}</strong>
-                                                    <p>{{ item.descricao }}</p>
-                                                </div>
-                                                {% if item.progress %}
-                                                <span class="account-progress__insight-progress">{{ item.progress.label }}</span>
-                                                <span class="account-progress__insight-remaining">{{ item.progress.remaining_label }}</span>
-                                                {% endif %}
-                                            </li>
-                                            {% endfor %}
-                                        {% else %}
-                                            <li class="account-progress__empty">Você completou todas as metas disponíveis por enquanto.</li>
-                                        {% endif %}
+                                            <small>{{ metrics.total_questions_answered|default:0 }} {{ metrics.total_questions_answered|default:0|pluralize:"questão respondida,questões respondidas" }}</small>
+                                        </li>
+                                        <li>
+                                            <span class="progress-analytics__metrics-label">Sequência ativa</span>
+                                            <strong class="progress-analytics__metrics-value">{{ metrics.current_streak|default:0 }} dia{{ metrics.current_streak|default:0|pluralize }}</strong>
+                                            <small>Recorde histórico: {{ gamification.best_streak|default_if_none:0 }} dia{{ gamification.best_streak|default_if_none:0|pluralize }}</small>
+                                        </li>
                                     </ul>
                                 </section>
-                                {% endif %}
-                            </div>
-                            {% endif %}
 
-                            {% if gamification and gamification.daily_engagement %}
+                                <section class="progress-analytics__panel progress-analytics__panel--frequency">
+                                    <header class="progress-analytics__panel-header">
+                                        <span class="material-symbols-outlined" aria-hidden="true">schedule</span>
+                                        <div>
+                                            <h3>Frequência e ritmo</h3>
+                                            <p>Volume de estudo recente e consolidação de hábitos.</p>
+                                        </div>
+                                    </header>
+                                    <ul class="progress-analytics__metrics">
+                                        <li>
+                                            <span class="progress-analytics__metrics-label">Últimos 30 dias</span>
+                                            <strong class="progress-analytics__metrics-value">{{ metrics.questions_last_30_days|default:0 }} {{ metrics.questions_last_30_days|default:0|pluralize:"questão,questões" }}</strong>
+                                            <small>{{ metrics.study_time_last_30_display|default:"0 min" }} dedicados no período</small>
+                                        </li>
+                                        <li>
+                                            <span class="progress-analytics__metrics-label">Hoje</span>
+                                            {% if gamification and gamification.daily_engagement %}
+                                                <strong class="progress-analytics__metrics-value">{{ gamification.daily_engagement.questions_today|default_if_none:0 }} {{ gamification.daily_engagement.questions_today|default_if_none:0|pluralize:"questão,questões" }}</strong>
+                                                <small>{{ gamification.daily_engagement.xp_today|default_if_none:0 }} XP gerados</small>
+                                            {% else %}
+                                                <strong class="progress-analytics__metrics-value">—</strong>
+                                                <small>Registre uma sessão para alimentar esta métrica</small>
+                                            {% endif %}
+                                        </li>
+                                        <li>
+                                            <span class="progress-analytics__metrics-label">Sessões totais</span>
+                                            <strong class="progress-analytics__metrics-value">{{ metrics.total_sessions|default:0 }}</strong>
+                                            <small>Consolidadas desde o início da sua jornada</small>
+                                        </li>
+                                    </ul>
+                                </section>
+
+                                {% if gamification and gamification.daily_engagement %}
                                 {% with daily=gamification.daily_engagement %}
-                                <div class="account-progress__daily">
-                                    <span class="material-symbols-outlined account-progress__daily-icon" aria-hidden="true">
-                                        {% if daily.has_activity_today %}verified{% else %}alarm{% endif %}
-                                    </span>
-                                    <div class="account-progress__daily-content">
-                                        <strong class="account-progress__daily-title">
-                                            {% if daily.has_activity_today %}
-                                                Ritmo diário mantido
-                                            {% else %}
-                                                Ritmo diário pendente
-                                            {% endif %}
-                                        </strong>
-                                        <p class="account-progress__daily-text">
-                                            {% if daily.has_activity_today %}
-                                                Você registrou {{ daily.questions_today|default_if_none:0 }} pergunta{{ daily.questions_today|default_if_none:0|pluralize }} hoje e somou {{ daily.xp_today|default_if_none:0 }} XP.
-                                            {% else %}
-                                                Resolva uma questão hoje para proteger sua sequência de {{ daily.streak_days|default_if_none:0 }} dia{{ daily.streak_days|default_if_none:0|pluralize }}.
-                                            {% endif %}
-                                        </p>
-                                        <ul class="account-progress__daily-list">
+                                <section class="progress-analytics__panel progress-analytics__panel--daily">
+                                    <header class="progress-analytics__panel-header">
+                                        <span class="material-symbols-outlined" aria-hidden="true">pace</span>
+                                        <div>
+                                            <h3>Ritmo diário</h3>
+                                            <p>Status do compromisso de estudo nas últimas 24 horas.</p>
+                                        </div>
+                                    </header>
+                                    <div class="progress-analytics__daily-status">
+                                        <div class="progress-analytics__daily-indicator">
+                                            <span class="material-symbols-outlined" aria-hidden="true">
+                                                {% if daily.has_activity_today %}task_alt{% else %}pending_actions{% endif %}
+                                            </span>
+                                            <div>
+                                                <strong>
+                                                    {% if daily.has_activity_today %}
+                                                        Ritmo mantido hoje
+                                                    {% else %}
+                                                        Atividade pendente
+                                                    {% endif %}
+                                                </strong>
+                                                <p>
+                                                    {% if daily.has_activity_today %}
+                                                        Você registrou {{ daily.questions_today|default_if_none:0 }} pergunta{{ daily.questions_today|default_if_none:0|pluralize }} e somou {{ daily.xp_today|default_if_none:0 }} XP.
+                                                    {% else %}
+                                                        Resolva pelo menos uma questão para preservar a sequência de {{ daily.streak_days|default_if_none:0 }} dia{{ daily.streak_days|default_if_none:0|pluralize }}.
+                                                    {% endif %}
+                                                </p>
+                                            </div>
+                                        </div>
+                                        <ul class="progress-analytics__daily-metrics">
                                             <li>
-                                                <span>Perguntas</span>
+                                                <span>Perguntas hoje</span>
                                                 <strong>{{ daily.questions_today|default_if_none:0 }}</strong>
                                             </li>
                                             <li>
-                                                <span>XP</span>
+                                                <span>XP hoje</span>
                                                 <strong>{{ daily.xp_today|default_if_none:0 }}</strong>
                                             </li>
                                             <li>
@@ -676,44 +618,47 @@
                                             </li>
                                         </ul>
                                     </div>
-                                </div>
+                                </section>
                                 {% endwith %}
-                            {% endif %}
-
-                            <div class="account-progress__highlights">
-                                <h3 class="account-progress__section-title">Marcos principais</h3>
-                                {% if gamification %}
-                                    <ul class="account-progress__list">
-                                        <li>
-                                            <span class="material-symbols-outlined" aria-hidden="true">military_tech</span>
-                                            <div>
-                                                <strong>Maior sequência</strong>
-                                                <p>{{ gamification.best_streak|default_if_none:0 }} dia{{ gamification.best_streak|default_if_none:0|pluralize }}</p>
-                                            </div>
-                                        </li>
-                                        {% if gamification.achievements %}
-                                        <li>
-                                            <span class="material-symbols-outlined" aria-hidden="true">emoji_events</span>
-                                            <div>
-                                                <strong>Conquistas desbloqueadas</strong>
-                                                <p>{{ gamification.achievements.total_unlocked|default:0 }} de {{ gamification.achievements.total_available|default:0 }}</p>
-                                            </div>
-                                        </li>
-                                        {% endif %}
-                                        {% if gamification.lifetime_stats %}
-                                        <li>
-                                            <span class="material-symbols-outlined" aria-hidden="true">query_stats</span>
-                                            <div>
-                                                <strong>Sessões concluídas</strong>
-                                                <p>{{ gamification.lifetime_stats.total_sessions|default_if_none:0 }} no total</p>
-                                            </div>
-                                        </li>
-                                        {% endif %}
-                                    </ul>
-                                {% else %}
-                                    <p class="account-progress__empty">Complete seu primeiro quiz para desbloquear conquistas e acompanhar seus indicadores.</p>
                                 {% endif %}
                             </div>
+
+                            {% if gamification and gamification.levels_path %}
+                            <section class="progress-analytics__timeline" aria-label="Escala de níveis e progresso">
+                                <header class="progress-analytics__timeline-header">
+                                    <h3>Mapa de níveis</h3>
+                                    <p>Entenda onde você está posicionado e quais etapas ainda estão pela frente.</p>
+                                </header>
+                                <div class="progress-analytics__timeline-track">
+                                    {% for level in gamification.levels_path %}
+                                    <article class="progress-analytics__timeline-node progress-analytics__timeline-node--{{ level.status }}{% if level.is_current %} is-current{% endif %}" role="listitem"{% if level.is_current %} aria-current="step"{% endif %}>
+                                        <span class="progress-analytics__timeline-order" aria-hidden="true">{{ level.order }}</span>
+                                        <div class="progress-analytics__timeline-content">
+                                            <div class="progress-analytics__timeline-head">
+                                                <strong>Nível {{ level.order }}</strong>
+                                                <span>{{ level.name }}</span>
+                                            </div>
+                                            <p class="progress-analytics__timeline-range">A partir de {{ level.xp_required }} XP{% if level.xp_max %} · até {{ level.xp_max }} XP{% endif %}</p>
+                                            <div class="progress-analytics__timeline-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ level.progress_percent|default_if_none:0 }}">
+                                                <span style="width: {{ level.progress_percent|default_if_none:0 }}%;"></span>
+                                            </div>
+                                            <span class="progress-analytics__timeline-status">
+                                                {% if level.is_current %}
+                                                    Em andamento
+                                                {% elif level.is_completed %}
+                                                    Concluído
+                                                {% elif level.is_unlocked %}
+                                                    Disponível
+                                                {% else %}
+                                                    Faltam {{ level.xp_to_unlock }} XP
+                                                {% endif %}
+                                            </span>
+                                        </div>
+                                    </article>
+                                    {% endfor %}
+                                </div>
+                            </section>
+                            {% endif %}
                         </div>
                     </section>
                 </div>


### PR DESCRIPTION
## Summary
- reconstrói a aba de progresso da conta com um painel analítico centrado em nível, desempenho e frequência
- adiciona novo conjunto de estilos `progress-analytics` para suportar o layout profissional e responsivo

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68eedb0c51bc8333b575636ad0cd0be6