### PR TITLE
Revamp progress analytics dashboard aesthetics

### DIFF
--- a/assets/css/sections/conta-section.css
+++ b/assets/css/sections/conta-section.css
@@ -1319,37 +1319,86 @@
 
 .progress-analytics__grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    grid-template-columns: minmax(0, 1fr);
     gap: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-xl, 36px));
 }
 
+@media (min-width: 960px) {
+    .progress-analytics__grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
 .progress-analytics__panel {
+    position: relative;
+    isolation: isolate;
     display: flex;
     flex-direction: column;
     gap: clamp(var(--spacing-sm, 16px), 2.4vw, var(--spacing-lg, 28px));
     padding: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
-    border-radius: var(--border-radius-xl);
-    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.97);
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.14);
-    box-shadow: var(--shadow-xs);
+    border-radius: calc(var(--border-radius-xl) * 1.05);
+    background: linear-gradient(160deg, rgba(var(--color-white-rgb, 255, 255, 255), 0.94), rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.9));
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
+    box-shadow: 0 18px 40px -30px rgba(var(--color-primary-dark-rgb, 8, 35, 64), 0.55);
+    overflow: hidden;
+    backdrop-filter: blur(6px);
+}
+
+.progress-analytics__panel::before,
+.progress-analytics__panel::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: -1;
+}
+
+.progress-analytics__panel::before {
+    opacity: 0.92;
+    background: radial-gradient(160% 120% at 0% 0%, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12), transparent 65%),
+                radial-gradient(120% 120% at 100% 0%, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.08), transparent 60%);
+}
+
+.progress-analytics__panel::after {
+    opacity: 0.85;
+    background: linear-gradient(140deg, rgba(255, 255, 255, 0.22) 0%, rgba(255, 255, 255, 0.02) 45%, rgba(14, 35, 64, 0.08) 100%);
+    mix-blend-mode: lighten;
+}
+
+.progress-analytics__panel--performance::before {
+    background: radial-gradient(140% 120% at 0% 0%, rgba(26, 95, 158, 0.24), transparent 60%),
+                radial-gradient(120% 140% at 85% 0%, rgba(64, 140, 255, 0.16), transparent 65%);
+}
+
+.progress-analytics__panel--frequency::before {
+    background: radial-gradient(150% 140% at 0% 0%, rgba(24, 164, 141, 0.25), transparent 65%),
+                radial-gradient(120% 150% at 90% 10%, rgba(102, 210, 200, 0.18), transparent 70%);
+}
+
+.progress-analytics__panel--daily::before {
+    background: radial-gradient(160% 140% at 0% 0%, rgba(255, 170, 76, 0.26), transparent 65%),
+                radial-gradient(120% 150% at 90% 15%, rgba(255, 217, 158, 0.2), transparent 70%);
 }
 
 .progress-analytics__panel-header {
     display: flex;
     align-items: flex-start;
     gap: var(--spacing-sm, 16px);
+    padding-bottom: var(--spacing-sm, 16px);
+    border-bottom: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
 }
 
 .progress-analytics__panel-header .material-symbols-outlined {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 40px;
-    height: 40px;
-    border-radius: var(--border-radius-pill);
-    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
-    color: var(--color-primary-medium);
-    font-size: 1.6rem;
+    width: clamp(42px, 5vw, 52px);
+    height: clamp(42px, 5vw, 52px);
+    border-radius: calc(var(--border-radius-pill) * 1.1);
+    background: linear-gradient(145deg, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.2), rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.08));
+    box-shadow: inset 0 0 0 1px rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.22);
+    color: var(--color-primary-dark);
+    font-size: clamp(1.5rem, 3vw, 1.8rem);
     flex-shrink: 0;
 }
 
@@ -1376,13 +1425,38 @@
 }
 
 .progress-analytics__metrics li {
+    position: relative;
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 8px;
     padding: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-md, 24px));
-    border-radius: var(--border-radius-lg);
-    border: 1px solid rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.9);
-    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.45);
+    border-radius: calc(var(--border-radius-lg) * 1.05);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.95);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.08);
+    box-shadow: inset 0 0 0 1px rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.9);
+    overflow: hidden;
+}
+
+.progress-analytics__metrics li::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(140% 120% at 0% 0%, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12), transparent 60%);
+    opacity: 0.9;
+    pointer-events: none;
+}
+
+.progress-analytics__panel--frequency .progress-analytics__metrics li::before {
+    background: radial-gradient(140% 120% at 0% 0%, rgba(26, 158, 133, 0.16), transparent 60%);
+}
+
+.progress-analytics__panel--daily .progress-analytics__metrics li::before {
+    background: radial-gradient(140% 120% at 0% 0%, rgba(255, 170, 76, 0.18), transparent 60%);
+}
+
+.progress-analytics__metrics li > * {
+    position: relative;
+    z-index: 1;
 }
 
 .progress-analytics__metrics-label {
@@ -1414,21 +1488,34 @@
     align-items: flex-start;
     gap: var(--spacing-sm, 16px);
     padding: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-md, 24px));
-    border-radius: var(--border-radius-lg);
-    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.5);
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
+    border-radius: calc(var(--border-radius-lg) * 1.05);
+    background: linear-gradient(150deg, rgba(255, 255, 255, 0.94), rgba(255, 255, 255, 0.78));
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.1);
+    box-shadow: inset 0 0 0 1px rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.8);
+    position: relative;
+    overflow: hidden;
+}
+
+.progress-analytics__daily-indicator::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(140% 140% at 0% 0%, rgba(255, 170, 76, 0.22), transparent 65%);
+    opacity: 0.85;
+    pointer-events: none;
 }
 
 .progress-analytics__daily-indicator .material-symbols-outlined {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 40px;
-    height: 40px;
-    border-radius: var(--border-radius-pill);
-    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
-    color: var(--color-primary-medium);
-    font-size: 1.6rem;
+    width: clamp(42px, 5vw, 52px);
+    height: clamp(42px, 5vw, 52px);
+    border-radius: calc(var(--border-radius-pill) * 1.05);
+    background: linear-gradient(140deg, rgba(255, 170, 76, 0.24), rgba(255, 206, 147, 0.18));
+    box-shadow: inset 0 0 0 1px rgba(255, 170, 76, 0.35);
+    color: rgba(138, 64, 0, 0.9);
+    font-size: clamp(1.5rem, 3vw, 1.8rem);
     flex-shrink: 0;
 }
 
@@ -1459,9 +1546,10 @@
     flex-direction: column;
     gap: 6px;
     padding: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-md, 24px));
-    border-radius: var(--border-radius-lg);
-    border: 1px dashed rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.25);
-    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.92);
+    border-radius: calc(var(--border-radius-lg) * 1.05);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(255, 245, 234, 0.9));
+    box-shadow: inset 0 0 0 1px rgba(255, 170, 76, 0.25);
     text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- refresh the progress analytics panels with layered gradients, glassmorphism accents, and richer icon treatments
- enforce a maximum of two columns for the analytics grid while keeping a single-column layout on narrow viewports
- align the daily indicator and metric cards with the new visual language using warm highlight gradients and refined borders

## Testing
- no automated tests were run (CSS-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68eee2e76ce8833399eb1917924c4754