### PR TITLE
Fix localized formatting of progress bars

### DIFF
--- a/quiz/templates/quiz/account_page.html
+++ b/quiz/templates/quiz/account_page.html
@@ -1,5 +1,5 @@
 {% extends "quiz/base.html" %}
-{% load static %}
+{% load static l10n %}
 
 {% block title %}{{ page_title|default:"Minha Conta" }} - MedQuiz{% endblock title %}
 
@@ -425,8 +425,8 @@
                                         {% endif %}
                                     </div>
                                 </div>
-                                <div class="progress-analytics__bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ gamification.progress.percent|default_if_none:0 }}">
-                                    <span class="progress-analytics__bar-fill" style="width: {{ gamification.progress.percent|default_if_none:0 }}%;"></span>
+                                <div class="progress-analytics__bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ gamification.progress.percent|default_if_none:0|unlocalize }}">
+                                    <span class="progress-analytics__bar-fill" style="width: {{ gamification.progress.percent|default_if_none:0|unlocalize }}%;"></span>
                                 </div>
                                 <ul class="progress-analytics__level-stats">
                                     <li>
@@ -639,8 +639,8 @@
                                                 <span>{{ level.name }}</span>
                                             </div>
                                             <p class="progress-analytics__timeline-range">A partir de {{ level.xp_required }} XP{% if level.xp_max %} · até {{ level.xp_max }} XP{% endif %}</p>
-                                            <div class="progress-analytics__timeline-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ level.progress_percent|default_if_none:0 }}">
-                                                <span style="width: {{ level.progress_percent|default_if_none:0 }}%;"></span>
+                                            <div class="progress-analytics__timeline-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ level.progress_percent|default_if_none:0|unlocalize }}">
+                                                <span style="width: {{ level.progress_percent|default_if_none:0|unlocalize }}%;"></span>
                                             </div>
                                             <span class="progress-analytics__timeline-status">
                                                 {% if level.is_current %}

--- a/quiz/templates/quiz/home.html
+++ b/quiz/templates/quiz/home.html
@@ -1,6 +1,6 @@
 {# Arquivo: templates/quiz/home.html #}
 {% extends "quiz/base.html" %}
-{% load static %}
+{% load static l10n %}
 {% block title %}{{ page_title|default:"MedQuiz - Início" }}{% endblock title %}
 {% block content %}
 <section id="home-section" class="home-landing">
@@ -16,8 +16,8 @@
                     <span id="home-progress-title">Nível {{ level_summary.name }}</span>
                     <span class="home-progress__percentage">{{ level_summary.progress_display }}</span>
                 </div>
-                <div class="home-progress__track" role="progressbar" aria-labelledby="home-progress-title" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ level_summary.progress_percent|default:0|floatformat:'0' }}">
-                    <span class="home-progress__fill" style="width: {{ level_summary.progress_percent|default:0 }}%;"></span>
+                <div class="home-progress__track" role="progressbar" aria-labelledby="home-progress-title" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ level_summary.progress_percent|default_if_none:0|floatformat:'0'|unlocalize }}">
+                    <span class="home-progress__fill" style="width: {{ level_summary.progress_percent|default_if_none:0|unlocalize }}%;"></span>
                 </div>
                 <div class="home-progress__meta">
                     <span class="home-progress__label">
@@ -137,8 +137,8 @@
                             <span class="home-card__progress-value">{{ card.progress.value }}</span>
                             {% endif %}
                         </div>
-                        <div class="home-card__progress-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ card.progress.percent|default:0|floatformat:'0' }}">
-                            <span class="home-card__progress-fill" style="width: {{ card.progress.percent|default:0 }}%;"></span>
+                        <div class="home-card__progress-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ card.progress.percent|default_if_none:0|floatformat:'0'|unlocalize }}">
+                            <span class="home-card__progress-fill" style="width: {{ card.progress.percent|default_if_none:0|unlocalize }}%;"></span>
                         </div>
                     </div>
                     {% if card.reward %}
@@ -168,8 +168,8 @@
                             <span class="home-card__progress-value">{{ card.progress.value }}</span>
                             {% endif %}
                         </div>
-                        <div class="home-card__progress-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ card.progress.percent|default:0|floatformat:'0' }}">
-                            <span class="home-card__progress-fill" style="width: {{ card.progress.percent|default:0 }}%;"></span>
+                        <div class="home-card__progress-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ card.progress.percent|default_if_none:0|floatformat:'0'|unlocalize }}">
+                            <span class="home-card__progress-fill" style="width: {{ card.progress.percent|default_if_none:0|unlocalize }}%;"></span>
                         </div>
                     </div>
                 </article>


### PR DESCRIPTION
## Summary
- prevent localized number formatting from zeroing progress bar widths on the home hero and cards by using the `unlocalize` template filter
- apply the same fix to account page progress components so CSS widths remain valid in Portuguese locales

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eef29a47e48333a26e4fb3c70e9565