### PR TITLE
Redesign progress dashboard with richer analytics

### DIFF
--- a/assets/css/sections/conta-section.css
+++ b/assets/css/sections/conta-section.css
@@ -1135,47 +1135,137 @@
 .progress-analytics {
     display: flex;
     flex-direction: column;
-    gap: clamp(var(--spacing-lg, 28px), 4vw, var(--spacing-xl, 40px));
+    gap: clamp(var(--spacing-lg, 28px), 4vw, var(--spacing-xxl, 48px));
 }
 
 .progress-analytics__card {
     --card-padding: clamp(var(--spacing-lg, 28px), 4vw, var(--spacing-xl, 40px));
     display: flex;
     flex-direction: column;
-    gap: clamp(var(--spacing-lg, 28px), 3vw, var(--spacing-xl, 36px));
+    gap: clamp(var(--spacing-lg, 28px), 3vw, var(--spacing-xl, 40px));
 }
 
 .progress-analytics__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--spacing-md, 20px);
-    padding-bottom: var(--spacing-md, 20px);
-    border-bottom: 1px solid rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.85);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: clamp(var(--spacing-lg, 28px), 3vw, var(--spacing-xl, 40px));
+    padding: clamp(var(--spacing-lg, 28px), 4vw, var(--spacing-xl, 40px));
+    border-radius: var(--border-radius-xl);
+    background: linear-gradient(135deg, rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.9), rgba(var(--color-white-rgb, 255, 255, 255), 0.95));
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18);
+    box-shadow: var(--shadow-sm);
+    position: relative;
+    overflow: hidden;
 }
 
-.progress-analytics__headline {
+.progress-analytics__header::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 80% 20%, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18), transparent 55%);
+    pointer-events: none;
+}
+
+.progress-analytics__intro {
+    position: relative;
+    z-index: 1;
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-xxs, 6px);
+    gap: var(--spacing-sm, 12px);
 }
 
-.progress-analytics__icon {
+.progress-analytics__eyebrow {
+    font-size: var(--font-size-xxs, 0.75rem);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--color-text-muted);
+}
+
+.progress-analytics__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-xs, 8px);
+}
+
+.progress-analytics__chip {
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    width: 48px;
-    height: 48px;
+    gap: var(--spacing-xxs, 6px);
+    padding: 6px 12px;
     border-radius: var(--border-radius-pill);
-    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.14);
-    color: var(--color-primary-medium);
-    font-size: 1.8rem;
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.24);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.85);
+    color: var(--color-primary-dark);
+    font-size: var(--font-size-xs, 0.82rem);
+    font-weight: var(--font-weight-medium);
+    backdrop-filter: blur(4px);
 }
 
-.progress-analytics__body {
+.progress-analytics__chip .material-symbols-outlined {
+    font-size: 1.1rem;
+}
+
+.progress-analytics__hero-meter {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md, 20px);
+    padding: var(--spacing-sm, 12px) var(--spacing-md, 20px);
+    border-radius: var(--border-radius-lg);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.78);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
+    box-shadow: var(--shadow-xs);
+}
+
+.progress-analytics__radial {
+    --progress-value: 0;
+    position: relative;
+    width: clamp(96px, 10vw, 120px);
+    aspect-ratio: 1;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    background: conic-gradient(var(--color-primary-medium) calc(var(--progress-value) * 1%), rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12) 0%);
+}
+
+.progress-analytics__radial::before {
+    content: "";
+    width: calc(100% - 16px);
+    height: calc(100% - 16px);
+    border-radius: 50%;
+    background: var(--color-white);
+    box-shadow: inset 0 0 0 1px rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.08);
+}
+
+.progress-analytics__radial-value {
+    position: absolute;
+    font-size: clamp(1.3rem, 2.5vw, 1.8rem);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
+}
+
+.progress-analytics__hero-meta {
     display: flex;
     flex-direction: column;
-    gap: clamp(var(--spacing-lg, 28px), 3vw, var(--spacing-xl, 40px));
+    gap: 4px;
+    min-width: 160px;
+}
+
+.progress-analytics__hero-meta strong {
+    font-size: clamp(1.1rem, 2.1vw, 1.4rem);
+    color: var(--color-primary-dark);
+}
+
+.progress-analytics__hero-meta p {
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm, 0.95rem);
+}
+
+.progress-analytics__hero-meta small {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xxs, 0.75rem);
 }
 
 .progress-analytics__label {
@@ -1185,228 +1275,247 @@
     color: var(--color-text-muted);
 }
 
-.progress-analytics__level {
+.progress-analytics__body {
     display: flex;
     flex-direction: column;
-    gap: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
+    gap: clamp(var(--spacing-lg, 28px), 3vw, var(--spacing-xl, 40px));
+}
+
+.progress-analytics__highlights {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+    gap: var(--spacing-md, 20px);
+}
+
+.progress-analytics__highlight {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs, 8px);
+    padding: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
+    border-radius: var(--border-radius-lg);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.95);
+    box-shadow: var(--shadow-xs);
+    transition: transform var(--transition-medium), box-shadow var(--transition-medium);
+}
+
+.progress-analytics__highlight:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-md);
+}
+
+.progress-analytics__highlight-header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs, 8px);
+}
+
+.progress-analytics__highlight-icon {
+    font-size: 1.4rem;
+    color: var(--color-primary-medium);
+}
+
+.progress-analytics__highlight-label {
+    font-size: var(--font-size-xs, 0.82rem);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+}
+
+.progress-analytics__highlight-value {
+    font-size: clamp(1.4rem, 2.6vw, 1.9rem);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
+}
+
+.progress-analytics__highlight-meta {
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm, 0.95rem);
+}
+
+.progress-analytics__overview {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: var(--spacing-md, 20px);
+}
+
+.progress-analytics__level-card,
+.progress-analytics__insight-card {
     padding: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
     border-radius: var(--border-radius-xl);
-    background: linear-gradient(135deg, rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.9), rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.15));
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.14);
+    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.35);
     box-shadow: var(--shadow-xs);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md, 20px);
 }
 
 .progress-analytics__level-header {
     display: flex;
-    align-items: flex-start;
     justify-content: space-between;
-    gap: var(--spacing-lg, 28px);
+    align-items: flex-start;
+    gap: var(--spacing-md, 20px);
 }
 
-.progress-analytics__level-title {
+.progress-analytics__level-header h3 {
     margin: 4px 0 0;
-    font-size: clamp(1.4rem, 3vw, 1.8rem);
+    font-size: clamp(1.2rem, 2.5vw, 1.6rem);
     font-weight: var(--font-weight-semibold);
     color: var(--color-primary-dark);
 }
 
-.progress-analytics__level-status {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
+.progress-analytics__level-numbers {
     text-align: right;
 }
 
-.progress-analytics__level-status strong {
-    font-size: clamp(1.4rem, 3vw, 1.9rem);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-primary-dark);
+.progress-analytics__level-numbers strong {
+    display: block;
+    font-size: clamp(1.2rem, 2.3vw, 1.5rem);
+    color: var(--color-primary-medium);
 }
 
-.progress-analytics__level-status span {
-    font-size: var(--font-size-xs, 0.82rem);
-    color: var(--color-text-secondary);
-}
-
-.progress-analytics__level-status small {
-    font-size: var(--font-size-xxs, 0.75rem);
+.progress-analytics__level-numbers small {
+    display: block;
     color: var(--color-text-muted);
+    font-size: var(--font-size-xxs, 0.75rem);
 }
 
-.progress-analytics__bar {
+.progress-analytics__progress-bar {
     position: relative;
     width: 100%;
     height: 12px;
     border-radius: 999px;
-    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.14);
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
     overflow: hidden;
 }
 
-.progress-analytics__bar-fill {
-    display: block;
-    height: 100%;
+.progress-analytics__progress-bar span {
+    position: absolute;
+    inset: 0;
     border-radius: inherit;
-    background: linear-gradient(90deg, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.9), rgba(var(--color-primary-dark-rgb, 8, 35, 64), 0.95));
-    transition: width 0.4s ease;
+    background: linear-gradient(90deg, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.85), rgba(var(--color-primary-dark-rgb, 8, 35, 64), 0.95));
+    transition: width var(--transition-medium);
 }
 
 .progress-analytics__level-stats {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    gap: clamp(var(--spacing-sm, 16px), 2.6vw, var(--spacing-lg, 28px));
-    list-style: none;
-    margin: 0;
-    padding: 0;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--spacing-md, 20px);
 }
 
-.progress-analytics__level-stats li {
+.progress-analytics__level-stats div {
     display: flex;
     flex-direction: column;
-    gap: 6px;
-    padding: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-md, 24px));
-    border-radius: var(--border-radius-lg);
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.15);
-    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.92);
+    gap: 4px;
 }
 
-.progress-analytics__level-stats strong {
-    font-size: clamp(1.05rem, 2.2vw, 1.45rem);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-primary-dark);
-}
-
-.progress-analytics__summary {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-xl, 36px));
-    margin: 0;
-    padding: 0;
-}
-
-.progress-analytics__summary-item {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xs, 10px);
-    padding: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
-    border-radius: var(--border-radius-xl);
-    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.96);
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
-    box-shadow: var(--shadow-xs);
-}
-
-.progress-analytics__summary-item dt {
-    margin: 0;
+.progress-analytics__level-stats dt {
     font-size: var(--font-size-xs, 0.82rem);
     color: var(--color-text-muted);
     text-transform: uppercase;
     letter-spacing: 0.08em;
 }
 
-.progress-analytics__summary-item dd {
+.progress-analytics__level-stats dd {
     margin: 0;
+    font-size: 1rem;
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-primary);
+}
+
+.progress-analytics__insight-header {
     display: flex;
-    flex-direction: column;
-    gap: 6px;
-    font-size: clamp(1.3rem, 3vw, 1.7rem);
+    align-items: flex-start;
+    gap: var(--spacing-sm, 12px);
+}
+
+.progress-analytics__insight-header .material-symbols-outlined {
+    font-size: 1.8rem;
+    color: var(--color-primary-medium);
+}
+
+.progress-analytics__insight-header h3 {
+    margin: 0;
+    font-size: 1.2rem;
     font-weight: var(--font-weight-semibold);
     color: var(--color-primary-dark);
 }
 
-.progress-analytics__summary-item small {
-    font-size: var(--font-size-xxs, 0.75rem);
+.progress-analytics__insight-header p {
+    margin: 4px 0 0;
     color: var(--color-text-secondary);
+    font-size: var(--font-size-sm, 0.95rem);
 }
 
-.progress-analytics__grid {
+.progress-analytics__insight-list {
     display: grid;
-    grid-template-columns: minmax(0, 1fr);
-    gap: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-xl, 36px));
+    gap: var(--spacing-sm, 12px);
 }
 
-@media (min-width: 960px) {
-    .progress-analytics__grid {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
+.progress-analytics__insight-list li {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: var(--spacing-sm, 12px);
+    border-radius: var(--border-radius-lg);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.9);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.08);
+}
+
+.progress-analytics__insight-list span {
+    font-size: var(--font-size-xs, 0.82rem);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.progress-analytics__insight-list strong {
+    font-size: 1.3rem;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
+}
+
+.progress-analytics__insight-list small {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-xs, 0.82rem);
+}
+
+.progress-analytics__panels {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: var(--spacing-md, 20px);
 }
 
 .progress-analytics__panel {
-    position: relative;
-    isolation: isolate;
+    padding: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
+    border-radius: var(--border-radius-xl);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
+    background: var(--color-white);
+    box-shadow: var(--shadow-xs);
     display: flex;
     flex-direction: column;
-    gap: clamp(var(--spacing-sm, 16px), 2.4vw, var(--spacing-lg, 28px));
-    padding: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
-    border-radius: calc(var(--border-radius-xl) * 1.05);
-    background: linear-gradient(160deg, rgba(var(--color-white-rgb, 255, 255, 255), 0.94), rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.9));
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
-    box-shadow: 0 18px 40px -30px rgba(var(--color-primary-dark-rgb, 8, 35, 64), 0.55);
-    overflow: hidden;
-    backdrop-filter: blur(6px);
-}
-
-.progress-analytics__panel::before,
-.progress-analytics__panel::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    z-index: -1;
-}
-
-.progress-analytics__panel::before {
-    opacity: 0.92;
-    background: radial-gradient(160% 120% at 0% 0%, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12), transparent 65%),
-                radial-gradient(120% 120% at 100% 0%, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.08), transparent 60%);
-}
-
-.progress-analytics__panel::after {
-    opacity: 0.85;
-    background: linear-gradient(140deg, rgba(255, 255, 255, 0.22) 0%, rgba(255, 255, 255, 0.02) 45%, rgba(14, 35, 64, 0.08) 100%);
-    mix-blend-mode: lighten;
-}
-
-.progress-analytics__panel--performance::before {
-    background: radial-gradient(140% 120% at 0% 0%, rgba(26, 95, 158, 0.24), transparent 60%),
-                radial-gradient(120% 140% at 85% 0%, rgba(64, 140, 255, 0.16), transparent 65%);
-}
-
-.progress-analytics__panel--frequency::before {
-    background: radial-gradient(150% 140% at 0% 0%, rgba(24, 164, 141, 0.25), transparent 65%),
-                radial-gradient(120% 150% at 90% 10%, rgba(102, 210, 200, 0.18), transparent 70%);
-}
-
-.progress-analytics__panel--daily::before {
-    background: radial-gradient(160% 140% at 0% 0%, rgba(255, 170, 76, 0.26), transparent 65%),
-                radial-gradient(120% 150% at 90% 15%, rgba(255, 217, 158, 0.2), transparent 70%);
+    gap: var(--spacing-md, 20px);
 }
 
 .progress-analytics__panel-header {
     display: flex;
     align-items: flex-start;
-    gap: var(--spacing-sm, 16px);
-    padding-bottom: var(--spacing-sm, 16px);
-    border-bottom: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
+    gap: var(--spacing-sm, 12px);
 }
 
 .progress-analytics__panel-header .material-symbols-outlined {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: clamp(42px, 5vw, 52px);
-    height: clamp(42px, 5vw, 52px);
-    border-radius: calc(var(--border-radius-pill) * 1.1);
-    background: linear-gradient(145deg, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.2), rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.08));
-    box-shadow: inset 0 0 0 1px rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.22);
-    color: var(--color-primary-dark);
-    font-size: clamp(1.5rem, 3vw, 1.8rem);
-    flex-shrink: 0;
+    font-size: 1.8rem;
+    color: var(--color-primary-medium);
 }
 
 .progress-analytics__panel-header h3 {
     margin: 0;
-    font-size: clamp(1.1rem, 2.4vw, 1.4rem);
+    font-size: 1.2rem;
     font-weight: var(--font-weight-semibold);
-    color: var(--color-text-primary);
+    color: var(--color-primary-dark);
 }
 
 .progress-analytics__panel-header p {
@@ -1416,126 +1525,76 @@
 }
 
 .progress-analytics__metrics {
+    display: grid;
+    gap: var(--spacing-sm, 12px);
     list-style: none;
     margin: 0;
     padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: clamp(var(--spacing-sm, 16px), 2.4vw, var(--spacing-md, 24px));
 }
 
 .progress-analytics__metrics li {
-    position: relative;
     display: flex;
     flex-direction: column;
-    gap: 8px;
-    padding: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-md, 24px));
-    border-radius: calc(var(--border-radius-lg) * 1.05);
-    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.95);
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.08);
-    box-shadow: inset 0 0 0 1px rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.9);
-    overflow: hidden;
-}
-
-.progress-analytics__metrics li::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background: radial-gradient(140% 120% at 0% 0%, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12), transparent 60%);
-    opacity: 0.9;
-    pointer-events: none;
-}
-
-.progress-analytics__panel--frequency .progress-analytics__metrics li::before {
-    background: radial-gradient(140% 120% at 0% 0%, rgba(26, 158, 133, 0.16), transparent 60%);
-}
-
-.progress-analytics__panel--daily .progress-analytics__metrics li::before {
-    background: radial-gradient(140% 120% at 0% 0%, rgba(255, 170, 76, 0.18), transparent 60%);
-}
-
-.progress-analytics__metrics li > * {
-    position: relative;
-    z-index: 1;
+    gap: 4px;
+    padding: var(--spacing-sm, 12px);
+    border-radius: var(--border-radius-lg);
+    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.5);
 }
 
 .progress-analytics__metrics-label {
-    font-size: var(--font-size-xs, 0.8rem);
-    color: var(--color-text-muted);
+    font-size: var(--font-size-xs, 0.82rem);
     text-transform: uppercase;
     letter-spacing: 0.08em;
+    color: var(--color-text-muted);
 }
 
 .progress-analytics__metrics-value {
-    font-size: clamp(1.2rem, 2.6vw, 1.6rem);
+    font-size: 1.2rem;
     font-weight: var(--font-weight-semibold);
     color: var(--color-primary-dark);
 }
 
 .progress-analytics__metrics small {
-    font-size: var(--font-size-xxs, 0.75rem);
     color: var(--color-text-secondary);
+    font-size: var(--font-size-xs, 0.82rem);
 }
 
 .progress-analytics__daily-status {
     display: flex;
     flex-direction: column;
-    gap: clamp(var(--spacing-sm, 16px), 2.4vw, var(--spacing-md, 24px));
+    gap: var(--spacing-sm, 12px);
 }
 
 .progress-analytics__daily-indicator {
     display: flex;
-    align-items: flex-start;
-    gap: var(--spacing-sm, 16px);
-    padding: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-md, 24px));
-    border-radius: calc(var(--border-radius-lg) * 1.05);
-    background: linear-gradient(150deg, rgba(255, 255, 255, 0.94), rgba(255, 255, 255, 0.78));
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.1);
-    box-shadow: inset 0 0 0 1px rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.8);
-    position: relative;
-    overflow: hidden;
-}
-
-.progress-analytics__daily-indicator::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background: radial-gradient(140% 140% at 0% 0%, rgba(255, 170, 76, 0.22), transparent 65%);
-    opacity: 0.85;
-    pointer-events: none;
+    align-items: center;
+    gap: var(--spacing-sm, 12px);
+    padding: var(--spacing-sm, 12px);
+    border-radius: var(--border-radius-lg);
+    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.6);
 }
 
 .progress-analytics__daily-indicator .material-symbols-outlined {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: clamp(42px, 5vw, 52px);
-    height: clamp(42px, 5vw, 52px);
-    border-radius: calc(var(--border-radius-pill) * 1.05);
-    background: linear-gradient(140deg, rgba(255, 170, 76, 0.24), rgba(255, 206, 147, 0.18));
-    box-shadow: inset 0 0 0 1px rgba(255, 170, 76, 0.35);
-    color: rgba(138, 64, 0, 0.9);
-    font-size: clamp(1.5rem, 3vw, 1.8rem);
-    flex-shrink: 0;
+    font-size: 2rem;
+    color: var(--color-primary-medium);
 }
 
 .progress-analytics__daily-indicator strong {
+    font-size: 1.05rem;
+    color: var(--color-primary-dark);
     display: block;
-    font-size: clamp(1.05rem, 2.2vw, 1.35rem);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-text-primary);
 }
 
 .progress-analytics__daily-indicator p {
-    margin: 6px 0 0;
+    margin: 4px 0 0;
     color: var(--color-text-secondary);
     font-size: var(--font-size-sm, 0.95rem);
 }
 
 .progress-analytics__daily-metrics {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: clamp(var(--spacing-sm, 16px), 2.4vw, var(--spacing-md, 24px));
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: var(--spacing-sm, 12px);
     list-style: none;
     margin: 0;
     padding: 0;
@@ -1544,24 +1603,23 @@
 .progress-analytics__daily-metrics li {
     display: flex;
     flex-direction: column;
-    gap: 6px;
-    padding: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-md, 24px));
-    border-radius: calc(var(--border-radius-lg) * 1.05);
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
-    background: linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(255, 245, 234, 0.9));
-    box-shadow: inset 0 0 0 1px rgba(255, 170, 76, 0.25);
+    gap: 4px;
+    padding: var(--spacing-sm, 12px);
+    border-radius: var(--border-radius-lg);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.9);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.1);
     text-align: center;
 }
 
 .progress-analytics__daily-metrics span {
-    font-size: var(--font-size-xs, 0.8rem);
+    font-size: var(--font-size-xs, 0.82rem);
     color: var(--color-text-muted);
     text-transform: uppercase;
     letter-spacing: 0.08em;
 }
 
 .progress-analytics__daily-metrics strong {
-    font-size: clamp(1.1rem, 2.4vw, 1.5rem);
+    font-size: 1.2rem;
     font-weight: var(--font-weight-semibold);
     color: var(--color-primary-dark);
 }
@@ -1569,14 +1627,14 @@
 .progress-analytics__timeline {
     display: flex;
     flex-direction: column;
-    gap: clamp(var(--spacing-sm, 16px), 2.4vw, var(--spacing-lg, 28px));
+    gap: var(--spacing-md, 20px);
 }
 
 .progress-analytics__timeline-header h3 {
     margin: 0;
-    font-size: clamp(1.1rem, 2.4vw, 1.45rem);
+    font-size: 1.2rem;
     font-weight: var(--font-weight-semibold);
-    color: var(--color-text-primary);
+    color: var(--color-primary-dark);
 }
 
 .progress-analytics__timeline-header p {
@@ -1586,65 +1644,74 @@
 }
 
 .progress-analytics__timeline-track {
+    position: relative;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-xl, 36px));
+    gap: var(--spacing-md, 20px);
+    padding-left: calc(var(--spacing-lg, 28px) + 12px);
+}
+
+.progress-analytics__timeline-track::before {
+    content: "";
+    position: absolute;
+    left: 18px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18);
 }
 
 .progress-analytics__timeline-node {
     position: relative;
     display: flex;
-    gap: var(--spacing-sm, 16px);
-    align-items: flex-start;
-    padding: clamp(var(--spacing-sm, 16px), 3vw, var(--spacing-lg, 28px));
-    border-radius: var(--border-radius-xl);
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
-    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.96);
+    gap: var(--spacing-md, 20px);
+    padding: var(--spacing-md, 20px);
+    border-radius: var(--border-radius-lg);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.95);
     box-shadow: var(--shadow-xs);
 }
 
-.progress-analytics__timeline-order {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 48px;
-    height: 48px;
-    border-radius: var(--border-radius-pill);
-    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
-    color: var(--color-primary-dark);
+.progress-analytics__timeline-marker {
+    position: absolute;
+    left: -28px;
+    top: calc(50% - 16px);
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    background: var(--color-white);
+    border: 2px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.5);
+    color: var(--color-primary-medium);
     font-weight: var(--font-weight-semibold);
-    font-size: 1.1rem;
-    flex-shrink: 0;
 }
 
 .progress-analytics__timeline-content {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-xs, 10px);
+    gap: var(--spacing-xs, 8px);
 }
 
-.progress-analytics__timeline-head {
+.progress-analytics__timeline-content header {
     display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: var(--spacing-sm, 16px);
+    flex-direction: column;
+    gap: 2px;
 }
 
-.progress-analytics__timeline-head strong {
+.progress-analytics__timeline-content header strong {
     font-size: 1rem;
-    color: var(--color-text-primary);
-    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
 }
 
-.progress-analytics__timeline-head span {
+.progress-analytics__timeline-content header span {
     font-size: var(--font-size-sm, 0.95rem);
     color: var(--color-text-secondary);
 }
 
-.progress-analytics__timeline-range {
+.progress-analytics__timeline-content p {
     margin: 0;
-    font-size: var(--font-size-xs, 0.82rem);
-    color: var(--color-text-muted);
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm, 0.95rem);
 }
 
 .progress-analytics__timeline-progress {
@@ -1652,68 +1719,42 @@
     width: 100%;
     height: 8px;
     border-radius: 999px;
-    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.14);
     overflow: hidden;
 }
 
 .progress-analytics__timeline-progress span {
-    display: block;
-    height: 100%;
+    position: absolute;
+    inset: 0;
     border-radius: inherit;
-    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.8);
-    transition: width 0.4s ease;
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.75);
+    transition: width var(--transition-medium);
 }
 
-.progress-analytics__timeline-status {
+.progress-analytics__timeline-content small {
+    color: var(--color-text-muted);
     font-size: var(--font-size-xs, 0.82rem);
-    color: var(--color-text-muted);
-    font-weight: var(--font-weight-medium);
-}
-
-.progress-analytics__timeline-node--completed .progress-analytics__timeline-order,
-.progress-analytics__timeline-node--completed .progress-analytics__timeline-progress span {
-    background: rgba(var(--color-success-medium-rgb, 35, 170, 105), 0.18);
-    color: var(--color-success-dark);
-}
-
-.progress-analytics__timeline-node--completed .progress-analytics__timeline-progress span {
-    background: rgba(var(--color-success-medium-rgb, 35, 170, 105), 0.6);
-}
-
-.progress-analytics__timeline-node--completed .progress-analytics__timeline-status {
-    color: var(--color-success-dark);
-}
-
-.progress-analytics__timeline-node--locked {
-    border-color: rgba(var(--color-text-muted-rgb, 125, 138, 152), 0.2);
-    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.9);
-}
-
-.progress-analytics__timeline-node--locked .progress-analytics__timeline-order {
-    background: rgba(var(--color-text-muted-rgb, 125, 138, 152), 0.16);
-    color: var(--color-text-muted);
-}
-
-.progress-analytics__timeline-node--locked .progress-analytics__timeline-progress span {
-    background: rgba(var(--color-text-muted-rgb, 125, 138, 152), 0.4);
 }
 
 .progress-analytics__timeline-node.is-current {
-    border-color: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.32);
-    box-shadow: 0 18px 32px rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
+    border-color: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.45);
+    box-shadow: var(--shadow-md);
+    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.6);
 }
 
-.progress-analytics__timeline-node.is-current .progress-analytics__timeline-order {
-    background: linear-gradient(135deg, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.9), rgba(var(--color-primary-dark-rgb, 8, 35, 64), 0.95));
+.progress-analytics__timeline-node.is-current .progress-analytics__timeline-marker {
+    background: var(--color-primary-medium);
     color: var(--color-white);
+    border-color: var(--color-primary-medium);
+    box-shadow: var(--shadow-grid-current-subtle);
 }
 
-.progress-analytics__timeline-node.is-current .progress-analytics__timeline-progress span {
-    background: linear-gradient(135deg, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.85), rgba(var(--color-primary-dark-rgb, 8, 35, 64), 0.9));
+.progress-analytics__timeline-node--completed .progress-analytics__timeline-marker {
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
 }
 
-.progress-analytics__timeline-node.is-current .progress-analytics__timeline-status {
-    color: var(--color-primary-dark);
+.progress-analytics__timeline-node--locked {
+    opacity: 0.78;
 }
 
 .progress-analytics__empty {
@@ -1722,8 +1763,8 @@
     gap: var(--spacing-md, 20px);
     padding: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
     border-radius: var(--border-radius-xl);
-    border: 1px dashed rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.24);
-    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.5);
+    border: 1px dashed rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.3);
+    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.45);
 }
 
 .progress-analytics__empty .material-symbols-outlined {
@@ -1733,8 +1774,8 @@
 
 .progress-analytics__empty strong {
     display: block;
-    font-size: clamp(1.05rem, 2.3vw, 1.35rem);
-    color: var(--color-text-primary);
+    font-size: clamp(1.1rem, 2.4vw, 1.4rem);
+    color: var(--color-primary-dark);
     font-weight: var(--font-weight-semibold);
 }
 
@@ -1744,54 +1785,62 @@
     font-size: var(--font-size-sm, 0.95rem);
 }
 
-@media (max-width: 1080px) {
-    .progress-analytics__timeline-track {
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    }
-}
-
-@media (max-width: 960px) {
+@media (max-width: 1024px) {
     .progress-analytics__header {
-        flex-direction: column;
-        align-items: flex-start;
+        grid-template-columns: 1fr;
     }
 
-    .progress-analytics__icon {
-        width: 42px;
-        height: 42px;
-        font-size: 1.5rem;
+    .progress-analytics__hero-meter {
+        justify-self: flex-start;
     }
 }
 
-@media (max-width: 780px) {
-    .progress-analytics__level-header {
+@media (max-width: 820px) {
+    .progress-analytics__highlights {
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+
+    .progress-analytics__hero-meter {
         flex-direction: column;
         align-items: flex-start;
+    }
+
+    .progress-analytics__hero-meta {
         text-align: left;
     }
 
-    .progress-analytics__level-status {
-        text-align: left;
-        align-items: flex-start;
+    .progress-analytics__timeline-track {
+        padding-left: calc(var(--spacing-md, 20px) + 12px);
+    }
+
+    .progress-analytics__timeline-track::before {
+        left: 14px;
+    }
+
+    .progress-analytics__timeline-marker {
+        left: -24px;
     }
 }
 
 @media (max-width: 640px) {
-    .progress-analytics__summary {
+    .progress-analytics__chips {
+        gap: var(--spacing-xxs, 6px);
+    }
+
+    .progress-analytics__chip {
+        width: 100%;
+        justify-content: flex-start;
+    }
+
+    .progress-analytics__highlights {
         grid-template-columns: 1fr;
     }
 
-    .progress-analytics__grid {
+    .progress-analytics__overview {
         grid-template-columns: 1fr;
     }
 
-    .progress-analytics__timeline-track {
-        grid-template-columns: 1fr;
-    }
-}
-
-@media (max-width: 520px) {
-    .progress-analytics__level-stats {
+    .progress-analytics__panels {
         grid-template-columns: 1fr;
     }
 
@@ -1801,9 +1850,33 @@
     }
 
     .progress-analytics__daily-metrics {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
     }
 }
+
+@media (max-width: 480px) {
+    .progress-analytics__hero-meter {
+        width: 100%;
+    }
+
+    .progress-analytics__timeline-node {
+        flex-direction: column;
+    }
+
+    .progress-analytics__timeline-marker {
+        position: static;
+        margin-bottom: var(--spacing-xs, 8px);
+    }
+
+    .progress-analytics__timeline-track {
+        padding-left: var(--spacing-md, 20px);
+    }
+
+    .progress-analytics__timeline-track::before {
+        left: 8px;
+    }
+}
+
 /* --- Histórico de Quizzes --- */
 .quiz-history__description {
     margin-bottom: var(--spacing-lg, 24px);

--- a/quiz/templates/quiz/account_page.html
+++ b/quiz/templates/quiz/account_page.html
@@ -394,119 +394,215 @@
                 <div class="progress-analytics">
                     <section class="card card--conta-perfil progress-analytics__card">
                         <header class="progress-analytics__header">
-                            <div class="progress-analytics__headline">
+                            <div class="progress-analytics__intro">
+                                <span class="progress-analytics__eyebrow">Panorama atual</span>
                                 <h2 class="card__title">Central de Progresso</h2>
                                 <p class="card__subtitle">Acompanhe nível, desempenho e consistência de estudo em uma visão estratégica.</p>
+                                <div class="progress-analytics__chips" role="list">
+                                    <span class="progress-analytics__chip" role="listitem">
+                                        <span class="material-symbols-outlined" aria-hidden="true">local_fire_department</span>
+                                        Sequência ativa: {{ metrics.current_streak|default:0 }} dia{{ metrics.current_streak|default:0|pluralize }}
+                                    </span>
+                                    <span class="progress-analytics__chip" role="listitem">
+                                        <span class="material-symbols-outlined" aria-hidden="true">assignment</span>
+                                        {% if metrics.total_sessions|default:0 == 1 %}
+                                            Histórico: 1 sessão concluída
+                                        {% else %}
+                                            Histórico: {{ metrics.total_sessions|default:0 }} sessões concluídas
+                                        {% endif %}
+                                    </span>
+                                    {% if gamification %}
+                                    <span class="progress-analytics__chip" role="listitem">
+                                        <span class="material-symbols-outlined" aria-hidden="true">military_tech</span>
+                                        {{ gamification.achievements.total_unlocked|default_if_none:0 }}/{{ gamification.achievements.total_available|default_if_none:0 }} conquistas
+                                    </span>
+                                    {% endif %}
+                                </div>
                             </div>
-                            <span class="material-symbols-outlined progress-analytics__icon" aria-hidden="true">query_stats</span>
+                            {% if gamification %}
+                            <div class="progress-analytics__hero-meter" role="presentation">
+                                <div class="progress-analytics__radial" style="--progress-value: {{ gamification.progress.percent|default_if_none:0|unlocalize }};">
+                                    <span class="progress-analytics__radial-value">{{ gamification.progress.percent|default_if_none:0|floatformat:0 }}%</span>
+                                </div>
+                                <div class="progress-analytics__hero-meta">
+                                    <span class="progress-analytics__label">Nível atual</span>
+                                    <strong>
+                                        {% if gamification.level %}
+                                            {{ gamification.level.nome }}
+                                        {% else %}
+                                            Jornada em definição
+                                        {% endif %}
+                                    </strong>
+                                    <p>Conclusão do nível atual</p>
+                                    <small>
+                                        {% if gamification.next_level %}
+                                            Próximo nível: {{ gamification.next_level.nome }}
+                                        {% else %}
+                                            Nível máximo atingido
+                                        {% endif %}
+                                    </small>
+                                </div>
+                            </div>
+                            {% endif %}
                         </header>
 
                         <div class="progress-analytics__body">
+                            <div class="progress-analytics__highlights" role="list">
+                                <article class="progress-analytics__highlight" role="listitem">
+                                    <header class="progress-analytics__highlight-header">
+                                        <span class="material-symbols-outlined progress-analytics__highlight-icon" aria-hidden="true">target</span>
+                                        <span class="progress-analytics__highlight-label">Precisão geral</span>
+                                    </header>
+                                    {% if metrics.accuracy is not None %}
+                                        <strong class="progress-analytics__highlight-value">{{ metrics.accuracy|floatformat:1 }}%</strong>
+                                    {% else %}
+                                        <strong class="progress-analytics__highlight-value">—</strong>
+                                    {% endif %}
+                                    <p class="progress-analytics__highlight-meta">{{ metrics.total_questions_answered|default:0 }} {{ metrics.total_questions_answered|default:0|pluralize:"questão analisada,questões analisadas" }}</p>
+                                </article>
+
+                                <article class="progress-analytics__highlight" role="listitem">
+                                    <header class="progress-analytics__highlight-header">
+                                        <span class="material-symbols-outlined progress-analytics__highlight-icon" aria-hidden="true">trending_up</span>
+                                        <span class="progress-analytics__highlight-label">Precisão (30 dias)</span>
+                                    </header>
+                                    {% if metrics.accuracy_last_30 is not None %}
+                                        <strong class="progress-analytics__highlight-value">{{ metrics.accuracy_last_30|floatformat:1 }}%</strong>
+                                    {% else %}
+                                        <strong class="progress-analytics__highlight-value">—</strong>
+                                    {% endif %}
+                                    <p class="progress-analytics__highlight-meta">{{ metrics.questions_last_30_days|default:0 }} {{ metrics.questions_last_30_days|default:0|pluralize:"questão no período,questões no período" }}</p>
+                                </article>
+
+                                <article class="progress-analytics__highlight" role="listitem">
+                                    <header class="progress-analytics__highlight-header">
+                                        <span class="material-symbols-outlined progress-analytics__highlight-icon" aria-hidden="true">score</span>
+                                        <span class="progress-analytics__highlight-label">Pontuação média</span>
+                                    </header>
+                                    {% if metrics.average_score is not None %}
+                                        <strong class="progress-analytics__highlight-value">{{ metrics.average_score|floatformat:1 }}</strong>
+                                    {% else %}
+                                        <strong class="progress-analytics__highlight-value">—</strong>
+                                    {% endif %}
+                                    <p class="progress-analytics__highlight-meta">Melhor sessão: {{ metrics.best_score|default:0 }}</p>
+                                </article>
+
+                                <article class="progress-analytics__highlight" role="listitem">
+                                    <header class="progress-analytics__highlight-header">
+                                        <span class="material-symbols-outlined progress-analytics__highlight-icon" aria-hidden="true">task_alt</span>
+                                        <span class="progress-analytics__highlight-label">Respostas corretas</span>
+                                    </header>
+                                    <strong class="progress-analytics__highlight-value">{{ metrics.total_correct_answers|default:0 }}</strong>
+                                    <p class="progress-analytics__highlight-meta">Erros acumulados: {{ metrics.total_incorrect_answers|default:0 }}</p>
+                                </article>
+
+                                <article class="progress-analytics__highlight" role="listitem">
+                                    <header class="progress-analytics__highlight-header">
+                                        <span class="material-symbols-outlined progress-analytics__highlight-icon" aria-hidden="true">pace</span>
+                                        <span class="progress-analytics__highlight-label">Consistência (30 dias)</span>
+                                    </header>
+                                    {% if metrics.consistency_last_30_percent is not None %}
+                                        <strong class="progress-analytics__highlight-value">{{ metrics.consistency_last_30_percent|floatformat:0 }}%</strong>
+                                    {% else %}
+                                        <strong class="progress-analytics__highlight-value">—</strong>
+                                    {% endif %}
+                                    <p class="progress-analytics__highlight-meta">Dias ativos: {{ metrics.active_days_last_30|default:0 }}</p>
+                                </article>
+
+                                <article class="progress-analytics__highlight" role="listitem">
+                                    <header class="progress-analytics__highlight-header">
+                                        <span class="material-symbols-outlined progress-analytics__highlight-icon" aria-hidden="true">hourglass_top</span>
+                                        <span class="progress-analytics__highlight-label">Tempo de estudo (30 dias)</span>
+                                    </header>
+                                    <strong class="progress-analytics__highlight-value">{{ metrics.study_time_last_30_display|default:"0 min" }}</strong>
+                                    <p class="progress-analytics__highlight-meta">{{ metrics.questions_last_30_days|default:0 }} {{ metrics.questions_last_30_days|default:0|pluralize:"questão revisada,questões revisadas" }}</p>
+                                </article>
+                            </div>
+
                             {% if gamification %}
-                            <section class="progress-analytics__level" aria-labelledby="progress-analytics-level-heading">
-                                <div class="progress-analytics__level-header">
-                                    <div>
-                                        <span class="progress-analytics__label">Nível atual</span>
-                                        <h3 id="progress-analytics-level-heading" class="progress-analytics__level-title">
-                                            {% if gamification.level %}
-                                                {{ gamification.level.nome }}
-                                            {% else %}
-                                                Jornada em definição
-                                            {% endif %}
-                                        </h3>
+                            <div class="progress-analytics__overview">
+                                <section class="progress-analytics__level-card" aria-labelledby="progress-analytics-level-heading">
+                                    <header class="progress-analytics__level-header">
+                                        <div>
+                                            <span class="progress-analytics__label">Detalhes do nível</span>
+                                            <h3 id="progress-analytics-level-heading">
+                                                {% if gamification.level %}
+                                                    {{ gamification.level.nome }}
+                                                {% else %}
+                                                    Jornada em definição
+                                                {% endif %}
+                                            </h3>
+                                        </div>
+                                        <div class="progress-analytics__level-numbers">
+                                            <strong>{{ gamification.xp_total|default:0 }} XP</strong>
+                                            <small>Total acumulado</small>
+                                        </div>
+                                    </header>
+                                    <div class="progress-analytics__progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ gamification.progress.percent|default_if_none:0|unlocalize }}">
+                                        <span style="width: {{ gamification.progress.percent|default_if_none:0|unlocalize }}%;"></span>
                                     </div>
-                                    <div class="progress-analytics__level-status">
-                                        <strong>{{ gamification.progress.percent|default_if_none:0|floatformat:0 }}%</strong>
-                                        <span>concluído do nível atual</span>
-                                        {% if gamification.next_level %}
-                                            <small>Próximo nível: {{ gamification.next_level.nome }}</small>
-                                        {% else %}
-                                            <small>Nível máximo atingido</small>
-                                        {% endif %}
-                                    </div>
-                                </div>
-                                <div class="progress-analytics__bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ gamification.progress.percent|default_if_none:0|unlocalize }}">
-                                    <span class="progress-analytics__bar-fill" style="width: {{ gamification.progress.percent|default_if_none:0|unlocalize }}%;"></span>
-                                </div>
-                                <ul class="progress-analytics__level-stats">
-                                    <li>
-                                        <span class="progress-analytics__label">XP total</span>
-                                        <strong>{{ gamification.xp_total|default:0 }}</strong>
-                                    </li>
-                                    <li>
-                                        <span class="progress-analytics__label">XP no nível</span>
-                                        <strong>{{ gamification.progress.xp_into_level|default:0 }}</strong>
-                                    </li>
-                                    <li>
-                                        <span class="progress-analytics__label">XP para avançar</span>
-                                        <strong>
-                                            {% if gamification.progress.xp_to_next_level is not None %}
-                                                {{ gamification.progress.xp_to_next_level }} XP
-                                            {% else %}
-                                                Objetivo concluído
-                                            {% endif %}
-                                        </strong>
-                                    </li>
-                                    <li>
-                                        <span class="progress-analytics__label">Status da jornada</span>
-                                        <strong>
-                                            {% if gamification.next_level %}
-                                                Em direção a {{ gamification.next_level.nome }}
-                                            {% else %}
-                                                Você está no topo
-                                            {% endif %}
-                                        </strong>
-                                    </li>
-                                </ul>
-                            </section>
-                            {% else %}
-                            <section class="progress-analytics__empty" aria-live="polite">
-                                <span class="material-symbols-outlined" aria-hidden="true">insights</span>
-                                <div>
-                                    <strong>Sem dados analíticos ainda</strong>
-                                    <p>Conclua seu primeiro quiz para gerar indicadores de nível, desempenho e frequência de estudo.</p>
-                                    <a class="button button--secondary button--small" href="{% url 'quiz:home' %}#home">Começar agora</a>
-                                </div>
-                            </section>
-                            {% endif %}
+                                    <dl class="progress-analytics__level-stats">
+                                        <div>
+                                            <dt>XP no nível</dt>
+                                            <dd>{{ gamification.progress.xp_into_level|default:0 }}</dd>
+                                        </div>
+                                        <div>
+                                            <dt>Meta para avançar</dt>
+                                            <dd>
+                                                {% if gamification.progress.xp_to_next_level is not None %}
+                                                    {{ gamification.progress.xp_to_next_level }} XP
+                                                {% else %}
+                                                    Objetivo concluído
+                                                {% endif %}
+                                            </dd>
+                                        </div>
+                                        <div>
+                                            <dt>Status da jornada</dt>
+                                            <dd>
+                                                {% if gamification.next_level %}
+                                                    Em direção a {{ gamification.next_level.nome }}
+                                                {% else %}
+                                                    Você está no topo
+                                                {% endif %}
+                                            </dd>
+                                        </div>
+                                        <div>
+                                            <dt>Melhor sequência</dt>
+                                            <dd>{{ gamification.best_streak|default_if_none:0 }} dia{{ gamification.best_streak|default_if_none:0|pluralize }}</dd>
+                                        </div>
+                                    </dl>
+                                </section>
 
-                            <dl class="progress-analytics__summary">
-                                <div class="progress-analytics__summary-item">
-                                    <dt>Precisão geral</dt>
-                                    <dd>
-                                        {% if metrics.accuracy is not None %}
-                                            {{ metrics.accuracy|floatformat:1 }}%
-                                        {% else %}
-                                            —
-                                        {% endif %}
-                                        <small>{{ metrics.total_questions_answered|default:0 }} {{ metrics.total_questions_answered|default:0|pluralize:"questão analisada,questões analisadas" }}</small>
-                                    </dd>
-                                </div>
-                                <div class="progress-analytics__summary-item">
-                                    <dt>Sessões concluídas</dt>
-                                    <dd>
-                                        {{ metrics.total_sessions|default:0 }}
-                                        <small>Histórico completo disponível no painel ao lado</small>
-                                    </dd>
-                                </div>
-                                <div class="progress-analytics__summary-item">
-                                    <dt>Questões respondidas</dt>
-                                    <dd>
-                                        {{ metrics.total_questions_answered|default:0 }}
-                                        <small>Inclui todas as tentativas registradas</small>
-                                    </dd>
-                                </div>
-                                <div class="progress-analytics__summary-item">
-                                    <dt>Tempo de estudo (30 dias)</dt>
-                                    <dd>
-                                        {{ metrics.study_time_last_30_display|default:"0 min" }}
-                                        <small>{{ metrics.questions_last_30_days|default:0 }} {{ metrics.questions_last_30_days|default:0|pluralize:"questão revisada,questões revisadas" }}</small>
-                                    </dd>
-                                </div>
-                            </dl>
+                                <section class="progress-analytics__insight-card" aria-label="Reconhecimentos e atualizações">
+                                    <header class="progress-analytics__insight-header">
+                                        <span class="material-symbols-outlined" aria-hidden="true">workspace_premium</span>
+                                        <div>
+                                            <h3>Reconhecimentos</h3>
+                                            <p>Conquistas, recompensas e status da jornada.</p>
+                                        </div>
+                                    </header>
+                                    <ul class="progress-analytics__insight-list">
+                                        <li>
+                                            <span>Conquistas desbloqueadas</span>
+                                            <strong>{{ gamification.achievements.total_unlocked|default_if_none:0 }}</strong>
+                                            <small>de {{ gamification.achievements.total_available|default_if_none:0 }} disponíveis</small>
+                                        </li>
+                                        <li>
+                                            <span>Recompensas resgatadas</span>
+                                            <strong>{{ gamification.rewards.claimed|length }}</strong>
+                                            <small>{{ gamification.rewards.available_to_claim|length }} aguardando resgate</small>
+                                        </li>
+                                        <li>
+                                            <span>Atualizado por último</span>
+                                            <strong>{{ gamification.lifetime_stats.last_update_display|default:"—" }}</strong>
+                                            <small>XP hoje: {{ gamification.lifetime_stats.xp_today|default_if_none:0 }}</small>
+                                        </li>
+                                    </ul>
+                                </section>
+                            </div>
 
-                            <div class="progress-analytics__grid">
-                                <section class="progress-analytics__panel progress-analytics__panel--performance">
+                            <div class="progress-analytics__panels">
+                                <section class="progress-analytics__panel">
                                     <header class="progress-analytics__panel-header">
                                         <span class="material-symbols-outlined" aria-hidden="true">monitoring</span>
                                         <div>
@@ -521,25 +617,27 @@
                                             <small>Melhor sessão: {{ metrics.best_score|default:0 }}</small>
                                         </li>
                                         <li>
-                                            <span class="progress-analytics__metrics-label">Taxa de acerto</span>
-                                            <strong class="progress-analytics__metrics-value">
-                                                {% if metrics.accuracy is not None %}
-                                                    {{ metrics.accuracy|floatformat:1 }}%
-                                                {% else %}
-                                                    —
-                                                {% endif %}
-                                            </strong>
-                                            <small>{{ metrics.total_questions_answered|default:0 }} {{ metrics.total_questions_answered|default:0|pluralize:"questão respondida,questões respondidas" }}</small>
+                                            <span class="progress-analytics__metrics-label">Pontuação média</span>
+                                            {% if metrics.average_score is not None %}
+                                                <strong class="progress-analytics__metrics-value">{{ metrics.average_score|floatformat:1 }}</strong>
+                                            {% else %}
+                                                <strong class="progress-analytics__metrics-value">—</strong>
+                                            {% endif %}
+                                            <small>Sessões avaliadas: {{ metrics.total_sessions|default:0 }}</small>
                                         </li>
                                         <li>
-                                            <span class="progress-analytics__metrics-label">Sequência ativa</span>
-                                            <strong class="progress-analytics__metrics-value">{{ metrics.current_streak|default:0 }} dia{{ metrics.current_streak|default:0|pluralize }}</strong>
-                                            <small>Recorde histórico: {{ gamification.best_streak|default_if_none:0 }} dia{{ gamification.best_streak|default_if_none:0|pluralize }}</small>
+                                            <span class="progress-analytics__metrics-label">Taxa de acerto</span>
+                                            {% if metrics.accuracy is not None %}
+                                                <strong class="progress-analytics__metrics-value">{{ metrics.accuracy|floatformat:1 }}%</strong>
+                                            {% else %}
+                                                <strong class="progress-analytics__metrics-value">—</strong>
+                                            {% endif %}
+                                            <small>{{ metrics.total_questions_answered|default:0 }} {{ metrics.total_questions_answered|default:0|pluralize:"questão respondida,questões respondidas" }}</small>
                                         </li>
                                     </ul>
                                 </section>
 
-                                <section class="progress-analytics__panel progress-analytics__panel--frequency">
+                                <section class="progress-analytics__panel">
                                     <header class="progress-analytics__panel-header">
                                         <span class="material-symbols-outlined" aria-hidden="true">schedule</span>
                                         <div>
@@ -554,28 +652,31 @@
                                             <small>{{ metrics.study_time_last_30_display|default:"0 min" }} dedicados no período</small>
                                         </li>
                                         <li>
-                                            <span class="progress-analytics__metrics-label">Hoje</span>
-                                            {% if gamification and gamification.daily_engagement %}
-                                                <strong class="progress-analytics__metrics-value">{{ gamification.daily_engagement.questions_today|default_if_none:0 }} {{ gamification.daily_engagement.questions_today|default_if_none:0|pluralize:"questão,questões" }}</strong>
-                                                <small>{{ gamification.daily_engagement.xp_today|default_if_none:0 }} XP gerados</small>
+                                            <span class="progress-analytics__metrics-label">Média por sessão</span>
+                                            {% if metrics.questions_per_session_avg is not None %}
+                                                <strong class="progress-analytics__metrics-value">{{ metrics.questions_per_session_avg|floatformat:1 }} perguntas</strong>
                                             {% else %}
                                                 <strong class="progress-analytics__metrics-value">—</strong>
-                                                <small>Registre uma sessão para alimentar esta métrica</small>
                                             {% endif %}
+                                            <small>Total de sessões: {{ metrics.total_sessions|default:0 }}</small>
                                         </li>
                                         <li>
-                                            <span class="progress-analytics__metrics-label">Sessões totais</span>
-                                            <strong class="progress-analytics__metrics-value">{{ metrics.total_sessions|default:0 }}</strong>
-                                            <small>Consolidadas desde o início da sua jornada</small>
+                                            <span class="progress-analytics__metrics-label">Consistência</span>
+                                            {% if metrics.consistency_last_30_percent is not None %}
+                                                <strong class="progress-analytics__metrics-value">{{ metrics.consistency_last_30_percent|floatformat:0 }}%</strong>
+                                            {% else %}
+                                                <strong class="progress-analytics__metrics-value">—</strong>
+                                            {% endif %}
+                                            <small>{{ metrics.active_days_last_30|default:0 }} dia{{ metrics.active_days_last_30|default:0|pluralize }} com atividade</small>
                                         </li>
                                     </ul>
                                 </section>
 
-                                {% if gamification and gamification.daily_engagement %}
+                                {% if gamification.daily_engagement %}
                                 {% with daily=gamification.daily_engagement %}
-                                <section class="progress-analytics__panel progress-analytics__panel--daily">
+                                <section class="progress-analytics__panel">
                                     <header class="progress-analytics__panel-header">
-                                        <span class="material-symbols-outlined" aria-hidden="true">pace</span>
+                                        <span class="material-symbols-outlined" aria-hidden="true">timelapse</span>
                                         <div>
                                             <h3>Ritmo diário</h3>
                                             <p>Status do compromisso de estudo nas últimas 24 horas.</p>
@@ -583,9 +684,7 @@
                                     </header>
                                     <div class="progress-analytics__daily-status">
                                         <div class="progress-analytics__daily-indicator">
-                                            <span class="material-symbols-outlined" aria-hidden="true">
-                                                {% if daily.has_activity_today %}task_alt{% else %}pending_actions{% endif %}
-                                            </span>
+                                            <span class="material-symbols-outlined" aria-hidden="true">{% if daily.has_activity_today %}task_alt{% else %}pending_actions{% endif %}</span>
                                             <div>
                                                 <strong>
                                                     {% if daily.has_activity_today %}
@@ -623,26 +722,28 @@
                                 {% endif %}
                             </div>
 
-                            {% if gamification and gamification.levels_path %}
+                            {% if gamification.levels_path %}
                             <section class="progress-analytics__timeline" aria-label="Escala de níveis e progresso">
                                 <header class="progress-analytics__timeline-header">
                                     <h3>Mapa de níveis</h3>
                                     <p>Entenda onde você está posicionado e quais etapas ainda estão pela frente.</p>
                                 </header>
-                                <div class="progress-analytics__timeline-track">
+                                <div class="progress-analytics__timeline-track" role="list">
                                     {% for level in gamification.levels_path %}
                                     <article class="progress-analytics__timeline-node progress-analytics__timeline-node--{{ level.status }}{% if level.is_current %} is-current{% endif %}" role="listitem"{% if level.is_current %} aria-current="step"{% endif %}>
-                                        <span class="progress-analytics__timeline-order" aria-hidden="true">{{ level.order }}</span>
+                                        <div class="progress-analytics__timeline-marker" aria-hidden="true">
+                                            <span>{{ level.order }}</span>
+                                        </div>
                                         <div class="progress-analytics__timeline-content">
-                                            <div class="progress-analytics__timeline-head">
+                                            <header>
                                                 <strong>Nível {{ level.order }}</strong>
                                                 <span>{{ level.name }}</span>
-                                            </div>
-                                            <p class="progress-analytics__timeline-range">A partir de {{ level.xp_required }} XP{% if level.xp_max %} · até {{ level.xp_max }} XP{% endif %}</p>
+                                            </header>
+                                            <p>A partir de {{ level.xp_required }} XP{% if level.xp_max %} · até {{ level.xp_max }} XP{% endif %}</p>
                                             <div class="progress-analytics__timeline-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ level.progress_percent|default_if_none:0|unlocalize }}">
                                                 <span style="width: {{ level.progress_percent|default_if_none:0|unlocalize }}%;"></span>
                                             </div>
-                                            <span class="progress-analytics__timeline-status">
+                                            <small>
                                                 {% if level.is_current %}
                                                     Em andamento
                                                 {% elif level.is_completed %}
@@ -652,10 +753,20 @@
                                                 {% else %}
                                                     Faltam {{ level.xp_to_unlock }} XP
                                                 {% endif %}
-                                            </span>
+                                            </small>
                                         </div>
                                     </article>
                                     {% endfor %}
+                                </div>
+                            </section>
+                            {% endif %}
+                            {% else %}
+                            <section class="progress-analytics__empty" aria-live="polite">
+                                <span class="material-symbols-outlined" aria-hidden="true">insights</span>
+                                <div>
+                                    <strong>Sem dados analíticos ainda</strong>
+                                    <p>Conclua seu primeiro quiz para liberar gráficos de nível, desempenho e ritmo.</p>
+                                    <a class="button button--secondary button--small" href="{% url 'quiz:home' %}#home">Começar agora</a>
                                 </div>
                             </section>
                             {% endif %}

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -407,10 +407,16 @@ def _build_account_profile_summary(user: User):
     total_correct_answers = aggregate_totals.get('total_correct') or 0
     total_score_all_time = aggregate_totals.get('total_score') or 0
     best_score = aggregate_totals.get('best_score') or 0
+    total_incorrect_answers = max(total_questions_answered - total_correct_answers, 0)
 
     accuracy = None
+    average_score = None
+    questions_per_session_avg = None
     if total_questions_answered:
         accuracy = round((total_correct_answers / total_questions_answered) * 100, 1)
+    if total_sessions_completed:
+        average_score = round(total_score_all_time / total_sessions_completed, 1)
+        questions_per_session_avg = round(total_questions_answered / total_sessions_completed, 1)
 
     favorite_mode = None
     if total_sessions_completed:
@@ -431,6 +437,19 @@ def _build_account_profile_summary(user: User):
     questions_last_30_days = last_thirty_days_stats.aggregate(
         total=Sum('perguntas_respondidas_dia')
     ).get('total') or 0
+    correct_last_30_days = last_thirty_days_stats.aggregate(
+        total=Sum('acertos_dia')
+    ).get('total') or 0
+    tracked_days_last_30 = last_thirty_days_stats.count()
+    active_days_last_30 = last_thirty_days_stats.filter(perguntas_respondidas_dia__gt=0).count()
+
+    accuracy_last_30 = None
+    if questions_last_30_days:
+        accuracy_last_30 = round((correct_last_30_days / questions_last_30_days) * 100, 1)
+
+    consistency_last_30_percent = None
+    if tracked_days_last_30:
+        consistency_last_30_percent = round((active_days_last_30 / tracked_days_last_30) * 100, 1)
 
     current_streak = daily_stats_qs.order_by('-data_estatistica').values_list(
         'sequencia_dias_quiz', flat=True
@@ -495,15 +514,23 @@ def _build_account_profile_summary(user: User):
         'metrics': {
             'total_sessions': total_sessions_completed,
             'total_questions_answered': total_questions_answered,
+            'total_correct_answers': total_correct_answers,
+            'total_incorrect_answers': total_incorrect_answers,
             'accuracy': accuracy,
+            'accuracy_last_30': accuracy_last_30,
             'favorite_questions_count': favorite_questions_count,
             'total_score': total_score_all_time,
             'best_score': best_score,
+            'average_score': average_score,
             'favorite_mode': favorite_mode,
             'favorite_mode_display': favorite_mode or 'Ainda não definido',
             'study_time_last_30_seconds': study_time_last_30_seconds,
             'study_time_last_30_display': _format_duration_compact(study_time_last_30_seconds) or '0 min',
             'questions_last_30_days': questions_last_30_days,
+            'correct_last_30_days': correct_last_30_days,
+            'questions_per_session_avg': questions_per_session_avg,
+            'active_days_last_30': active_days_last_30,
+            'consistency_last_30_percent': consistency_last_30_percent,
             'current_streak': current_streak,
         },
         'completion': {


### PR DESCRIPTION
## Summary
- redesign the account progress center with a new hero, highlight metrics, reorganized panels, and refined timeline messaging
- add essential performance metrics (30-day accuracy, averages, consistency insights) to the profile summary payload consumed by the dashboard
- refresh the progress analytics styling to deliver a cohesive, minimal layout aligned with the rest of the site

## Testing
- python -m compileall quiz/views.py

------
https://chatgpt.com/codex/tasks/task_e_68eef611bea88333a0a2bbee7abfefff