### PR TITLE
Refine account progress dashboard visuals

### DIFF
--- a/assets/css/sections/conta-section.css
+++ b/assets/css/sections/conta-section.css
@@ -1146,15 +1146,16 @@
 }
 
 .progress-analytics__header {
+    position: relative;
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: clamp(var(--spacing-lg, 28px), 3vw, var(--spacing-xl, 40px));
     padding: clamp(var(--spacing-lg, 28px), 4vw, var(--spacing-xl, 40px));
     border-radius: var(--border-radius-xl);
-    background: linear-gradient(135deg, rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.9), rgba(var(--color-white-rgb, 255, 255, 255), 0.95));
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18);
-    box-shadow: var(--shadow-sm);
-    position: relative;
+    background: linear-gradient(135deg, rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.72), rgba(var(--color-white-rgb, 255, 255, 255), 0.94));
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
+    box-shadow: 0 24px 40px -32px rgba(var(--color-primary-dark-rgb, 14, 44, 73), 0.45);
+    align-items: stretch;
     overflow: hidden;
 }
 
@@ -1162,7 +1163,8 @@
     content: "";
     position: absolute;
     inset: 0;
-    background: radial-gradient(circle at 80% 20%, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18), transparent 55%);
+    background: radial-gradient(circle at 15% 15%, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18), transparent 58%),
+        radial-gradient(circle at 85% 35%, rgba(var(--color-secondary-medium-rgb, 255, 143, 94), 0.12), transparent 62%);
     pointer-events: none;
 }
 
@@ -1171,7 +1173,8 @@
     z-index: 1;
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-sm, 12px);
+    gap: clamp(var(--spacing-sm, 12px), 2vw, var(--spacing-md, 20px));
+    justify-content: center;
 }
 
 .progress-analytics__eyebrow {
@@ -1179,6 +1182,22 @@
     text-transform: uppercase;
     letter-spacing: 0.12em;
     color: var(--color-text-muted);
+}
+
+.progress-analytics__hero {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: clamp(var(--spacing-md, 20px), 2vw, var(--spacing-lg, 28px));
+    padding: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-xl, 40px));
+    border-radius: var(--border-radius-lg);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.78);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.14);
+    box-shadow: inset 0 1px 0 rgba(var(--color-white-rgb, 255, 255, 255), 0.6);
+    backdrop-filter: blur(6px);
 }
 
 .progress-analytics__chips {
@@ -1193,29 +1212,16 @@
     gap: var(--spacing-xxs, 6px);
     padding: 6px 12px;
     border-radius: var(--border-radius-pill);
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.24);
-    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.85);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.2);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.82);
     color: var(--color-primary-dark);
     font-size: var(--font-size-xs, 0.82rem);
     font-weight: var(--font-weight-medium);
-    backdrop-filter: blur(4px);
+    backdrop-filter: blur(6px);
 }
 
 .progress-analytics__chip .material-symbols-outlined {
     font-size: 1.1rem;
-}
-
-.progress-analytics__hero-meter {
-    position: relative;
-    z-index: 1;
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-md, 20px);
-    padding: var(--spacing-sm, 12px) var(--spacing-md, 20px);
-    border-radius: var(--border-radius-lg);
-    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.78);
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
-    box-shadow: var(--shadow-xs);
 }
 
 .progress-analytics__radial {
@@ -1248,8 +1254,9 @@
 .progress-analytics__hero-meta {
     display: flex;
     flex-direction: column;
-    gap: 4px;
-    min-width: 160px;
+    gap: 6px;
+    align-items: center;
+    text-align: center;
 }
 
 .progress-analytics__hero-meta strong {
@@ -1275,6 +1282,80 @@
     color: var(--color-text-muted);
 }
 
+.progress-analytics__hero-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: var(--spacing-sm, 12px);
+    margin: var(--spacing-sm, 12px) 0;
+}
+
+.progress-analytics__hero-stats div {
+    padding: var(--spacing-sm, 12px);
+    border-radius: var(--border-radius-lg);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.88);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.08);
+    backdrop-filter: blur(6px);
+}
+
+.progress-analytics__hero-stats dt {
+    font-size: var(--font-size-xxs, 0.75rem);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+    margin-bottom: 4px;
+}
+
+.progress-analytics__hero-stats dd {
+    margin: 0;
+    font-size: var(--font-size-sm, 0.95rem);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-primary-dark);
+}
+
+.progress-analytics__quick-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: var(--spacing-md, 20px);
+}
+
+.progress-analytics__quick-card {
+    padding: clamp(var(--spacing-md, 20px), 2.5vw, var(--spacing-lg, 28px));
+    border-radius: var(--border-radius-lg);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.94);
+    box-shadow: var(--shadow-xs);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs, 8px);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.progress-analytics__quick-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 20px 32px -28px rgba(var(--color-primary-dark-rgb, 14, 44, 73), 0.55);
+}
+
+.progress-analytics__quick-card header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs, 8px);
+    color: var(--color-primary-medium);
+    font-size: var(--font-size-sm, 0.95rem);
+    font-weight: var(--font-weight-semibold);
+}
+
+.progress-analytics__quick-card strong {
+    font-size: clamp(1.4rem, 2.6vw, 1.8rem);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
+}
+
+.progress-analytics__quick-card p {
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm, 0.95rem);
+}
+
 .progress-analytics__body {
     display: flex;
     flex-direction: column;
@@ -1283,26 +1364,25 @@
 
 .progress-analytics__highlights {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: var(--spacing-md, 20px);
 }
 
 .progress-analytics__highlight {
-    position: relative;
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-xs, 8px);
-    padding: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
+    gap: var(--spacing-sm, 12px);
+    padding: clamp(var(--spacing-md, 20px), 2.5vw, var(--spacing-lg, 28px));
     border-radius: var(--border-radius-lg);
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
-    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.95);
-    box-shadow: var(--shadow-xs);
-    transition: transform var(--transition-medium), box-shadow var(--transition-medium);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.08);
+    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.55);
+    backdrop-filter: blur(4px);
+    transition: transform 0.2s ease, border-color 0.2s ease;
 }
 
 .progress-analytics__highlight:hover {
-    transform: translateY(-4px);
-    box-shadow: var(--shadow-md);
+    transform: translateY(-3px);
+    border-color: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.24);
 }
 
 .progress-analytics__highlight-header {
@@ -1317,14 +1397,13 @@
 }
 
 .progress-analytics__highlight-label {
-    font-size: var(--font-size-xs, 0.82rem);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--color-text-muted);
+    font-size: var(--font-size-sm, 0.95rem);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
 }
 
 .progress-analytics__highlight-value {
-    font-size: clamp(1.4rem, 2.6vw, 1.9rem);
+    font-size: clamp(1.3rem, 2.4vw, 1.7rem);
     font-weight: var(--font-weight-semibold);
     color: var(--color-primary-dark);
 }
@@ -1342,7 +1421,8 @@
 }
 
 .progress-analytics__level-card,
-.progress-analytics__insight-card {
+.progress-analytics__insight-card,
+.progress-analytics__session-card {
     padding: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
     border-radius: var(--border-radius-xl);
     border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.14);
@@ -1424,6 +1504,90 @@
     font-size: 1rem;
     font-weight: var(--font-weight-medium);
     color: var(--color-text-primary);
+}
+
+.progress-analytics__session-header {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--spacing-sm, 12px);
+}
+
+.progress-analytics__session-header .material-symbols-outlined {
+    font-size: 1.8rem;
+    color: var(--color-primary-medium);
+}
+
+.progress-analytics__session-header h3 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-primary-dark);
+}
+
+.progress-analytics__session-header p {
+    margin: 4px 0 0;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm, 0.95rem);
+}
+
+.progress-analytics__session-stats {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--spacing-sm, 12px);
+}
+
+.progress-analytics__session-stats div {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: var(--spacing-sm, 12px);
+    border-radius: var(--border-radius-lg);
+    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.45);
+}
+
+.progress-analytics__session-stats dt {
+    font-size: var(--font-size-xxs, 0.75rem);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+}
+
+.progress-analytics__session-stats dd {
+    margin: 0;
+    font-size: var(--font-size-sm, 0.95rem);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-primary-dark);
+}
+
+.progress-analytics__session-footer {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs, 8px);
+    padding: var(--spacing-sm, 12px);
+    border-radius: var(--border-radius-lg);
+    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.35);
+    color: var(--color-primary-medium);
+}
+
+.progress-analytics__session-footer p {
+    margin: 0;
+    color: var(--color-primary-dark);
+    font-size: var(--font-size-sm, 0.95rem);
+}
+
+.progress-analytics__session-empty {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm, 12px);
+    padding: var(--spacing-md, 20px);
+    border-radius: var(--border-radius-lg);
+    background: rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.35);
+    color: var(--color-text-secondary);
+}
+
+.progress-analytics__session-empty .material-symbols-outlined {
+    font-size: 1.8rem;
+    color: var(--color-primary-medium);
 }
 
 .progress-analytics__insight-header {
@@ -1790,7 +1954,7 @@
         grid-template-columns: 1fr;
     }
 
-    .progress-analytics__hero-meter {
+    .progress-analytics__hero {
         justify-self: flex-start;
     }
 }
@@ -1800,7 +1964,7 @@
         grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
     }
 
-    .progress-analytics__hero-meter {
+    .progress-analytics__hero {
         flex-direction: column;
         align-items: flex-start;
     }
@@ -1855,7 +2019,7 @@
 }
 
 @media (max-width: 480px) {
-    .progress-analytics__hero-meter {
+    .progress-analytics__hero {
         width: 100%;
     }
 

--- a/quiz/templates/quiz/account_page.html
+++ b/quiz/templates/quiz/account_page.html
@@ -394,33 +394,8 @@
                 <div class="progress-analytics">
                     <section class="card card--conta-perfil progress-analytics__card">
                         <header class="progress-analytics__header">
-                            <div class="progress-analytics__intro">
-                                <span class="progress-analytics__eyebrow">Panorama atual</span>
-                                <h2 class="card__title">Central de Progresso</h2>
-                                <p class="card__subtitle">Acompanhe nível, desempenho e consistência de estudo em uma visão estratégica.</p>
-                                <div class="progress-analytics__chips" role="list">
-                                    <span class="progress-analytics__chip" role="listitem">
-                                        <span class="material-symbols-outlined" aria-hidden="true">local_fire_department</span>
-                                        Sequência ativa: {{ metrics.current_streak|default:0 }} dia{{ metrics.current_streak|default:0|pluralize }}
-                                    </span>
-                                    <span class="progress-analytics__chip" role="listitem">
-                                        <span class="material-symbols-outlined" aria-hidden="true">assignment</span>
-                                        {% if metrics.total_sessions|default:0 == 1 %}
-                                            Histórico: 1 sessão concluída
-                                        {% else %}
-                                            Histórico: {{ metrics.total_sessions|default:0 }} sessões concluídas
-                                        {% endif %}
-                                    </span>
-                                    {% if gamification %}
-                                    <span class="progress-analytics__chip" role="listitem">
-                                        <span class="material-symbols-outlined" aria-hidden="true">military_tech</span>
-                                        {{ gamification.achievements.total_unlocked|default_if_none:0 }}/{{ gamification.achievements.total_available|default_if_none:0 }} conquistas
-                                    </span>
-                                    {% endif %}
-                                </div>
-                            </div>
                             {% if gamification %}
-                            <div class="progress-analytics__hero-meter" role="presentation">
+                            <div class="progress-analytics__hero" role="presentation">
                                 <div class="progress-analytics__radial" style="--progress-value: {{ gamification.progress.percent|default_if_none:0|unlocalize }};">
                                     <span class="progress-analytics__radial-value">{{ gamification.progress.percent|default_if_none:0|floatformat:0 }}%</span>
                                 </div>
@@ -433,7 +408,7 @@
                                             Jornada em definição
                                         {% endif %}
                                     </strong>
-                                    <p>Conclusão do nível atual</p>
+                                    <p>Conclusão do nível</p>
                                     <small>
                                         {% if gamification.next_level %}
                                             Próximo nível: {{ gamification.next_level.nome }}
@@ -444,83 +419,198 @@
                                 </div>
                             </div>
                             {% endif %}
+                            <div class="progress-analytics__intro">
+                                <span class="progress-analytics__eyebrow">Panorama atual</span>
+                                <h2 class="card__title">Central de Progresso</h2>
+                                <p class="card__subtitle">Visualize nível, desempenho e hábitos em uma única visão minimalista e acionável.</p>
+                                <dl class="progress-analytics__hero-stats">
+                                    <div>
+                                        <dt>XP acumulado</dt>
+                                        <dd>
+                                            {% if gamification %}
+                                                {{ gamification.xp_total|default:0 }} XP
+                                            {% else %}
+                                                —
+                                            {% endif %}
+                                        </dd>
+                                    </div>
+                                    <div>
+                                        <dt>Sequência ativa</dt>
+                                        <dd>{{ metrics.current_streak|default:0 }} dia{{ metrics.current_streak|default:0|pluralize }}</dd>
+                                    </div>
+                                    <div>
+                                        <dt>Sessões concluídas</dt>
+                                        <dd>{{ metrics.total_sessions|default:0 }}</dd>
+                                    </div>
+                                    <div>
+                                        <dt>Modo favorito</dt>
+                                        <dd>{{ metrics.favorite_mode_display }}</dd>
+                                    </div>
+                                </dl>
+                                <div class="progress-analytics__chips" role="list">
+                                    <span class="progress-analytics__chip" role="listitem">
+                                        <span class="material-symbols-outlined" aria-hidden="true">local_fire_department</span>
+                                        Sequência ativa: {{ metrics.current_streak|default:0 }} dia{{ metrics.current_streak|default:0|pluralize }}
+                                    </span>
+                                    <span class="progress-analytics__chip" role="listitem">
+                                        <span class="material-symbols-outlined" aria-hidden="true">assignment</span>
+                                        {% if metrics.total_sessions|default:0 == 1 %}
+                                            1 sessão concluída
+                                        {% else %}
+                                            {{ metrics.total_sessions|default:0 }} sessões concluídas
+                                        {% endif %}
+                                    </span>
+                                    <span class="progress-analytics__chip" role="listitem">
+                                        <span class="material-symbols-outlined" aria-hidden="true">bookmarks</span>
+                                        Favoritas: {{ metrics.favorite_questions_count|default:0 }} questões
+                                    </span>
+                                    {% if gamification %}
+                                    <span class="progress-analytics__chip" role="listitem">
+                                        <span class="material-symbols-outlined" aria-hidden="true">military_tech</span>
+                                        {{ gamification.achievements.total_unlocked|default_if_none:0 }}/{{ gamification.achievements.total_available|default_if_none:0 }} conquistas
+                                    </span>
+                                    {% endif %}
+                                </div>
+                            </div>
                         </header>
+
+                        <div class="progress-analytics__quick-grid" role="list">
+                            <article class="progress-analytics__quick-card" role="listitem">
+                                <header>
+                                    <span class="material-symbols-outlined" aria-hidden="true">target</span>
+                                    <span>Precisão geral</span>
+                                </header>
+                                <strong>
+                                    {% if metrics.accuracy is not None %}
+                                        {{ metrics.accuracy|floatformat:1 }}%
+                                    {% else %}
+                                        —
+                                    {% endif %}
+                                </strong>
+                                <p>{{ metrics.total_correct_answers|default:0 }} acertos • {{ metrics.total_incorrect_answers|default:0 }} erros</p>
+                            </article>
+                            <article class="progress-analytics__quick-card" role="listitem">
+                                <header>
+                                    <span class="material-symbols-outlined" aria-hidden="true">schedule</span>
+                                    <span>Ritmo (30 dias)</span>
+                                </header>
+                                <strong>{{ metrics.study_time_last_30_display|default:"0 min" }}</strong>
+                                <p>{{ metrics.questions_last_30_days|default:0 }} {{ metrics.questions_last_30_days|default:0|pluralize:"questão revisada,questões revisadas" }}</p>
+                            </article>
+                            <article class="progress-analytics__quick-card" role="listitem">
+                                <header>
+                                    <span class="material-symbols-outlined" aria-hidden="true">trending_up</span>
+                                    <span>Tendência de acerto</span>
+                                </header>
+                                <strong>
+                                    {% if metrics.accuracy_last_30 is not None %}
+                                        {{ metrics.accuracy_last_30|floatformat:1 }}%
+                                    {% else %}
+                                        —
+                                    {% endif %}
+                                </strong>
+                                <p>{{ metrics.correct_last_30_days|default:0 }} acertos no período</p>
+                            </article>
+                            <article class="progress-analytics__quick-card" role="listitem">
+                                <header>
+                                    <span class="material-symbols-outlined" aria-hidden="true">score</span>
+                                    <span>Pontuação média</span>
+                                </header>
+                                <strong>
+                                    {% if metrics.average_score is not None %}
+                                        {{ metrics.average_score|floatformat:1 }}
+                                    {% else %}
+                                        —
+                                    {% endif %}
+                                </strong>
+                                <p>Melhor sessão: {{ metrics.best_score|default:0 }}</p>
+                            </article>
+                        </div>
 
                         <div class="progress-analytics__body">
                             <div class="progress-analytics__highlights" role="list">
                                 <article class="progress-analytics__highlight" role="listitem">
                                     <header class="progress-analytics__highlight-header">
-                                        <span class="material-symbols-outlined progress-analytics__highlight-icon" aria-hidden="true">target</span>
-                                        <span class="progress-analytics__highlight-label">Precisão geral</span>
-                                    </header>
-                                    {% if metrics.accuracy is not None %}
-                                        <strong class="progress-analytics__highlight-value">{{ metrics.accuracy|floatformat:1 }}%</strong>
-                                    {% else %}
-                                        <strong class="progress-analytics__highlight-value">—</strong>
-                                    {% endif %}
-                                    <p class="progress-analytics__highlight-meta">{{ metrics.total_questions_answered|default:0 }} {{ metrics.total_questions_answered|default:0|pluralize:"questão analisada,questões analisadas" }}</p>
-                                </article>
-
-                                <article class="progress-analytics__highlight" role="listitem">
-                                    <header class="progress-analytics__highlight-header">
-                                        <span class="material-symbols-outlined progress-analytics__highlight-icon" aria-hidden="true">trending_up</span>
-                                        <span class="progress-analytics__highlight-label">Precisão (30 dias)</span>
-                                    </header>
-                                    {% if metrics.accuracy_last_30 is not None %}
-                                        <strong class="progress-analytics__highlight-value">{{ metrics.accuracy_last_30|floatformat:1 }}%</strong>
-                                    {% else %}
-                                        <strong class="progress-analytics__highlight-value">—</strong>
-                                    {% endif %}
-                                    <p class="progress-analytics__highlight-meta">{{ metrics.questions_last_30_days|default:0 }} {{ metrics.questions_last_30_days|default:0|pluralize:"questão no período,questões no período" }}</p>
-                                </article>
-
-                                <article class="progress-analytics__highlight" role="listitem">
-                                    <header class="progress-analytics__highlight-header">
-                                        <span class="material-symbols-outlined progress-analytics__highlight-icon" aria-hidden="true">score</span>
-                                        <span class="progress-analytics__highlight-label">Pontuação média</span>
-                                    </header>
-                                    {% if metrics.average_score is not None %}
-                                        <strong class="progress-analytics__highlight-value">{{ metrics.average_score|floatformat:1 }}</strong>
-                                    {% else %}
-                                        <strong class="progress-analytics__highlight-value">—</strong>
-                                    {% endif %}
-                                    <p class="progress-analytics__highlight-meta">Melhor sessão: {{ metrics.best_score|default:0 }}</p>
-                                </article>
-
-                                <article class="progress-analytics__highlight" role="listitem">
-                                    <header class="progress-analytics__highlight-header">
                                         <span class="material-symbols-outlined progress-analytics__highlight-icon" aria-hidden="true">task_alt</span>
-                                        <span class="progress-analytics__highlight-label">Respostas corretas</span>
+                                        <span class="progress-analytics__highlight-label">Total de respostas</span>
                                     </header>
-                                    <strong class="progress-analytics__highlight-value">{{ metrics.total_correct_answers|default:0 }}</strong>
-                                    <p class="progress-analytics__highlight-meta">Erros acumulados: {{ metrics.total_incorrect_answers|default:0 }}</p>
+                                    <strong class="progress-analytics__highlight-value">{{ metrics.total_questions_answered|default:0 }}</strong>
+                                    <p class="progress-analytics__highlight-meta">{{ metrics.total_correct_answers|default:0 }} corretas • {{ metrics.total_incorrect_answers|default:0 }} incorretas</p>
+                                </article>
+
+                                <article class="progress-analytics__highlight" role="listitem">
+                                    <header class="progress-analytics__highlight-header">
+                                        <span class="material-symbols-outlined progress-analytics__highlight-icon" aria-hidden="true">insights</span>
+                                        <span class="progress-analytics__highlight-label">Média por sessão</span>
+                                    </header>
+                                    {% if metrics.questions_per_session_avg is not None %}
+                                        <strong class="progress-analytics__highlight-value">{{ metrics.questions_per_session_avg|floatformat:1 }} questões</strong>
+                                    {% else %}
+                                        <strong class="progress-analytics__highlight-value">—</strong>
+                                    {% endif %}
+                                    <p class="progress-analytics__highlight-meta">{{ metrics.total_sessions|default:0 }} sessão{{ metrics.total_sessions|default:0|pluralize }}</p>
                                 </article>
 
                                 <article class="progress-analytics__highlight" role="listitem">
                                     <header class="progress-analytics__highlight-header">
                                         <span class="material-symbols-outlined progress-analytics__highlight-icon" aria-hidden="true">pace</span>
-                                        <span class="progress-analytics__highlight-label">Consistência (30 dias)</span>
+                                        <span class="progress-analytics__highlight-label">Consistência</span>
                                     </header>
                                     {% if metrics.consistency_last_30_percent is not None %}
                                         <strong class="progress-analytics__highlight-value">{{ metrics.consistency_last_30_percent|floatformat:0 }}%</strong>
                                     {% else %}
                                         <strong class="progress-analytics__highlight-value">—</strong>
                                     {% endif %}
-                                    <p class="progress-analytics__highlight-meta">Dias ativos: {{ metrics.active_days_last_30|default:0 }}</p>
+                                    <p class="progress-analytics__highlight-meta">{{ metrics.active_days_last_30|default:0 }} dia{{ metrics.active_days_last_30|default:0|pluralize }} com atividade</p>
                                 </article>
 
                                 <article class="progress-analytics__highlight" role="listitem">
                                     <header class="progress-analytics__highlight-header">
                                         <span class="material-symbols-outlined progress-analytics__highlight-icon" aria-hidden="true">hourglass_top</span>
-                                        <span class="progress-analytics__highlight-label">Tempo de estudo (30 dias)</span>
+                                        <span class="progress-analytics__highlight-label">Tempo investido</span>
                                     </header>
                                     <strong class="progress-analytics__highlight-value">{{ metrics.study_time_last_30_display|default:"0 min" }}</strong>
                                     <p class="progress-analytics__highlight-meta">{{ metrics.questions_last_30_days|default:0 }} {{ metrics.questions_last_30_days|default:0|pluralize:"questão revisada,questões revisadas" }}</p>
                                 </article>
+
+                                <article class="progress-analytics__highlight" role="listitem">
+                                    <header class="progress-analytics__highlight-header">
+                                        <span class="material-symbols-outlined progress-analytics__highlight-icon" aria-hidden="true">workspace_premium</span>
+                                        <span class="progress-analytics__highlight-label">Conquistas</span>
+                                    </header>
+                                    {% if gamification %}
+                                        <strong class="progress-analytics__highlight-value">{{ gamification.achievements.total_unlocked|default_if_none:0 }}</strong>
+                                        <p class="progress-analytics__highlight-meta">de {{ gamification.achievements.total_available|default_if_none:0 }} disponíveis</p>
+                                    {% else %}
+                                        <strong class="progress-analytics__highlight-value">—</strong>
+                                        <p class="progress-analytics__highlight-meta">Aguarde os primeiros dados</p>
+                                    {% endif %}
+                                </article>
+
+                                <article class="progress-analytics__highlight" role="listitem">
+                                    <header class="progress-analytics__highlight-header">
+                                        <span class="material-symbols-outlined progress-analytics__highlight-icon" aria-hidden="true">event</span>
+                                        <span class="progress-analytics__highlight-label">Última sessão</span>
+                                    </header>
+                                    {% if profile_summary.last_session %}
+                                        <strong class="progress-analytics__highlight-value">{{ profile_summary.last_session.score|default:0 }}</strong>
+                                        <p class="progress-analytics__highlight-meta">
+                                            {{ profile_summary.last_session.question_count|default:0 }} questões •
+                                            {% if profile_summary.last_session.accuracy is not None %}
+                                                {{ profile_summary.last_session.accuracy|floatformat:1 }}% de acerto
+                                            {% else %}
+                                                precisão em cálculo
+                                            {% endif %}
+                                        </p>
+                                    {% else %}
+                                        <strong class="progress-analytics__highlight-value">—</strong>
+                                        <p class="progress-analytics__highlight-meta">Conclua um quiz para destravar histórico</p>
+                                    {% endif %}
+                                </article>
                             </div>
 
-                            {% if gamification %}
                             <div class="progress-analytics__overview">
+                                {% if gamification %}
                                 <section class="progress-analytics__level-card" aria-labelledby="progress-analytics-level-heading">
                                     <header class="progress-analytics__level-header">
                                         <div>
@@ -572,7 +662,64 @@
                                         </div>
                                     </dl>
                                 </section>
+                                {% endif %}
 
+                                <section class="progress-analytics__session-card" aria-label="Resumo da última sessão">
+                                    <header class="progress-analytics__session-header">
+                                        <span class="material-symbols-outlined" aria-hidden="true">event_upcoming</span>
+                                        <div>
+                                            <h3>Última sessão</h3>
+                                            <p>Acompanhe o desempenho mais recente e identifique tendências.</p>
+                                        </div>
+                                    </header>
+                                    {% if profile_summary.last_session %}
+                                        <dl class="progress-analytics__session-stats">
+                                            <div>
+                                                <dt>Realizada em</dt>
+                                                <dd>{{ profile_summary.last_session.date|date:"d \de F" }}</dd>
+                                            </div>
+                                            <div>
+                                                <dt>Modo</dt>
+                                                <dd>{{ profile_summary.last_session.mode|default:"—" }}</dd>
+                                            </div>
+                                            <div>
+                                                <dt>Pontuação</dt>
+                                                <dd>{{ profile_summary.last_session.score|default:0 }}</dd>
+                                            </div>
+                                            <div>
+                                                <dt>Acertos</dt>
+                                                <dd>
+                                                    {% if profile_summary.last_session.accuracy is not None %}
+                                                        {{ profile_summary.last_session.accuracy|floatformat:1 }}%
+                                                    {% else %}
+                                                        —
+                                                    {% endif %}
+                                                </dd>
+                                            </div>
+                                            <div>
+                                                <dt>Questões</dt>
+                                                <dd>{{ profile_summary.last_session.question_count|default:0 }}</dd>
+                                            </div>
+                                            <div>
+                                                <dt>Duração</dt>
+                                                <dd>{{ profile_summary.last_session.duration_display|default:"—" }}</dd>
+                                            </div>
+                                        </dl>
+                                        {% if profile_summary.last_session.quiz_name %}
+                                        <footer class="progress-analytics__session-footer">
+                                            <span class="material-symbols-outlined" aria-hidden="true">menu_book</span>
+                                            <p>Quiz: {{ profile_summary.last_session.quiz_name }}</p>
+                                        </footer>
+                                        {% endif %}
+                                    {% else %}
+                                        <div class="progress-analytics__session-empty">
+                                            <span class="material-symbols-outlined" aria-hidden="true">hourglass_disabled</span>
+                                            <p>Conclua um quiz para ver estatísticas de sessão aqui.</p>
+                                        </div>
+                                    {% endif %}
+                                </section>
+
+                                {% if gamification %}
                                 <section class="progress-analytics__insight-card" aria-label="Reconhecimentos e atualizações">
                                     <header class="progress-analytics__insight-header">
                                         <span class="material-symbols-outlined" aria-hidden="true">workspace_premium</span>
@@ -599,6 +746,7 @@
                                         </li>
                                     </ul>
                                 </section>
+                                {% endif %}
                             </div>
 
                             <div class="progress-analytics__panels">
@@ -672,7 +820,7 @@
                                     </ul>
                                 </section>
 
-                                {% if gamification.daily_engagement %}
+                                {% if gamification and gamification.daily_engagement %}
                                 {% with daily=gamification.daily_engagement %}
                                 <section class="progress-analytics__panel">
                                     <header class="progress-analytics__panel-header">
@@ -722,7 +870,7 @@
                                 {% endif %}
                             </div>
 
-                            {% if gamification.levels_path %}
+                            {% if gamification and gamification.levels_path %}
                             <section class="progress-analytics__timeline" aria-label="Escala de níveis e progresso">
                                 <header class="progress-analytics__timeline-header">
                                     <h3>Mapa de níveis</h3>


### PR DESCRIPTION
## Summary
- redesign the account progress hero to surface quick stats, streaks, favourites and an updated level gauge
- add an at-a-glance metrics strip plus a detailed last-session card so learners can track recent performance
- refresh the progress analytics styling for highlights, cards and responsive layouts to match the new minimal direction

## Testing
- `python manage.py check` *(fails: Django not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eef9d3852c8333b623a573c6c54458