### PR TITLE
Refine progress analytics header and level map layout

### DIFF
--- a/assets/css/sections/conta-section.css
+++ b/assets/css/sections/conta-section.css
@@ -1140,35 +1140,23 @@
 
 .progress-analytics__card {
     --card-padding: clamp(var(--spacing-lg, 28px), 4vw, var(--spacing-xl, 40px));
+    --card-header-margin-bottom: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 28px));
+    --card-header-padding-bottom: clamp(var(--spacing-sm, 12px), 2vw, var(--spacing-md, 18px));
+    --card-header-border-bottom-color: var(--color-gray-200);
     display: flex;
     flex-direction: column;
-    gap: clamp(var(--spacing-lg, 28px), 3vw, var(--spacing-xl, 40px));
+    gap: 0;
 }
 
 .progress-analytics__header {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: clamp(var(--spacing-lg, 28px), 3vw, var(--spacing-xl, 40px));
-    padding: clamp(var(--spacing-lg, 28px), 4vw, var(--spacing-xl, 40px));
-    border-radius: var(--border-radius-xl);
-    background: linear-gradient(135deg, rgba(var(--color-primary-light-rgb, 238, 243, 248), 0.9), rgba(var(--color-white-rgb, 255, 255, 255), 0.95));
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18);
-    box-shadow: var(--shadow-sm);
-    position: relative;
-    overflow: hidden;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
+    gap: clamp(var(--spacing-md, 20px), 4vw, var(--spacing-xl, 40px));
 }
 
-.progress-analytics__header::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background: radial-gradient(circle at 80% 20%, rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18), transparent 55%);
-    pointer-events: none;
-}
-
-.progress-analytics__intro {
-    position: relative;
-    z-index: 1;
+.progress-analytics__header-content {
+    flex: 1 1 min(420px, 100%);
     display: flex;
     flex-direction: column;
     gap: var(--spacing-sm, 12px);
@@ -1182,6 +1170,9 @@
 }
 
 .progress-analytics__chips {
+    list-style: none;
+    margin: 0;
+    padding: 0;
     display: flex;
     flex-wrap: wrap;
     gap: var(--spacing-xs, 8px);
@@ -1205,17 +1196,21 @@
     font-size: 1.1rem;
 }
 
+.progress-analytics__header-hero {
+    flex: 1 1 min(320px, 100%);
+    display: grid;
+    gap: var(--spacing-sm, 12px);
+    align-content: start;
+}
+
 .progress-analytics__hero-meter {
-    position: relative;
-    z-index: 1;
     display: flex;
     align-items: center;
     gap: var(--spacing-md, 20px);
     padding: var(--spacing-sm, 12px) var(--spacing-md, 20px);
     border-radius: var(--border-radius-lg);
-    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.78);
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.16);
-    box-shadow: var(--shadow-xs);
+    background: var(--color-gray-50);
+    border: 1px solid var(--color-gray-200);
 }
 
 .progress-analytics__radial {
@@ -1266,6 +1261,35 @@
 .progress-analytics__hero-meta small {
     color: var(--color-text-muted);
     font-size: var(--font-size-xxs, 0.75rem);
+}
+
+.progress-analytics__hero-summary {
+    margin: 0;
+    padding: var(--spacing-sm, 12px) var(--spacing-md, 20px);
+    border-radius: var(--border-radius-lg);
+    border: 1px solid var(--color-gray-200);
+    background: var(--color-white);
+    display: grid;
+    gap: var(--spacing-xs, 10px);
+}
+
+.progress-analytics__hero-summary-item {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.progress-analytics__hero-summary-item dt {
+    font-size: var(--font-size-xs, 0.82rem);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-text-muted);
+}
+
+.progress-analytics__hero-summary-item dd {
+    margin: 0;
+    font-weight: var(--font-weight-medium);
+    color: var(--color-primary-dark);
 }
 
 .progress-analytics__label {
@@ -1644,58 +1668,89 @@
 }
 
 .progress-analytics__timeline-track {
-    position: relative;
+    --progress-timeline-gap: clamp(var(--spacing-md, 20px), 3vw, var(--spacing-lg, 32px));
+    list-style: none;
+    margin: 0;
+    padding: 0;
     display: grid;
-    gap: var(--spacing-md, 20px);
-    padding-left: calc(var(--spacing-lg, 28px) + 12px);
-}
-
-.progress-analytics__timeline-track::before {
-    content: "";
-    position: absolute;
-    left: 18px;
-    top: 0;
-    bottom: 0;
-    width: 2px;
-    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18);
+    gap: var(--progress-timeline-gap);
 }
 
 .progress-analytics__timeline-node {
     position: relative;
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(52px, auto) 1fr;
     gap: var(--spacing-md, 20px);
     padding: var(--spacing-md, 20px);
     border-radius: var(--border-radius-lg);
-    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.12);
-    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.95);
+    border: 1px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.14);
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.96);
     box-shadow: var(--shadow-xs);
+    align-items: start;
 }
 
 .progress-analytics__timeline-marker {
-    position: absolute;
-    left: -28px;
-    top: calc(50% - 16px);
-    width: 32px;
-    height: 32px;
+    position: relative;
+    width: 52px;
+    height: 52px;
     border-radius: 50%;
     display: grid;
     place-items: center;
     background: var(--color-white);
-    border: 2px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.5);
+    border: 3px solid rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.45);
     color: var(--color-primary-medium);
     font-weight: var(--font-weight-semibold);
+    font-size: 1rem;
+}
+
+.progress-analytics__timeline-marker::before,
+.progress-analytics__timeline-marker::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    width: 2px;
+    transform: translateX(-50%);
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.18);
+}
+
+.progress-analytics__timeline-marker::before {
+    top: calc(var(--progress-timeline-gap) * -1);
+    height: calc(var(--progress-timeline-gap) + 4px);
+}
+
+.progress-analytics__timeline-marker::after {
+    top: 100%;
+    height: calc(var(--progress-timeline-gap) + 4px);
+}
+
+.progress-analytics__timeline-node:first-child .progress-analytics__timeline-marker::before {
+    display: none;
+}
+
+.progress-analytics__timeline-node:last-child .progress-analytics__timeline-marker::after {
+    display: none;
+}
+
+.progress-analytics__timeline-step {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: rgba(var(--color-primary-medium-rgb, 26, 95, 158), 0.1);
 }
 
 .progress-analytics__timeline-content {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-xs, 8px);
+    gap: var(--spacing-sm, 12px);
 }
 
 .progress-analytics__timeline-content header {
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: 4px;
 }
 
 .progress-analytics__timeline-content header strong {
@@ -1708,10 +1763,30 @@
     color: var(--color-text-secondary);
 }
 
-.progress-analytics__timeline-content p {
+.progress-analytics__timeline-range {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: var(--spacing-sm, 12px);
     margin: 0;
-    color: var(--color-text-secondary);
-    font-size: var(--font-size-sm, 0.95rem);
+}
+
+.progress-analytics__timeline-range div {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.progress-analytics__timeline-range dt {
+    font-size: var(--font-size-xs, 0.82rem);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+}
+
+.progress-analytics__timeline-range dd {
+    margin: 0;
+    font-weight: var(--font-weight-medium);
+    color: var(--color-primary-dark);
 }
 
 .progress-analytics__timeline-progress {
@@ -1731,9 +1806,10 @@
     transition: width var(--transition-medium);
 }
 
-.progress-analytics__timeline-content small {
-    color: var(--color-text-muted);
-    font-size: var(--font-size-xs, 0.82rem);
+.progress-analytics__timeline-status {
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm, 0.95rem);
 }
 
 .progress-analytics__timeline-node.is-current {
@@ -1747,6 +1823,10 @@
     color: var(--color-white);
     border-color: var(--color-primary-medium);
     box-shadow: var(--shadow-grid-current-subtle);
+}
+
+.progress-analytics__timeline-node.is-current .progress-analytics__timeline-step {
+    background: rgba(var(--color-white-rgb, 255, 255, 255), 0.2);
 }
 
 .progress-analytics__timeline-node--completed .progress-analytics__timeline-marker {
@@ -1810,15 +1890,11 @@
     }
 
     .progress-analytics__timeline-track {
-        padding-left: calc(var(--spacing-md, 20px) + 12px);
+        --progress-timeline-gap: clamp(var(--spacing-sm, 12px), 3vw, var(--spacing-md, 20px));
     }
 
-    .progress-analytics__timeline-track::before {
-        left: 14px;
-    }
-
-    .progress-analytics__timeline-marker {
-        left: -24px;
+    .progress-analytics__timeline-node {
+        grid-template-columns: minmax(48px, auto) 1fr;
     }
 }
 
@@ -1860,20 +1936,17 @@
     }
 
     .progress-analytics__timeline-node {
-        flex-direction: column;
+        grid-template-columns: 1fr;
     }
 
     .progress-analytics__timeline-marker {
-        position: static;
+        justify-self: flex-start;
         margin-bottom: var(--spacing-xs, 8px);
     }
 
-    .progress-analytics__timeline-track {
-        padding-left: var(--spacing-md, 20px);
-    }
-
-    .progress-analytics__timeline-track::before {
-        left: 8px;
+    .progress-analytics__timeline-marker::before,
+    .progress-analytics__timeline-marker::after {
+        display: none;
     }
 }
 

--- a/quiz/templates/quiz/account_page.html
+++ b/quiz/templates/quiz/account_page.html
@@ -393,60 +393,88 @@
                 {% with metrics=profile_summary.metrics gamification=profile_summary.gamification %}
                 <div class="progress-analytics">
                     <section class="card card--conta-perfil progress-analytics__card">
-                        <header class="progress-analytics__header">
-                            <div class="progress-analytics__intro">
+                        <div class="card__header progress-analytics__header">
+                            <div class="progress-analytics__header-content">
                                 <span class="progress-analytics__eyebrow">Panorama atual</span>
                                 <h2 class="card__title">Central de Progresso</h2>
                                 <p class="card__subtitle">Acompanhe nível, desempenho e consistência de estudo em uma visão estratégica.</p>
-                                <div class="progress-analytics__chips" role="list">
-                                    <span class="progress-analytics__chip" role="listitem">
+                                <ul class="progress-analytics__chips" role="list">
+                                    <li class="progress-analytics__chip">
                                         <span class="material-symbols-outlined" aria-hidden="true">local_fire_department</span>
                                         Sequência ativa: {{ metrics.current_streak|default:0 }} dia{{ metrics.current_streak|default:0|pluralize }}
-                                    </span>
-                                    <span class="progress-analytics__chip" role="listitem">
+                                    </li>
+                                    <li class="progress-analytics__chip">
                                         <span class="material-symbols-outlined" aria-hidden="true">assignment</span>
                                         {% if metrics.total_sessions|default:0 == 1 %}
                                             Histórico: 1 sessão concluída
                                         {% else %}
                                             Histórico: {{ metrics.total_sessions|default:0 }} sessões concluídas
                                         {% endif %}
-                                    </span>
+                                    </li>
                                     {% if gamification %}
-                                    <span class="progress-analytics__chip" role="listitem">
+                                    <li class="progress-analytics__chip">
                                         <span class="material-symbols-outlined" aria-hidden="true">military_tech</span>
                                         {{ gamification.achievements.total_unlocked|default_if_none:0 }}/{{ gamification.achievements.total_available|default_if_none:0 }} conquistas
-                                    </span>
+                                    </li>
                                     {% endif %}
-                                </div>
+                                </ul>
                             </div>
                             {% if gamification %}
-                            <div class="progress-analytics__hero-meter" role="presentation">
-                                <div class="progress-analytics__radial" style="--progress-value: {{ gamification.progress.percent|default_if_none:0|unlocalize }};">
-                                    <span class="progress-analytics__radial-value">{{ gamification.progress.percent|default_if_none:0|floatformat:0 }}%</span>
+                            <div class="progress-analytics__header-hero" role="presentation">
+                                <div class="progress-analytics__hero-meter">
+                                    <div class="progress-analytics__radial" style="--progress-value: {{ gamification.progress.percent|default_if_none:0|unlocalize }};">
+                                        <span class="progress-analytics__radial-value">{{ gamification.progress.percent|default_if_none:0|floatformat:0 }}%</span>
+                                    </div>
+                                    <div class="progress-analytics__hero-meta">
+                                        <span class="progress-analytics__label">Nível atual</span>
+                                        <strong>
+                                            {% if gamification.level %}
+                                                {{ gamification.level.nome }}
+                                            {% else %}
+                                                Jornada em definição
+                                            {% endif %}
+                                        </strong>
+                                        <p>Conclusão do nível atual</p>
+                                        <small>
+                                            {% if gamification.next_level %}
+                                                Próximo nível: {{ gamification.next_level.nome }}
+                                            {% else %}
+                                                Nível máximo atingido
+                                            {% endif %}
+                                        </small>
+                                    </div>
                                 </div>
-                                <div class="progress-analytics__hero-meta">
-                                    <span class="progress-analytics__label">Nível atual</span>
-                                    <strong>
-                                        {% if gamification.level %}
-                                            {{ gamification.level.nome }}
-                                        {% else %}
-                                            Jornada em definição
-                                        {% endif %}
-                                    </strong>
-                                    <p>Conclusão do nível atual</p>
-                                    <small>
-                                        {% if gamification.next_level %}
-                                            Próximo nível: {{ gamification.next_level.nome }}
-                                        {% else %}
-                                            Nível máximo atingido
-                                        {% endif %}
-                                    </small>
-                                </div>
+                                <dl class="progress-analytics__hero-summary">
+                                    <div class="progress-analytics__hero-summary-item">
+                                        <dt>XP dentro do nível</dt>
+                                        <dd>{{ gamification.progress.xp_into_level|default:0 }} XP</dd>
+                                    </div>
+                                    <div class="progress-analytics__hero-summary-item">
+                                        <dt>Próximo nível</dt>
+                                        <dd>
+                                            {% if gamification.next_level %}
+                                                {{ gamification.next_level.nome }}
+                                            {% else %}
+                                                —
+                                            {% endif %}
+                                        </dd>
+                                    </div>
+                                    <div class="progress-analytics__hero-summary-item">
+                                        <dt>Meta atual</dt>
+                                        <dd>
+                                            {% if gamification.progress.xp_to_next_level is not None %}
+                                                Faltam {{ gamification.progress.xp_to_next_level }} XP
+                                            {% else %}
+                                                Nível máximo atingido
+                                            {% endif %}
+                                        </dd>
+                                    </div>
+                                </dl>
                             </div>
                             {% endif %}
-                        </header>
+                        </div>
 
-                        <div class="progress-analytics__body">
+                        <div class="card__body progress-analytics__body">
                             <div class="progress-analytics__highlights" role="list">
                                 <article class="progress-analytics__highlight" role="listitem">
                                     <header class="progress-analytics__highlight-header">
@@ -728,36 +756,48 @@
                                     <h3>Mapa de níveis</h3>
                                     <p>Entenda onde você está posicionado e quais etapas ainda estão pela frente.</p>
                                 </header>
-                                <div class="progress-analytics__timeline-track" role="list">
+                                <ol class="progress-analytics__timeline-track" role="list">
                                     {% for level in gamification.levels_path %}
-                                    <article class="progress-analytics__timeline-node progress-analytics__timeline-node--{{ level.status }}{% if level.is_current %} is-current{% endif %}" role="listitem"{% if level.is_current %} aria-current="step"{% endif %}>
-                                        <div class="progress-analytics__timeline-marker" aria-hidden="true">
-                                            <span>{{ level.order }}</span>
+                                    <li class="progress-analytics__timeline-node progress-analytics__timeline-node--{{ level.status }}{% if level.is_current %} is-current{% endif %}"{% if level.is_current %} aria-current="step"{% endif %}>
+                                        <div class="progress-analytics__timeline-marker">
+                                            <span class="progress-analytics__timeline-step" aria-hidden="true">{{ level.order }}</span>
+                                            <span class="u-sr-only">Nível {{ level.order }}</span>
                                         </div>
                                         <div class="progress-analytics__timeline-content">
                                             <header>
                                                 <strong>Nível {{ level.order }}</strong>
                                                 <span>{{ level.name }}</span>
                                             </header>
-                                            <p>A partir de {{ level.xp_required }} XP{% if level.xp_max %} · até {{ level.xp_max }} XP{% endif %}</p>
+                                            <dl class="progress-analytics__timeline-range">
+                                                <div>
+                                                    <dt>Início</dt>
+                                                    <dd>{{ level.xp_required }} XP</dd>
+                                                </div>
+                                                {% if level.xp_max %}
+                                                <div>
+                                                    <dt>Limite</dt>
+                                                    <dd>{{ level.xp_max }} XP</dd>
+                                                </div>
+                                                {% endif %}
+                                            </dl>
                                             <div class="progress-analytics__timeline-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ level.progress_percent|default_if_none:0|unlocalize }}">
                                                 <span style="width: {{ level.progress_percent|default_if_none:0|unlocalize }}%;"></span>
                                             </div>
-                                            <small>
+                                            <p class="progress-analytics__timeline-status">
                                                 {% if level.is_current %}
-                                                    Em andamento
+                                                    Em andamento — {{ level.progress_percent|default_if_none:0|floatformat:0 }}% concluído
                                                 {% elif level.is_completed %}
                                                     Concluído
                                                 {% elif level.is_unlocked %}
-                                                    Disponível
+                                                    Disponível para iniciar
                                                 {% else %}
-                                                    Faltam {{ level.xp_to_unlock }} XP
+                                                    Faltam {{ level.xp_to_unlock }} XP para desbloquear
                                                 {% endif %}
-                                            </small>
+                                            </p>
                                         </div>
-                                    </article>
+                                    </li>
                                     {% endfor %}
-                                </div>
+                                </ol>
                             </section>
                             {% endif %}
                             {% else %}


### PR DESCRIPTION
## Summary
- align the progress analytics card header with the shared account card structure and add a concise hero summary
- rebuild the level map markup to use semantic lists, improved status messaging, and screen reader support
- update the associated styles to simplify the header treatment and stabilize the level timeline layout across breakpoints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef032311cc8333a5e39e2612e179f7