### PR TITLE
Replace social share asset with SVG

### DIFF
--- a/assets/icons/favicon.svg
+++ b/assets/icons/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">MedQuiz Favicon</title>
+  <desc id="desc">Stylized cross within a speech bubble representing medical quizzes.</desc>
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2E7DFF"/>
+      <stop offset="100%" stop-color="#6C43FF"/>
+    </linearGradient>
+  </defs>
+  <rect x="4" y="12" width="56" height="40" rx="12" fill="url(#g)"/>
+  <path fill="#ffffff" d="M33 21h-2v10h-10v2h10v10h2V33h10v-2H33z"/>
+  <path fill="#ffffff" d="M24 44l-4 8 10-6z" opacity="0.8"/>
+</svg>

--- a/assets/images/social-card.svg
+++ b/assets/images/social-card.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">MedQuiz Social Share Card</title>
+  <desc id="desc">Banner roxo em degradê com título MedQuiz e subtítulo descrevendo quizzes médicos.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2E7DFF"/>
+      <stop offset="100%" stop-color="#6C43FF"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#FFB347"/>
+      <stop offset="100%" stop-color="#FF805D"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="24" stdDeviation="32" flood-opacity="0.25"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="630" rx="56" fill="url(#bg)"/>
+  <g filter="url(#shadow)" transform="translate(120 140)">
+    <rect width="520" height="350" rx="32" fill="#fff" fill-opacity="0.08" stroke="#ffffff" stroke-opacity="0.2" stroke-width="2"/>
+    <path fill="#ffffff" d="M260 96h-20v96h-96v20h96v96h20v-96h96v-20h-96z"/>
+    <path fill="#ffffff" fill-opacity="0.9" d="M200 280l-48 96 120-72z"/>
+  </g>
+  <text x="640" y="250" font-family="'Montserrat', 'Roboto', sans-serif" font-size="96" font-weight="700" fill="#fff">MedQuiz</text>
+  <text x="640" y="320" font-family="'Roboto', sans-serif" font-size="36" fill="#F0F6FF">Quizzes inteligentes para dominar a residência</text>
+  <rect x="640" y="360" width="320" height="6" fill="url(#accent)" rx="3"/>
+  <text x="640" y="430" font-family="'Roboto', sans-serif" font-size="30" fill="#FFFFFF" fill-opacity="0.9">• Pratique com cenários clínicos reais</text>
+  <text x="640" y="480" font-family="'Roboto', sans-serif" font-size="30" fill="#FFFFFF" fill-opacity="0.9">• Acompanhe desempenho e conquistas</text>
+  <text x="640" y="530" font-family="'Roboto', sans-serif" font-size="30" fill="#FFFFFF" fill-opacity="0.9">• Estude no seu ritmo, onde estiver</text>
+</svg>

--- a/quiz/templates/quiz/base.html
+++ b/quiz/templates/quiz/base.html
@@ -4,14 +4,59 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="{% block meta_description %}Plataforma gamificada de quizzes médicos para praticar, aprender e evoluir rumo à aprovação em provas de residência e concursos.{% endblock meta_description %}">
+    <meta property="og:title" content="{% block og_title %}MedQuiz — Aprendizado médico que acompanha o seu ritmo{% endblock og_title %}">
+    <meta property="og:description" content="{% block og_description %}Pratique com quizzes inteligentes, acompanhe o desempenho e destrave conquistas em uma jornada de estudos para medicina.{% endblock og_description %}">
+    <meta property="og:type" content="website">
+    <meta property="og:locale" content="pt_BR">
+    <meta property="og:site_name" content="MedQuiz">
+    <meta property="og:url" content="{% block og_url %}{{ request.build_absolute_uri }}{% endblock og_url %}">
+    <meta property="og:image" content="{% block og_image %}{{ request.scheme }}://{{ request.get_host }}{% static 'images/social-card.svg' %}{% endblock og_image %}">
+    <meta property="og:image:alt" content="{% block og_image_alt %}Banner do MedQuiz destacando quizzes médicos gamificados{% endblock og_image_alt %}">
+    <meta property="og:image:type" content="image/svg+xml">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{% block twitter_title %}MedQuiz — Aprendizado médico que acompanha o seu ritmo{% endblock twitter_title %}">
+    <meta name="twitter:description" content="{% block twitter_description %}Pratique com quizzes inteligentes, acompanhe o desempenho e destrave conquistas em uma jornada de estudos para medicina.{% endblock twitter_description %}">
+    <meta name="twitter:image" content="{% block twitter_image %}{{ request.scheme }}://{{ request.get_host }}{% static 'images/social-card.svg' %}{% endblock twitter_image %}">
+    <meta name="twitter:image:alt" content="{% block twitter_image_alt %}Banner do MedQuiz destacando quizzes médicos gamificados{% endblock twitter_image_alt %}">
+    <meta name="twitter:image:type" content="image/svg+xml">
+    <meta name="twitter:image:width" content="1200">
+    <meta name="twitter:image:height" content="630">
+    <link rel="canonical" href="{% block canonical_url %}{{ request.build_absolute_uri }}{% endblock canonical_url %}">
+    <meta name="theme-color" content="#2E7DFF">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" as="style" crossorigin>
+    <link rel="preload"
+        href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap"
+        as="style" crossorigin>
     <link rel="stylesheet"
         href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
     <link
         href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap"
         rel="stylesheet">
+    <link rel="preload" href="{% static 'css/style.bundle.css' %}" as="style">
     <link rel="stylesheet" href="{% static 'css/style.bundle.css' %}">
+    <link rel="preload" href="{% static 'js/main.js' %}" as="script">
+    <link rel="icon" type="image/svg+xml" href="{% static 'icons/favicon.svg' %}">
+    <link rel="apple-touch-icon" href="{% static 'icons/favicon.svg' %}">
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "WebSite",
+            "name": "MedQuiz",
+            "url": "{{ request.scheme }}://{{ request.get_host }}",
+            "description": "Plataforma gamificada de quizzes médicos para estudantes e profissionais de saúde.",
+            "potentialAction": {
+                "@type": "SearchAction",
+                "target": "{{ request.scheme }}://{{ request.get_host }}/?q={search_term_string}",
+                "query-input": "required name=search_term_string"
+            }
+        }
+    </script>
+    {% block extra_head %}{% endblock extra_head %}
     <title>{% block title %}MedQuiz{% endblock title %}</title>
 </head>
 {# ===== MODIFICAÇÃO AQUI para adicionar data-page-id e os novos data attributes ===== #}


### PR DESCRIPTION
## Summary
- replace the binary Open Graph/Twitter artwork with a vector social card so the PR no longer includes binary files
- update base layout metadata to reference the SVG card and declare alt/type/size hints for crawlers
- reuse the SVG favicon for the Apple touch icon to keep share assets text-based

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f17209ac588333816c1f213f2ae1eb